### PR TITLE
Update links to use the new github organization urls.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,13 +21,13 @@ WriteMakefile(
     no_index       => {directory => ['examples', 't']},
     prereqs        => {runtime => {requires => {perl => '5.010001'}}},
     resources      => {
-      bugtracker => {web => 'https://github.com/kraih/mojo/issues'},
+      bugtracker => {web => 'https://github.com/mojolicious/mojo/issues'},
       homepage   => 'https://mojolicious.org',
       license    => ['http://www.opensource.org/licenses/artistic-license-2.0'],
       repository => {
         type => 'git',
-        url  => 'https://github.com/kraih/mojo.git',
-        web  => 'https://github.com/kraih/mojo',
+        url  => 'https://github.com/mojolicious/mojo.git',
+        web  => 'https://github.com/mojolicious/mojo',
       },
       x_IRC => 'irc://irc.perl.org/#mojo'
     },

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 <p align="center">
   <a href="https://mojolicious.org">
-    <img src="https://raw.github.com/kraih/mojo/master/lib/Mojolicious/resources/public/mojo/logo.png?raw=true" style="margin: 0 auto;">
+    <img src="https://raw.github.com/mojolicious/mojo/master/lib/Mojolicious/resources/public/mojo/logo.png?raw=true" style="margin: 0 auto;">
   </a>
 </p>
 
- # [![Build Status](https://travis-ci.com/kraih/mojo.svg?branch=master)](https://travis-ci.com/kraih/mojo) [![Windows build status](https://ci.appveyor.com/api/projects/status/rf4661uxfjolra2y?svg=true)](https://ci.appveyor.com/project/kraih/mojo)
+ # [![Build Status](https://travis-ci.com/mojolicious/mojo.svg?branch=master)](https://travis-ci.com/mojoliocus/mojo) [![Windows build status](https://ci.appveyor.com/api/projects/status/rf4661uxfjolra2y?svg=true)](https://ci.appveyor.com/project/kraih/mojo)
 
   Back in the early days of the web, many people learned Perl because of a
   wonderful Perl library called [CGI](https://metacpan.org/module/CGI). It was

--- a/lib/Mojo/UserAgent.pm
+++ b/lib/Mojo/UserAgent.pm
@@ -400,7 +400,7 @@ Mojo::UserAgent - Non-blocking I/O HTTP and WebSocket user agent
 
   # Follow redirects to download Mojolicious from GitHub
   $ua->max_redirects(5)
-    ->get('https://www.github.com/kraih/mojo/tarball/master')
+    ->get('https://www.github.com/mojolicious/mojo/tarball/master')
     ->result->content->asset->move_to('/home/sri/mojo.tar.gz');
 
   # Form POST (application/x-www-form-urlencoded) with manual exception handling

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -1209,7 +1209,7 @@ the terms of the Artistic License version 2.0.
 
 =head1 SEE ALSO
 
-L<https://github.com/kraih/mojo>, L<Mojolicious::Guides>,
+L<https://github.com/mojolicious/mojo>, L<Mojolicious::Guides>,
 L<https://mojolicious.org>.
 
 =cut

--- a/lib/Mojolicious/Guides.pod
+++ b/lib/Mojolicious/Guides.pod
@@ -192,13 +192,14 @@ database schema with migrations and build scalable real-time web applications
 with the publish/subscribe pattern.
 
 And it comes with two great
-L<example applications|https://github.com/kraih/mojo-pg/tree/master/examples/>
+L<example
+applications|https://github.com/mojolicious/mojo-pg/tree/master/examples/>
 you can use for inspiration. The minimal
-L<chat|https://github.com/kraih/mojo-pg/tree/master/examples/chat.pl>
+L<chat|https://github.com/mojolicious/mojo-pg/tree/master/examples/chat.pl>
 application will show you how to scale WebSockets to multiple servers, and the
 well-structured
-L<blog|https://github.com/kraih/mojo-pg/tree/master/examples/blog> application
-how to apply the MVC design pattern in practice.
+L<blog|https://github.com/mojolicious/mojo-pg/tree/master/examples/blog> 
+application how to apply the MVC design pattern in practice.
 
 =item L<Minion>
 
@@ -210,7 +211,8 @@ find image resizing, spam filtering, HTTP downloads, building tarballs, warming
 caches and basically everything else you can imagine that's not super fast.
 
 And it comes with a great example application you can use for inspiration. The
-L<link checker|https://github.com/kraih/minion/tree/master/examples/linkcheck>
+L<link
+checker|https://github.com/mojolicious/minion/tree/master/examples/linkcheck>
 will show you how to integrate background jobs into well-structured
 L<Mojolicious> applications.
 
@@ -529,7 +531,7 @@ This is the class hierarchy of the L<Mojolicious> distribution.
 =head1 MORE
 
 A lot more documentation and examples by many different authors can be found in
-the L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>.
+the L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>.
 
 =head1 SUPPORT
 

--- a/lib/Mojolicious/Guides/Contributing.pod
+++ b/lib/Mojolicious/Guides/Contributing.pod
@@ -12,8 +12,8 @@ few of them.
 
 =head1 REPORTING BUGS
 
-We use the L<GitHub issue tracker|https://github.com/kraih/mojo/issues>, so
-you'll need to create a (free) GitHub account to be able to submit issues,
+We use the L<GitHub issue tracker|https://github.com/mojolicious/mojo/issues>, 
+so you'll need to create a (free) GitHub account to be able to submit issues,
 comments and pull requests.
 
 First of all, make sure you are using the latest version of L<Mojolicious>, it
@@ -43,7 +43,7 @@ develop and release a proper fix.
 =head1 RESOLVING ISSUES
 
 There are many ways in which you can help us resolve existing issues on the
-L<GitHub issue tracker|https://github.com/kraih/mojo/issues>.
+L<GitHub issue tracker|https://github.com/mojolicious/mojo/issues>.
 
 Can you replicate the problem on your computer? Add a comment saying that
 you're seeing the same. Perhaps you can provide additional information that
@@ -60,7 +60,7 @@ One of the easiest ways to contribute to L<Mojolicious> is through
 documentation improvements. While the L<Mojolicious::Guides> are carefully
 curated by the core team, everybody with a (free) GitHub account can make
 changes and add new information to the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>.
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>.
 
 Pull requests with additions or changes to the documentation included in the
 L<Mojolicious> distribution follow the same rules as code contributions. Please
@@ -163,7 +163,7 @@ The master source code repository should always be kept in a stable state, use
 feature branches for actual development.
 
 Code has to be run through L<Perl::Tidy> with the included
-L<.perltidyrc|https://github.com/kraih/mojo/blob/master/.perltidyrc>, and
+L<.perltidyrc|https://github.com/mojolicious/mojo/blob/master/.perltidyrc>, and
 everything should look like it was written by a single person.
 
 Functions and methods should be as short as possible, no spaghetti code.
@@ -300,8 +300,8 @@ bug fixes.
 =head1 MORE
 
 You can continue with L<Mojolicious::Guides> now or take a look at the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>, which contains a lot more
-documentation and examples by many different authors.
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>, which contains a
+lot more documentation and examples by many different authors.
 
 =head1 SUPPORT
 

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -1221,7 +1221,7 @@ file with L<Mojo::Asset::File/"move_to">.
 
   # Fetch the latest Mojolicious tarball
   my $ua = Mojo::UserAgent->new(max_redirects => 5);
-  my $tx = $ua->get('https://www.github.com/kraih/mojo/tarball/master');
+  my $tx = $ua->get('https://www.github.com/mojolicious/mojo/tarball/master');
   $tx->result->content->asset->move_to('mojo.tar.gz');
 
 To protect you from excessively large files there is also a limit of 2GiB by
@@ -1835,8 +1835,8 @@ And you can use all the commands from L<Mojolicious::Commands>.
 =head1 MORE
 
 You can continue with L<Mojolicious::Guides> now or take a look at the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>, which contains a lot more
-documentation and examples by many different authors.
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>, which contains a
+lot more documentation and examples by many different authors.
 
 =head1 SUPPORT
 

--- a/lib/Mojolicious/Guides/FAQ.pod
+++ b/lib/Mojolicious/Guides/FAQ.pod
@@ -262,7 +262,7 @@ weakened.
 =head1 MORE
 
 You can continue with L<Mojolicious::Guides> now or take a look at the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>, which contains a lot more
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>, which contains a lot more
 documentation and examples by many different authors.
 
 =head1 SUPPORT

--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -821,8 +821,8 @@ powerful tool.
 =head1 MORE
 
 You can continue with L<Mojolicious::Guides> now or take a look at the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>, which contains a lot more
-documentation and examples by many different authors.
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>, which contains a
+lot more documentation and examples by many different authors.
 
 =head1 SUPPORT
 

--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -1544,8 +1544,8 @@ explicitly.
 =head1 MORE
 
 You can continue with L<Mojolicious::Guides> now or take a look at the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>, which contains a lot more
-documentation and examples by many different authors.
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>, which contains a
+lot more documentation and examples by many different authors.
 
 =head1 SUPPORT
 

--- a/lib/Mojolicious/Guides/Routing.pod
+++ b/lib/Mojolicious/Guides/Routing.pod
@@ -1112,8 +1112,8 @@ done.
 =head1 MORE
 
 You can continue with L<Mojolicious::Guides> now or take a look at the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>, which contains a lot more
-documentation and examples by many different authors.
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>, which contains a
+lot more documentation and examples by many different authors.
 
 =head1 SUPPORT
 

--- a/lib/Mojolicious/Guides/Testing.pod
+++ b/lib/Mojolicious/Guides/Testing.pod
@@ -704,8 +704,8 @@ with roles and how to use those roles to simplify testing.
 =head1 MORE
 
 You can continue with L<Mojolicious::Guides> now or take a look at the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>, which contains a lot more
-documentation and examples by many different authors.
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>, which contains a
+lot more documentation and examples by many different authors.
 
 =head1 SUPPORT
 

--- a/lib/Mojolicious/Guides/Tutorial.pod
+++ b/lib/Mojolicious/Guides/Tutorial.pod
@@ -1021,8 +1021,8 @@ Just run your tests with L<prove>.
 =head1 MORE
 
 You can continue with L<Mojolicious::Guides> now or take a look at the
-L<Mojolicious wiki|http://github.com/kraih/mojo/wiki>, which contains a lot more
-documentation and examples by many different authors.
+L<Mojolicious wiki|http://github.com/mojolicious/mojo/wiki>, which contains a
+lot more documentation and examples by many different authors.
 
 =head1 SUPPORT
 

--- a/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
@@ -60,8 +60,8 @@
   <div id="mojobar-links">
     %= link_to Documentation => 'https://mojolicious.org/perldoc'
     %= link_to Chat => 'https://chat.mibbit.com/?channel=%23mojo&server=irc.perl.org'
-    %= link_to Wiki => 'https://github.com/kraih/mojo/wiki'
-    %= link_to GitHub => 'https://github.com/kraih/mojo'
+    %= link_to Wiki => 'https://github.com/mojolicious/mojo/wiki'
+    %= link_to GitHub => 'https://github.com/mojolicious/mojo'
     %= link_to CPAN => 'https://metacpan.org/release/Mojolicious/'
     %= link_to MailingList => 'https://groups.google.com/group/mojolicious'
     %= link_to Twitter => 'https://twitter.com/kraih'


### PR DESCRIPTION
Even tho links are still working via redirect it's nicer to use the new ones.

Note that I did not update appveyor as it seems it didn't automatically follow
the redirect like travis did. Also it seems to be showing the status of
feature branches in our README, which probably isn't a good thing?