### PR TITLE
Add log alias

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -403,8 +403,8 @@ L<Mojolicious::Controller> implements the following attributes.
 A reference back to the application that dispatched to this controller, usually
 a L<Mojolicious> object.
 
-  # Use application logger
-  $c->app->log->debug('Hello Mojo');
+  # Use application user agent
+  my $tx = $c->app->ua->get('mojolicious.org');
 
   # Generate path
   my $path = $c->app->home->child('templates', 'foo', 'bar.html.ep');
@@ -542,6 +542,7 @@ L<Mojolicious::Plugin::DefaultHelpers> and L<Mojolicious::Plugin::TagHelpers>.
   # Use a nested helper instead of the "reply" controller method
   $c->helpers->reply->not_found;
 
+
 =head2 on
 
   my $cb = $c->on(finish => sub {...});
@@ -554,26 +555,26 @@ establish the WebSocket connection.
   # Do something after the transaction has been finished
   $c->on(finish => sub {
     my $c = shift;
-    $c->app->log->debug('All data has been sent');
+    $c->log->debug('All data has been sent');
   });
 
   # Receive WebSocket message
   $c->on(message => sub {
     my ($c, $msg) = @_;
-    $c->app->log->debug("Message: $msg");
+    $c->log->debug("Message: $msg");
   });
 
   # Receive JSON object via WebSocket message
   $c->on(json => sub {
     my ($c, $hash) = @_;
-    $c->app->log->debug("Test: $hash->{test}");
+    $c->log->debug("Test: $hash->{test}");
   });
 
   # Receive WebSocket "Binary" message
   $c->on(binary => sub {
     my ($c, $bytes) = @_;
     my $len = length $bytes;
-    $c->app->log->debug("Received $len bytes");
+    $c->log->debug("Received $len bytes");
   });
 
 =head2 param

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -814,7 +814,7 @@ L<Mojolicious::Controller/"send">.
     my $c = shift;
 
     # Opened
-    $c->app->log->debug('WebSocket opened');
+    $c->log->debug('WebSocket opened');
 
     # Increase inactivity timeout for connection a bit
     $c->inactivity_timeout(300);
@@ -828,7 +828,7 @@ L<Mojolicious::Controller/"send">.
     # Closed
     $c->on(finish => sub {
       my ($c, $code, $reason) = @_;
-      $c->app->log->debug("WebSocket closed with status $code");
+      $c->log->debug("WebSocket closed with status $code");
     });
   };
 
@@ -896,7 +896,7 @@ infrastructure requirements, since it reuses the HTTP protocol for transport.
     $c->write;
 
     # Subscribe to "message" event and forward "log" events to browser
-    my $cb = $c->app->log->on(message => sub {
+    my $cb = $c->log->on(message => sub {
       my ($log, $level, @lines) = @_;
       $c->write("event:log\ndata: [$level] @lines\n\n");
     });
@@ -904,7 +904,7 @@ infrastructure requirements, since it reuses the HTTP protocol for transport.
     # Unsubscribe from "message" event again once we are done
     $c->on(finish => sub {
       my $c = shift;
-      $c->app->log->unsubscribe(message => $cb);
+      $c->log->unsubscribe(message => $cb);
     });
   };
 

--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -652,7 +652,7 @@ action could do.
 
   helper debug => sub {
     my ($c, $str) = @_;
-    $c->app->log->debug($str);
+    $c->log->debug($str);
   };
 
   get '/' => sub {
@@ -1108,7 +1108,7 @@ applications, plugins make that very simple.
     my ($self, $app) = @_;
     $app->helper(debug => sub {
       my ($c, $str) = @_;
-      $c->app->log->debug($str);
+      $c->log->debug($str);
     });
   }
 

--- a/lib/Mojolicious/Guides/Tutorial.pod
+++ b/lib/Mojolicious/Guides/Tutorial.pod
@@ -330,7 +330,7 @@ actions to templates.
   get '/secret' => sub {
     my $c    = shift;
     my $user = $c->whois;
-    $c->app->log->debug("Request from $user");
+    $c->log->debug("Request from $user");
   };
 
   app->start;
@@ -971,7 +971,7 @@ from the attribute L<Mojolicious/"mode">.
 
   get '/' => sub {
     my $c = shift;
-    $c->app->log->debug('Rendering mode specific message');
+    $c->log->debug('Rendering mode specific message');
     $c->render(text => $msg);
   };
 

--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -37,6 +37,7 @@ sub register {
 
   $app->helper(dumper => sub { shift; dumper @_ });
   $app->helper(include => sub { shift->render_to_string(@_) });
+  $app->helper(log     => sub { shift->app->log(@_) });
 
   $app->helper("reply.$_" => $self->can("_$_")) for qw(asset file static);
 
@@ -378,6 +379,12 @@ response headers with L<Mojolicious::Static/"is_fresh">.
 Set C<layout> stash value, all additional key/value pairs get merged into the
 L</"stash">.
 
+=head2 log
+
+  % log->debug('Hello Mojo')
+
+Alias for L<Mojolicious/"log">.
+
 =head2 param
 
   %= param 'foo'
@@ -486,7 +493,7 @@ created with L</"timing-E<gt>begin"> or C<undef> if no such timestamp exists.
   $c->timing->begin('database_stuff');
   ...
   my $elapsed = $c->timing->elapsed('database_stuff');
-  $c->app->log->debug("Database stuff took $elapsed seconds");
+  $c->log->debug("Database stuff took $elapsed seconds");
 
 =head2 timing->rps
 
@@ -501,7 +508,7 @@ number is too low.
   ...
   my $elapsed = $c->timing->elapsed('web_stuff');
   my $rps     = $c->timing->rps($elapsed);
-  $c->app->log->debug("Web stuff took $elapsed seconds ($rps per second)");
+  $c->log->debug("Web stuff took $elapsed seconds ($rps per second)");
 
 =head2 timing->server_timing
 


### PR DESCRIPTION
Add a log alias helper to Mojolicious::Plugin::DefaultHelpers,
and update guides and helpers to use it


Logging often happens from the controller, and this saves you from
repetitive $c->app->log calls.

This is a updated version of #1270