### PR TITLE
avoid "uninitialized value" warning in select_field

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -134,7 +134,7 @@ sub _option {
 sub _select_field {
   my ($c, $name, $options, %attrs) = (shift, shift, shift, @_);
 
-  my %values = map { $_ => 1 } @{$c->every_param($name)};
+  my %values = map { $_ => 1 } grep { defined } @{$c->every_param($name)};
 
   my $groups = '';
   for my $group (@$options) {

--- a/t/mojolicious/tag_helper_lite_app.t
+++ b/t/mojolicious/tag_helper_lite_app.t
@@ -453,7 +453,7 @@ $t->put_ok('/selection?foo=bar&a=e&foo=baz&bar=d&yada=a&yada=b&h=i&h=j')
     . "\n</form>\n");
 
 # Selection with multiple values preselected
-$t->put_ok('/selection?preselect=1')->status_is(200)
+$t->put_ok('/selection?preselect=1&undef=1')->status_is(200)
   ->content_is("<form action=\"/selection?_method=PUT\" method=\"POST\">\n  "
     . '<select name="a">'
     . '<option selected value="b">b</option>'
@@ -668,6 +668,7 @@ __DATA__
 
 @@ selection.html.ep
 % param a => qw(b g) if param 'preselect';
+% param foo => undef if param 'undef';
 %= form_for selection => begin
   %= select_field a => ['b', c(c => ['<d', [ E => 'e'], 'f']), 'g']
   %= select_field foo => [qw(bar baz)], multiple => 'multiple'


### PR DESCRIPTION
### Summary
passing an undefined start value to select_field TagHelper throws an "uninitialized value" warning

> Use of uninitialized value in list assignment at .../site_perl/5.28.0/Mojolicious/Plugin/TagHelpers.pm line 137.

### Motivation
consistency with other TagHelpers which do not produce a warning when passing undefined start values

Test script:
```
use Mojolicious::Lite;

get '/' => sub {
    my $c = shift;

    $c->param(txt => undef);
    $c->param(cb  => undef);
    $c->param(sel => undef);
} => 'index';

app->start;

__DATA__
@@ index.html.ep
%= text_field 'txt'
%= check_box 'cb'
%= select_field 'sel' => [qw(foo bar)]
```
