### PR TITLE
Fix 5 warnings on Perl 5.10

### DIFF
--- a/lib/Mojo/DOM/CSS.pm
+++ b/lib/Mojo/DOM/CSS.pm
@@ -120,7 +120,9 @@ sub _compile {
     # Tag
     elsif ($css =~ /\G((?:$ESCAPE_RE\s|\\.|[^,.#:[ >~+])+)/gco) {
       my $alias = (my $name = $1) =~ s/^([^|]*)\|// && $1 ne '*' ? $1 : undef;
-      my $ns = length $alias ? $ns{$alias} // return [['invalid']] : $alias;
+      my $ns = defined $alias && length $alias
+        ? $ns{$alias} // return [['invalid']]
+        : $alias;
       push @$last, ['tag', $name eq '*' ? undef : _name($name), _unescape($ns)];
     }
 

--- a/lib/Mojo/IOLoop/Stream.pm
+++ b/lib/Mojo/IOLoop/Stream.pm
@@ -37,7 +37,7 @@ sub is_writing {
   return !!length($self->{buffer}) || $self->has_subscribers('drain');
 }
 
-sub new { shift->SUPER::new(handle => shift, timeout => 15) }
+sub new { shift->SUPER::new(handle => shift, buffer => '', timeout => 15) }
 
 sub start {
   my $self = shift;
@@ -122,7 +122,8 @@ sub _write {
   }
 
   # Clear the buffer to free the underlying SV* memory
-  undef $self->{buffer}, $self->emit('drain') unless length $self->{buffer};
+  undef $self->{buffer}, $self->{buffer} = '', $self->emit('drain')
+    unless length $self->{buffer};
   return if $self->is_writing;
   return $self->close if $self->{graceful};
   $self->reactor->watch($handle, !$self->{paused}, 0) if $self->{handle};

--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -75,7 +75,7 @@ sub optional {
     @input = map { $self->$cb($name, $_) } @input;
   }
   $self->output->{$name} = ref $input eq 'ARRAY' ? \@input : $input[0]
-    if @input && !grep { !length } @input;
+    if @input && !grep { !defined || !length } @input;
 
   return $self->topic($name);
 }


### PR DESCRIPTION
### Summary
These changes fix 4 warnings in high-traffic code (every use of a Mojo::DOM selector for tags and potentially multiple for every write to a Mojo::IOLoop::Stream), and 1 in less-used code (validations)

For example, on Perl 5.10 this command results in 3 warnings (2 from Mojo::IOLoop::Stream, one from Mojo::DOM::CSS): `perl -Mojo -E'say g("http://google.com")->dom->at("body")'`

### Motivation
Removing these warnings makes it easier to see real issues

### References
3 of the warnings were introduced by the memory freeing done for #1256. This change has been checked using the same tests in that ticket to ensure that the memory is still freed.