### PR TITLE
switch DynamicMethods to a pre-cached super

### DIFF
--- a/lib/Mojo/DynamicMethods.pm
+++ b/lib/Mojo/DynamicMethods.pm
@@ -9,11 +9,12 @@ sub import {
   return unless $flag eq '-dispatch';
 
   my $dyn_pkg = "${caller}::_Dynamic";
+  my $caller_can = $caller->can('SUPER::can');
   monkey_patch $dyn_pkg, 'can', sub {
     my ($self, $method, @rest) = @_;
 
     # Delegate to our parent's "can" if there is one, without breaking if not
-    my $can = $self->${\($self->next::can || 'UNIVERSAL::can')}($method, @rest);
+    my $can = $self->$caller_can($method, @rest);
     return undef unless $can;
     no warnings 'once';
     my $h = do { no strict 'refs'; *{"${dyn_pkg}::${method}"}{CODE} };


### PR DESCRIPTION
Doing this (ala Class::Method::Modifiers) lets me avoid C3 mro trickery to avoid unexpected linearisation errors - means e.g,. people doing

  use Mojo::Base 'Mojolicious::Controller';

twice won't get an error they don't understand. Note that while the example I gave is something that was wrong but accidentally works, it seems to me too easy to get the same helper using class in isa twice and this makes that situation much more predictable