### PR TITLE
Add options to PODRenderer to allow for customisation

### DIFF
--- a/lib/Mojolicious/resources/templates/mojo/perldoc.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/perldoc.html.ep
@@ -106,10 +106,10 @@
           % for my $part (split '/', $module) {
             %= '::' if $path
             % $path .= "/$part";
-            %= link_to $part => url_for("/perldoc$path")
+            %= link_to $part => url_for("$root$path")
           % }
           <div id="more">
-            (<%= link_to 'source' => url_for("/perldoc$path.txt") %>,
+            (<%= link_to 'source' => url_for("$root$path.txt") %>,
             <%= link_to 'CPAN' => $cpan %>)
           </div>
         </div>

--- a/t/mojolicious/pod_renderer_lite_app.t
+++ b/t/mojolicious/pod_renderer_lite_app.t
@@ -13,6 +13,12 @@ use Mojolicious::Lite;
 plugin('PODRenderer')->name('perldoc');
 ok app->routes->find('perldoc'), 'route found';
 
+plugin('PODRenderer', {
+    route => '/doc',
+    index => 'MojoliciousTest::PODTest',
+});
+ok app->routes->find('doc'), 'alternate route found';
+
 # Default layout
 app->defaults(layout => 'gray');
 
@@ -61,6 +67,10 @@ $t->get_ok('/perldoc/MojoliciousTest/PODTest')->status_is(200)
   ->element_exists('a[href=#One]')->element_exists('a[href=#Two]')
   ->element_exists('a[href=#Three]')->element_exists('a[href=#Four]')
   ->text_like('pre code', qr/\$foo/);
+
+# Specified index
+$t->get_ok('/doc')->element_exists('#mojobar')
+  ->text_like('title', qr/PODTest/);
 
 # Trailing slash
 $t->get_ok('/perldoc/MojoliciousTest/PODTest/')->element_exists('#mojobar')


### PR DESCRIPTION
### Summary
These changes add options to the PODRenderer plugin to make it possible to adjust the module that the the browser loads by default; the route under which the browser is made available; and the template to use for rendering the HTML.

These make it possible to customise the browser so it fits the style of an existing project, including any possible branding that may be necessary. It also makes it possible to set a landing page that makes sense for that particular project (much like Mojolicious::Guides does for Mojolicious).

### Motivation
I would like to be able to customise the documentation browser so it fits the style of my project.

### References
I suggested this change [on the Mojolicious Telegram channel](https://t.me/perlmojo/12717), and was told having code to look at would make the decision process easier.

### Implementation details
I've tried to make the code fit the style in the rest of the distribution, but I'd be happy to make any changes that are deemed necessary.

I'm not sure if the handling of the `route` option (accepting either a string or a route object) is a desirable feature or if it adds too much complexity for too little benefit, so I'd be OK with making changes to this.

Likewise, moving the `_perldoc` sub into the `any` call was done because I needed access to the config values, but if there is a better way to do this, I'd be happy to change it.