### PR TITLE
Make secure_compare fail on undef or empty string

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -264,8 +264,8 @@ sub quote {
 }
 
 sub secure_compare {
-  my ($one, $two) = @_;
-  return undef if length $one != length $two;
+  my ($one, $two) = (shift // '', shift // '');
+  return undef if !length $one or length $one != length $two;
   my $r = 0;
   $r |= ord(substr $one, $_) ^ ord(substr $two, $_) for 0 .. length($one) - 1;
   return $r == 0;

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -427,6 +427,9 @@ ok !secure_compare('0♥',  '♥'),   'values are not equal';
 ok !secure_compare('0♥1', '1♥0'), 'values are not equal';
 ok !secure_compare('',      '♥'),   'values are not equal';
 ok !secure_compare('♥',   ''),      'values are not equal';
+ok !secure_compare(undef, undef), 'values are not equal';
+ok !secure_compare(undef, ''), 'values are not equal';
+ok !secure_compare('', ''), 'values are not equal';
 
 # xor_encode
 is xor_encode('hello', 'foo'), "\x0e\x0a\x03\x0a\x00", 'right result';


### PR DESCRIPTION
### Summary
Make secure_compare fail if either of its arguments are not defined or an empty string

### Motivation
secure_compare is most likely to be used in a security context but (undef, undef), (undef, '') and ('', '') all return true. This means that an error in the configuration file (e.g. typo in hash key) could lead to unexpected success as the undefined value from the error would be regarded as equal to the lack of credentials from the client (e.g. Basic authentication in an under route).

I know this goes against what Perl regards as equal (especially two empty strings). May still be worth doing from a security perspective though.. can't think of any reason you would intentionally use an empty string in this context.

Possibly important but this implementation fails faster for ('', '1') than ('1', ''), which violates the "constant compare" time I think?