### PR TITLE
Add support for the SameSite cookie attribute

### DIFF
--- a/lib/Mojo/Cookie/Response.pm
+++ b/lib/Mojo/Cookie/Response.pm
@@ -129,7 +129,13 @@ Max age for cookie.
 =head2 samesite
 
   my $samesite = $cookie->samesite;
-  $cookie       = $cookie->samesite('Lax');
+  $cookie      = $cookie->samesite('Lax');
+  # or
+  $cookie      = $cookie->samesite('Strict');
+
+SameSite flag, prevents the browser from sending cookies along with cross-site requests.
+The B<Strict> option blocks all cross-site cookies, even for top-level navigation (such as clicking on links).
+B<Lax> will only block cross-site cookies for cross-site resource requires, such as images.
 
 =head2 path
 

--- a/lib/Mojo/Cookie/Response.pm
+++ b/lib/Mojo/Cookie/Response.pm
@@ -4,9 +4,9 @@ use Mojo::Base 'Mojo::Cookie';
 use Mojo::Date;
 use Mojo::Util qw(quote split_cookie_header);
 
-has [qw(domain expires host_only httponly max_age path secure)];
+has [qw(domain expires host_only httponly max_age path secure samesite)];
 
-my %ATTRS = map { $_ => 1 } qw(domain expires httponly max-age path secure);
+my %ATTRS = map { $_ => 1 } qw(domain expires httponly max-age path secure samesite);
 
 sub parse {
   my ($self, $str) = @_;
@@ -55,6 +55,9 @@ sub to_string {
 
   # "Max-Age"
   if (defined(my $max = $self->max_age)) { $cookie .= "; Max-Age=$max" }
+
+  # "Same-Site"
+  if (defined(my $samesite = $self->samesite)) { $cookie .= "; SameSite=$samesite" }
 
   return $cookie;
 }
@@ -122,6 +125,11 @@ cookie.
   $cookie     = $cookie->max_age(60);
 
 Max age for cookie.
+
+=head2 samesite
+
+  my $samesite = $cookie->samesite;
+  $cookie       = $cookie->samesite('Lax');
 
 =head2 path
 

--- a/lib/Mojolicious/Sessions.pm
+++ b/lib/Mojolicious/Sessions.pm
@@ -4,7 +4,7 @@ use Mojo::Base -base;
 use Mojo::JSON;
 use Mojo::Util qw(b64_decode b64_encode);
 
-has [qw(cookie_domain secure)];
+has [qw(cookie_domain secure samesite)];
 has cookie_name        => 'mojolicious';
 has cookie_path        => '/';
 has default_expiration => 3600;
@@ -55,7 +55,8 @@ sub store {
     expires  => $session->{expires},
     httponly => 1,
     path     => $self->cookie_path,
-    secure   => $self->secure
+    secure   => $self->secure,
+    samesite => $self->samesite
   };
   $c->signed_cookie($self->cookie_name, $value, $options);
 }

--- a/t/mojo/cookie.t
+++ b/t/mojo/cookie.t
@@ -443,4 +443,8 @@ like $@, qr/Method "parse" not implemented by subclass/, 'right error';
 eval { Mojo::Cookie->to_string };
 like $@, qr/Method "to_string" not implemented by subclass/, 'right error';
 
+$cookies = Mojo::Cookie::Response->parse(
+  'foo=bar; Path=/; Expires=Tuesday, 09-Nov-99 23:12:40 GMT; SameSite=Lax');
+is $cookies->[0]->samesite, 'Lax', 'right samesite';
+
 done_testing();


### PR DESCRIPTION
### Summary
This PR adds support for the SameSite cookie attribute to Mojo::Cookie::Response and Mojolicious::Sessions.

### Motivation
SameSite prevents the browser from sending cookies along with cross-site requests. The main goal is mitigate the risk of cross-origin information leakage. It also provides some protection against cross-site request forgery attacks. 

## Links

https://tools.ietf.org/html/draft-west-first-party-cookies-07