### PR TITLE
Add support for SameSite cookies

### DIFF
--- a/lib/Mojo/Cookie/Response.pm
+++ b/lib/Mojo/Cookie/Response.pm
@@ -4,9 +4,9 @@ use Mojo::Base 'Mojo::Cookie';
 use Mojo::Date;
 use Mojo::Util qw(quote split_cookie_header);
 
-has [qw(domain expires host_only httponly max_age path secure)];
+has [qw(domain expires host_only httponly max_age path samesite secure)];
 
-my %ATTRS = map { $_ => 1 } qw(domain expires httponly max-age path secure);
+my %ATTRS = map { $_ => 1 } qw(domain expires httponly max-age path samesite secure);
 
 sub parse {
   my ($self, $str) = @_;
@@ -55,6 +55,9 @@ sub to_string {
 
   # "Max-Age"
   if (defined(my $max = $self->max_age)) { $cookie .= "; Max-Age=$max" }
+
+  # "Same-Site"
+  if (defined(my $samesite = $self->samesite)) { $cookie .= "; SameSite=$samesite" }
 
   return $cookie;
 }
@@ -129,6 +132,16 @@ Max age for cookie.
   $cookie  = $cookie->path('/test');
 
 Cookie path.
+
+=head2 samesite
+
+  my $samesite = $cookie->samesite;
+  $cookie      = $cookie->samesite('Lax');
+
+SameSite option. prevents the browser from sending cookies along with cross-site
+requests. The B<Strict> option blocks all cross-site cookies, even for top-level
+navigation (such as clicking on links).  B<Lax> will only block cross-site
+cookies for cross-site resource requires, such as images.
 
 =head2 secure
 

--- a/lib/Mojolicious/Sessions.pm
+++ b/lib/Mojolicious/Sessions.pm
@@ -152,7 +152,6 @@ SameSite attribute for session cookies.
 This attribute is used to control when the browser is allowed to send cookies
 for cross-site requests.
 
-
 =over 4
 
 =item C<"Lax">

--- a/lib/Mojolicious/Sessions.pm
+++ b/lib/Mojolicious/Sessions.pm
@@ -9,6 +9,7 @@ has cookie_name        => 'mojolicious';
 has cookie_path        => '/';
 has default_expiration => 3600;
 has deserialize        => sub { \&Mojo::JSON::j };
+has samesite           => 'Lax';
 has serialize          => sub { \&Mojo::JSON::encode_json };
 
 sub load {
@@ -55,7 +56,7 @@ sub store {
     expires  => $session->{expires},
     httponly => 1,
     path     => $self->cookie_path,
-    samesite => 'Lax',
+    samesite => $self->samesite,
     secure   => $self->secure,
   };
   $c->signed_cookie($self->cookie_name, $value, $options);
@@ -140,6 +141,39 @@ A callback used to deserialize sessions, defaults to L<Mojo::JSON/"j">.
     my $bytes = shift;
     return {};
   });
+
+=head2 samesite
+
+  my $str   = $sessions->samesite;
+  $sessions = $sessions->samesite('Lax')
+
+SameSite attribute for session cookies.
+
+This attribute is used to control when the browser is allowed to send cookies
+for cross-site requests.
+
+
+=over 4
+
+=item C<"Lax">
+
+This is the default value.
+
+Cookies will be sent for clicking on links and for C<method="get"> forms. They
+will not be sent for cross-site images, iframes, ajax, and C<method="post">
+forms.
+
+=item C<"Strict">
+
+Cookies will never be sent for cross-site requests. Even when the user follows a
+link to the application, the session cookies will not be sent.
+
+=item C<undef>
+
+Cookies will be sent for all cross-site requests. This is the traditional
+behavior of cookies.
+
+=back
 
 =head2 secure
 

--- a/lib/Mojolicious/Sessions.pm
+++ b/lib/Mojolicious/Sessions.pm
@@ -55,7 +55,8 @@ sub store {
     expires  => $session->{expires},
     httponly => 1,
     path     => $self->cookie_path,
-    secure   => $self->secure
+    samesite => 'Lax',
+    secure   => $self->secure,
   };
   $c->signed_cookie($self->cookie_name, $value, $options);
 }

--- a/t/mojo/cookie.t
+++ b/t/mojo/cookie.t
@@ -164,9 +164,14 @@ $cookie->max_age(60);
 $cookie->expires(1218092879);
 $cookie->secure(1);
 $cookie->httponly(1);
+$cookie->samesite('Lax');
 is $cookie->to_string,
   '0="ba r"; expires=Thu, 07 Aug 2008 07:07:59 GMT; domain=example.com;'
-  . ' path=/test; secure; HttpOnly; Max-Age=60', 'right format';
+  . ' path=/test; secure; HttpOnly; Max-Age=60; SameSite=Lax', 'right format';
+
+$cookies = Mojo::Cookie::Response->parse(
+  'foo=bar; Path=/; Expires=Tuesday, 09-Nov-99 23:12:40 GMT; SameSite=Lax');
+is $cookies->[0]->samesite, 'Lax', 'right samesite';
 
 # Empty response cookie
 is_deeply(Mojo::Cookie::Response->parse, [], 'no cookies');

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -633,7 +633,16 @@ $t->get_ok('/shortcut/act')->status_is(200)
 # Session with domain
 $t->get_ok('/foo/session')->status_is(200)
   ->header_like('Set-Cookie' => qr/; domain=\.example\.com/)
+  ->header_like('Set-Cookie' => qr/; SameSite=Lax/)
   ->header_like('Set-Cookie' => qr!; path=/bar!)->content_is('Bender rockzzz!');
+
+$t->app->sessions->samesite('Strict');
+$t->get_ok('/foo/session')
+  ->header_like('Set-Cookie' => qr/; SameSite=Strict/);
+
+$t->app->sessions->samesite(undef);
+$t->get_ok('/foo/session')
+  ->header_unlike('Set-Cookie' => qr/; SameSite=/);
 
 # Mixed formats
 $t->get_ok('/rss.xml')->status_is(200)->content_type_is('application/rss+xml')


### PR DESCRIPTION
### Summary
This PR adds support for the SameSite cookie attribute to Mojo::Cookie::Response and Mojolicious::Sessions.

### Motivation
SameSite prevents the browser from sending cookies along with cross-site requests. The main goal is mitigate the risk of cross-origin information leakage. It also provides some protection against cross-site request forgery attacks. 

This security implications of this are comparable to the httponly flag, and as such Mojolicious::Sessions sets SameSite=Lax by default. I do not understand the use case for SameSite=Strict (it seems to break normal browsing behavior)

### References

* https://tools.ietf.org/html/draft-west-first-party-cookies-07
* #1298 
* #1057
