### PR TITLE
add limit argument to split function

### DIFF
--- a/lib/Mojo/ByteStream.pm
+++ b/lib/Mojo/ByteStream.pm
@@ -48,8 +48,8 @@ sub secure_compare { Mojo::Util::secure_compare ${shift()}, shift }
 sub size { length ${$_[0]} }
 
 sub split {
-  my ($self, $pattern) = @_;
-  return Mojo::Collection->new(map { $self->new($_) } split $pattern, $$self);
+  my ($self, $pat, $lim) = (shift, shift, shift // 0);
+  return Mojo::Collection->new(map { $self->new($_) } split $pat, $$self, $lim);
 }
 
 sub tap { shift->Mojo::Base::tap(@_) }
@@ -274,12 +274,16 @@ Generate URL slug for bytestream with L<Mojo::Util/"slugify">.
 =head2 split
 
   my $collection = $stream->split(',');
+  my $collection = $stream->split(',', -1);
 
 Turn bytestream into L<Mojo::Collection> object containing L<Mojo::ByteStream>
 objects.
 
   # "One,Two,Three"
   b("one,two,three")->split(',')->map('camelize')->join(',');
+
+  # "One,Two,Three,,,"
+  b("one,two,three,,,")->split(',', -1)->map('camelize')->join(',');
 
 =head2 tap
 

--- a/t/mojo/bytestream.t
+++ b/t/mojo/bytestream.t
@@ -98,6 +98,8 @@ ok !ref $stream->to_string, 'nested bytestream stringified';
 $stream = b('1,2,3,4,5');
 is_deeply $stream->split(',')->to_array,   [1, 2, 3, 4, 5], 'right elements';
 is_deeply $stream->split(qr/,/)->to_array, [1, 2, 3, 4, 5], 'right elements';
+is_deeply b('1,2,3,4,5,,,')->split(',')->to_array, [1, 2, 3, 4, 5], 'right elements';
+is_deeply b('1,2,3,4,5,,,')->split(',', -1)->to_array, [1, 2, 3, 4, 5, '', '', ''], 'right elements';
 is_deeply b('54321')->split('')->to_array, [5, 4, 3, 2, 1], 'right elements';
 is_deeply b('')->split('')->to_array,    [], 'no elements';
 is_deeply b('')->split(',')->to_array,   [], 'no elements';


### PR DESCRIPTION
### Summary
Add support for the limit argument of Perl's split function to Mojo::ByteStream->split.
This PR contains both documentation and tests.

### Motivation
When processing character-delimited text files, a record may not have a value for it's ending fields and Perl's split function requires supplying a value for limit in order to retain those fields.
Additionally, according to the Perl manual, "In time-critical applications, it is worthwhile to avoid splitting into more fields than necessary."  As such, it makes sense to be able to override how many fields are actually processed.

### References
Brief discussion on the mailing list with the subject "Mojo::ByteStream->split"