### PR TITLE
Made debug, exception and not_found pages responsive

### DIFF
--- a/lib/Mojolicious/resources/templates/mojo/debug.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/debug.html.ep
@@ -4,6 +4,7 @@
   <head>
     % my $title = stash('exception') ? 'Server error' : 'Page not found';
     <title><%= $title %> (<%= app->mode %> mode)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="-1">
     %= javascript '/mojo/jquery/jquery.js'
@@ -82,14 +83,12 @@
         font-weight: 300;
         margin: 0;
         text-shadow: #333 0 1px 0;
+        word-break: word-break;
+        margin-top: 60px;
       }
       #footer {
         padding-top: 0.5em;
         text-align: center;
-      }
-      #nothing {
-        border-bottom: 0;
-        padding-top: 60px;
       }
       #showcase {
         border-bottom: 0;
@@ -127,6 +126,17 @@
         max-width: 1000px;
         margin: 0 auto;
       }
+      @media (max-width: 900px) {
+        .box {
+          overflow-x: auto;
+          padding: 0.5em;
+        }
+        .spaced {
+          margin: 0;
+          border: 0;
+          border-radius: 0 !important;
+        }
+      }
     </style>
   </head>
   <body>
@@ -155,7 +165,6 @@
         </tr>
       % end
       % if (my $exception = stash 'exception') {
-        <div id="nothing" class="box spaced"></div>
         % my $cv = begin
           % my ($key, $value, $i) = @_;
           %= tag 'tr', $i ? (class => 'important') : (), begin

--- a/lib/Mojolicious/resources/templates/mojo/debug.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/debug.html.ep
@@ -48,6 +48,9 @@
         border-collapse: collapse;
         width: 100%;
       }
+      td, th {
+        text-align: left;
+      }
       td { padding: 0.5em }
       .box {
         background-color: #fff;

--- a/lib/Mojolicious/resources/templates/mojo/exception.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/exception.html.ep
@@ -3,17 +3,28 @@
 <html>
   <head>
     <title>Server error</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       body { background-color: #caecf6 }
       #raptor {
         background: url(<%= url_for '/mojo/failraptor.png' %>);
+        background-position: 50% 50%;
+        background-repeat: no-repeat;
+        width: 743px;
         height: 488px;
-        left: 50%;
         margin-left: -371px;
         margin-top: -244px;
-        position:absolute;
+        position: absolute;
         top: 50%;
-        width: 743px;
+        left: 50%;
+      }
+      @media (max-width: 700px) {
+        #raptor {
+          background-size: contain;
+          width: 100%;
+          left: 0;
+          margin-left: 0;
+        }
       }
     </style>
   </head>

--- a/lib/Mojolicious/resources/templates/mojo/exception.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/exception.html.ep
@@ -22,8 +22,9 @@
         #raptor {
           background-size: contain;
           width: 100%;
-          left: 0;
-          margin-left: 0;
+          height: 100vh;
+          margin: 0;
+          position: static;
         }
       }
     </style>

--- a/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
@@ -67,21 +67,21 @@
       #mojobar-brand picture:after {
         content: "\2261";
         color: #f0f9fc;
-        font-size: 46px;
-        line-height: 16px;
+        font-size: 36px;
         text-align: center;
         width: 28px;
-        height: 28px;
+        height: 46px;
+        line-height: 46px;
+        vertical-align: middle;
         position: absolute;
-        top: 12px;
+        top: 0;
         right: 1rem;
         transition: transform 0.26s ease;
         display: block;
       }
       #mojobar.open #mojobar-brand picture:after {
         content: "\2715";
-        font-size: 26px;
-        line-height: 32px;
+        font-size: 30px;
         transform: rotate(180deg);
       }
       #mojobar-links {
@@ -150,10 +150,11 @@
       $('html, body').animate({scrollTop: offset.top - mojobarHeight}, 1);
     }
   }
-  document.querySelector("#mojobar-brand").addEventListener("click", function (e) {
-    if (window.innerWidth > 900) return;
-    e.preventDefault();
-    document.querySelector("#mojobar").classList.toggle("open");
+  $("#mojobar-brand").on("click", function (e) {
+    if (window.innerWidth <= 900) {
+      e.preventDefault();
+      $("#mojobar").toggleClass("open");
+    }
   });
   $(window).on('load', function () {
     if (window.location.hash) {

--- a/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
@@ -50,6 +50,71 @@
     }
     #mojobar-links form { display: inline }
     .animated { transition: all 0.25s ease }
+    @media (max-width: 900px) {
+      #mojobar.open {
+        overflow: visible;
+        box-shadow: none;
+        transform: translateY(0) !important; /* prevent for being hidden on scroll */
+      }
+      #mojobar-brand {
+        line-height: 46px;
+        padding: 0 1rem;
+        display: block;
+        overflow: visible;
+      }
+      #mojobar-brand img {
+        vertical-align: middle;
+      }
+      #mojobar-brand picture:after {
+        content: "\2261";
+        color: #f0f9fc;
+        font-size: 46px;
+        line-height: 16px;
+        text-align: center;
+        width: 28px;
+        height: 28px;
+        position: absolute;
+        top: 12px;
+        right: 1rem;
+        transition: transform 0.26s ease;
+        display: block;
+      }
+      #mojobar.open #mojobar-brand picture:after {
+        content: "\2715";
+        font-size: 26px;
+        line-height: 32px;
+        transform: rotate(180deg);
+      }
+      #mojobar-links {
+        background-color: #1a1a1a;
+        padding: 0.5rem 0 1rem 0 !important;
+        margin: 0 !important;
+        height: auto !important;
+        float: none !important;
+        display: block !important;
+        transform: scaleY(0);
+        transform-origin: top;
+        transition: transform 0.26s ease;
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.5);
+      }
+      #mojobar-links a {
+        font-size: 1rem !important;
+        padding: 0.3rem 1rem;
+        display: block;
+      }
+      #mojobar-links input {
+        font-size: 1rem !important;
+        margin: 0.3rem 1rem !important;
+        width: calc(100% - 2rem) !important;
+        display: block !important;
+      }
+      #mojobar-links input:focus {
+        background-color: #eee !important;
+      }
+      #mojobar.open #mojobar-links {
+        transform: scaleY(1);
+      }
+    }
   </style>
   %= link_to 'https://mojolicious.org' => (id => 'mojobar-brand') => begin
     <picture>
@@ -86,6 +151,11 @@
       $('html, body').animate({scrollTop: offset.top - mojobarHeight}, 1);
     }
   }
+  document.querySelector("#mojobar-brand").addEventListener("click", function (e) {
+    if (window.innerWidth > 900) return;
+    e.preventDefault();
+    document.querySelector("#mojobar").classList.toggle("open");
+  });
   $(window).on('load', function () {
     if (window.location.hash) {
       fixOffset();

--- a/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
@@ -54,7 +54,6 @@
       #mojobar.open {
         overflow: visible;
         box-shadow: none;
-        transform: translateY(0) !important; /* prevent for being hidden on scroll */
       }
       #mojobar-brand {
         line-height: 46px;
@@ -166,7 +165,7 @@
     var hidden = mojobarHeight + 1;
     $(window).on('scroll', function () {
       var st = $(window).scrollTop();
-      if (fixed) {
+      if (fixed && !mojobar.hasClass('open')) {
         if (st <= start) {
           fixed = false;
           mojobar.removeClass('animated');

--- a/lib/Mojolicious/resources/templates/mojo/not_found.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/not_found.html.ep
@@ -25,10 +25,9 @@
     </style>
   </head>
   <body>
-    %= link_to url_for->base => begin
+    %= link_to url_for->base, id => 'notfound', begin
       %= image '/mojo/noraptor.png', alt => 'Bye!', id => 'noraptor'
     % end
-    <div id="notfound"></div>
   </body>
 </html>
 <!-- a padding to disable MSIE and Chrome friendly error page -->

--- a/lib/Mojolicious/resources/templates/mojo/not_found.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/not_found.html.ep
@@ -3,6 +3,7 @@
 <html>
   <head>
     <title>Page not found</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       a img { border: 0 }
       body { background-color: #caecf6 }
@@ -13,13 +14,13 @@
       }
       #notfound {
         background: url(<%= url_for '/mojo/notfound.png' %>);
+        width: 306px;
         height: 62px;
-        left: 50%;
         margin-left: -153px;
         margin-top: -31px;
-        position:absolute;
+        position: absolute;
         top: 50%;
-        width: 306px;
+        left: 50%;
       }
     </style>
   </head>

--- a/lib/Mojolicious/resources/templates/mojo/perldoc.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/perldoc.html.ep
@@ -3,6 +3,7 @@
 <html>
   <head>
     <title><%= $title %></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     %= javascript '/mojo/prettify/run_prettify.js'
     <style>
       a { color: inherit }


### PR DESCRIPTION
### Summary
This PR makes the debug, exception and not_found pages mobile friendly. See screenshots below for a quick overview of the changes.

* Menu links is hidden under a hamburger toggle on small screens.
* The debug pages on mobile will allow the pre/table elements to scroll horizontally.
* The images on not_found and exception pages are in center on mobile.
* Should lib/Mojolicious/resources/templates/mojo/perldoc.html.ep be deleted?

### Motivation
The motivation for this PR is to make Mojolicious more mobile friendly. It will also make the diff for  https://github.com/mojolicious/mojolicious.org/pull/6 smaller.

### References
* https://github.com/mojolicious/mojolicious.org/pull/6

<img width="322" alt="not found production" src="https://user-images.githubusercontent.com/45729/50321049-52e80b80-0512-11e9-9a2e-fde7372d8830.png">
<img width="323" alt="exception production" src="https://user-images.githubusercontent.com/45729/50321050-5380a200-0512-11e9-9b89-8450d5904e19.png">
<img width="322" alt="exception development" src="https://user-images.githubusercontent.com/45729/50321067-63988180-0512-11e9-9485-f61d852dfee5.png">
<img width="322" alt="not found menu open development" src="https://user-images.githubusercontent.com/45729/50321211-1d8fed80-0513-11e9-91df-33339b776829.png">
