### PR TITLE
Mojo::IOLoop::Client: no NDN until next_tick

### DIFF
--- a/t/mojo/stream_while_stopped.t
+++ b/t/mojo/stream_while_stopped.t
@@ -1,0 +1,12 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Mojo::IOLoop;
+
+Mojo::IOLoop->client({address => 'localhost'}, sub {});
+
+ok(!exists Mojo::IOLoop->singleton->reactor->{io}, 'no handles created');
+
+done_testing;
+
+1;


### PR DESCRIPTION
as is done with blocking dns, delay creation of the NDN object (and
importantly, its sockets) until the loop runs.

adds a test to check that no handles are added to the reactor if a stream is
created without the loop running. i'm making the assumption that the next_tick
done with blocking dns is intending what i'm testing for -- no handles in the
reactor without actually running the loop

i first i thought the issue was with Net::DNS::Native. there's some more details at: https://github.com/olegwtf/p5-Net-DNS-Native/pull/5

not creating these objects without the loop running also avoids some warnings from NDN about destroying objects early.