### PR TITLE
Add Mojo::Promise handling to the eval command

### DIFF
--- a/lib/Mojolicious/Command/eval.pm
+++ b/lib/Mojolicious/Command/eval.pm
@@ -2,6 +2,7 @@ package Mojolicious::Command::eval;
 use Mojo::Base 'Mojolicious::Command';
 
 use Mojo::Util 'getopt';
+use Scalar::Util 'blessed';
 
 has description => 'Run code against application';
 has usage       => sub { shift->extract_usage };
@@ -16,7 +17,13 @@ sub run {
   my $app = $self->app;
   no warnings;
   my $result = eval "package main; sub app; local *app = sub { \$app }; $code";
-  return $@ ? die $@ : $result unless defined $result && ($v1 || $v2);
+  die $@ if $@;
+  if (blessed $result && $result->isa('Mojo::Promise')) {
+    my $err;
+    $result->then(sub { $result = shift }, sub { $err = shift })->wait;
+    die $err if $err;
+  }
+  return $result unless defined $result && ($v1 || $v2);
   $v2 ? print($app->dumper($result)) : say $result;
 }
 
@@ -48,7 +55,9 @@ Mojolicious::Command::eval - Eval command
 
 =head1 DESCRIPTION
 
-L<Mojolicious::Command::eval> runs code against applications.
+L<Mojolicious::Command::eval> runs code against applications. If the result is
+a L<Mojo::Promise>, it will wait until the promise is fulfilled or rejected and
+the result is returned.
 
 This is a core command, that means it is always enabled and its code a good
 example for learning to build new commands, you're welcome to fork it.

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -217,6 +217,15 @@ $buffer = '';
   $eval->run('-v', 'app->controller_class');
 }
 like $buffer, qr/Mojolicious::Controller/, 'right output';
+$buffer = '';
+{
+  open my $handle, '>', \$buffer;
+  local *STDOUT = $handle;
+  $eval->run('-v', 'Mojo::Promise->new->resolve("Zoidberg")');
+}
+like $buffer, qr/Zoidberg/, 'right output';
+eval { $eval->run('-v', 'Mojo::Promise->new->reject("DOOM")') };
+like $@, qr/DOOM/, 'right output';
 
 # generate
 require Mojolicious::Command::Author::generate;


### PR DESCRIPTION
I find the eval command to be invaluable for one-off usage and testing, especially while developing. As I've been writing more promise apis and now as I'm writing fewer blocking apis due to the existence of Mojo::AsyncAwait, I'm finding the usage of promises in the eval command to be cumbersome to the point of not using it. With this change, one that I doubt would affect any usage in the wild (who wants to dump the stringified promise?), we can make a very comfortable interface for one-off testing of promise apis and make for easy examples and demos for newcomers or answer-seekers on irc.
