### PR TITLE
Add Mojo::Promise->timeout

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -63,6 +63,13 @@ sub then {
   return $new;
 }
 
+sub timeout {
+  my ($self, $after, $err)
+    = (ref $_[0] ? shift : shift->new, @_, 'Promise timeout');
+  $self->ioloop->timer($after => sub { $self->reject($err) });
+  return $self;
+}
+
 sub wait {
   my $self = shift;
   return if (my $loop = $self->ioloop)->is_running;
@@ -347,6 +354,15 @@ L<Mojo::Promise> object resolving to the return value of the called handler.
       return "This is bad: $reason[0]";
     }
   );
+
+=head2 timeout
+
+  my $promise = $promise->timeout(5 => 'Timeout!');
+  my $promise = $promise->timeout(5);
+
+Create a new L<Mojo::Promise> that will be rejected after a given amount of
+time in seconds. A default rejection reason will be provided, unless specified
+as input.
 
 =head2 wait
 

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -134,7 +134,7 @@ is_deeply \@results, ['pass'], 'promise resolved';
 
 # Clone
 my $loop = Mojo::IOLoop->new;
-$promise  = Mojo::Promise->new(ioloop => $loop)->resolve('failed');
+$promise = Mojo::Promise->new(ioloop => $loop)->resolve('failed');
 $promise2 = $promise->clone;
 (@results, @errors) = ();
 $promise2->then(sub { @results = @_ }, sub { @errors = @_ });
@@ -180,6 +180,21 @@ $promise->resolve('first');
 Mojo::IOLoop->one_tick;
 is_deeply \@results, [], 'promises not resolved';
 is_deeply \@errors, ['second'], 'promise rejected';
+
+# Timeout
+(@errors, @results) = @_;
+$promise = Mojo::Promise->timeout(0.25 => 'Timeout1');
+$promise2 = Mojo::Promise->new->timeout(0.025 => 'Timeout2');
+$promise3
+  = Mojo::Promise->race($promise, $promise2)->then(sub { @results = @_ })
+  ->catch(sub { @errors = @_ })->wait;
+is_deeply \@results, [], 'promises not resolved';
+is_deeply \@errors, ['Timeout2'], 'promise rejected';
+
+# Timeout with default message
+@errors = ();
+Mojo::Promise->timeout(0.025)->catch(sub { @errors = @_ })->wait;
+is_deeply \@errors, ['Promise timeout'], 'default timeout message';
 
 # All
 $promise  = Mojo::Promise->new->then(sub {@_});


### PR DESCRIPTION
### Summary
Adding a timeout method to avoid having to wrap Mojo::IOLoop->timeout(...) in a promise.

### Motivation
To make Mojo::Promise simpler to use in a generic usecase.

### References
https://github.com/mojolicious/mojo/issues/1310#issuecomment-451748766
