### PR TITLE
Add get methods to Mojo::Promise

### DIFF
--- a/lib/Mojolicious/Command/eval.pm
+++ b/lib/Mojolicious/Command/eval.pm
@@ -19,10 +19,7 @@ sub run {
   die $@ if $@;
 
   # Handle promises
-  my $err;
-  Mojo::Promise->resolve($result)
-    ->then(sub { $result = shift }, sub { $err = shift })->wait;
-  die $err if $err;
+  $result = Mojo::Promise->resolve($result)->get_one;
 
   return $result unless defined $result && ($v1 || $v2);
   $v2 ? print($app->dumper($result)) : say $result;


### PR DESCRIPTION
### Summary
Add a `get` method to Mojo::Promise for retrieving results in a synchronous manner.

### Motivation
The `get` method in Future is widely used to similarly await the results of a Future. The `eval` core command can handle promises much more simply using this method.

### References
https://github.com/mojolicious/mojo/issues/1310#issuecomment-452119631, https://metacpan.org/pod/Mojo::Promise::Role::Get, https://metacpan.org/pod/Future#get
