### PR TITLE
Wait for promise to resolve regardless of loop being stopped

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -100,8 +100,9 @@ sub timeout { shift->_timer('reject',  @_) }
 sub wait {
   my $self = shift;
   return if (my $loop = $self->ioloop)->is_running;
-  $self->finally(sub { $loop->stop });
-  $loop->start;
+  my $done;
+  $self->finally(sub { $done++; $loop->stop });
+  $loop->start until $done;
 }
 
 sub _defer {

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -336,4 +336,14 @@ $promise->then(sub { $ok = 1; $loop->stop });
 $loop->start;
 ok $ok, 'loop completed';
 
+# Wait for stopped loop
+@results = ();
+$promise = Mojo::Promise->new;
+Mojo::IOLoop->next_tick(sub {
+  Mojo::IOLoop->stop;
+  Mojo::IOLoop->timer(0.1 => sub { $promise->resolve('wait') });
+});
+$promise->then(sub { @results = @_ })->wait;
+is_deeply \@results, ['wait'], 'promise resolved';
+
 done_testing();


### PR DESCRIPTION
### Summary
Ensure that `wait` will keep running the loop until the promise is no longer pending.

### Motivation
Calling `wait` can result in a still-pending promise even if the loop is not running, as anything may stop the loop. This small change ensures that it will not return while the promise is pending, which is the documented behavior and user expectation. This is also important for the proposed `get` method(s), to ensure it does not return before the results are available.

### References
Prior art: the implementations of `await` and `get` in Future event loop subclasses will loop until the Future is no longer pending.