### PR TITLE
Allow for integer times in Mojo::Log default format (resolves #1316)

### DIFF
--- a/lib/Mojo/Log.pm
+++ b/lib/Mojo/Log.pm
@@ -56,7 +56,7 @@ sub _default {
   my ($time, $level) = (shift, shift);
   my ($s, $m, $h, $day, $month, $year) = localtime $time;
   $time = sprintf '%04d-%02d-%02d %02d:%02d:%08.5f', $year + 1900, $month + 1,
-    $day, $h, $m, "$s." . (split /\./, $time)[1];
+    $day, $h, $m, "$s." . ((split /\./, $time)[1] // 0);
   return "[$time] [$$] [$level] " . join "\n", @_, '';
 }
 

--- a/t/mojo/log.t
+++ b/t/mojo/log.t
@@ -52,6 +52,8 @@ like $log->format->(time, 'debug', qw(Test 1 2 3)),
   qr/^\[.*\] \[debug\] Test\n1\n2\n3\n$/, 'right format';
 like $log->format->(time, 'error', 'I ♥ Mojolicious'),
   qr/^\[.*\] \[error\] I ♥ Mojolicious\n$/, 'right format';
+like $log->format->(CORE::time, 'error', 'I ♥ Mojolicious'),
+  qr/^\[.*\] \[error\] I ♥ Mojolicious\n$/, 'right format';
 $log->format(sub {
   my ($time, $level, @lines) = @_;
   return join ':', $level, $time, @lines;


### PR DESCRIPTION
### Summary
If Time::HiRes::time returns an integer time (when the decimal component is 0) a warning is generated due to using the undef value in a string.

### Motivation
Prevent warnings

### References
#1316
