### PR TITLE
Make using a unknwon type in routes fatal

### DIFF
--- a/lib/Mojolicious/Routes/Pattern.pm
+++ b/lib/Mojolicious/Routes/Pattern.pm
@@ -113,7 +113,7 @@ sub _compile {
     # Placeholder
     else {
       if ($value =~ /^(.+)\Q$start\E(.+)$/) {
-        ($value, $part) = ($1, _compile_req($types->{$2} // '?!'));
+        ($value, $part) = ($1, _compile_req($types->{$2} // die qq{Unknown route type "$2"}));
       }
       else {
         $part = $type ? $type eq 'relaxed' ? '([^/]+)' : '(.+)' : '([^/.]+)';

--- a/t/mojolicious/routes.t
+++ b/t/mojolicious/routes.t
@@ -971,13 +971,8 @@ is $m->path_for->{path}, '/custom_pattern/a_123_b/c.123/d/123', 'right path';
 $r = Mojolicious::Routes->new;
 $r->get('/<foo:does_not_exist>');
 $m = Mojolicious::Routes::Match->new(root => $r);
-$m->find($c => {method => 'GET', path => '/'});
-is_deeply $m->stack, [], 'empty stack';
-$m = Mojolicious::Routes::Match->new(root => $r);
-$m->find($c => {method => 'GET', path => '/test'});
-is_deeply $m->stack, [], 'empty stack';
-$m = Mojolicious::Routes::Match->new(root => $r);
-$m->find($c => {method => 'GET', path => '/23'});
+eval { $m->find($c => {method => 'GET', path => '/whatever'}); };
+like $@, qr/Unknown route type "does_not_exist"/, 'right error';
 is_deeply $m->stack, [], 'empty stack';
 
 done_testing();


### PR DESCRIPTION
### Summary
When creating routes that use placeholders that have types, the routes should throw an exception when matching instead of simply failing to match anything if a route type used does not exist.

### Motivation
This is a hard to debug problem where a typo in a placeholder type can result in routes not working in a subtle way

### References

IRC 2019-02-08
>&lt;markfowler> So, what the logic behind having a route that uses a type that doesn't exist resulting in a route that never matches
>12:34 PM rather than going bang
>12:37 PM &lt;kraih> ?
>12:38 PM &lt;markfowler> Mark Fowler So If I do $r->get("/foo/<bar:a_type_i_have_not_declared")
>12:38 PM Then I get an unmatchable route, not some sort of immediate error
>12:38 PM &lt;kraih> implementation detail, feel free to propose improvements
