### PR TITLE
Add map class method to Mojo::Promise

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -41,6 +41,31 @@ sub finally {
   return $new;
 }
 
+sub map {
+  my ($class, $options) = (shift, ref $_[0] eq 'HASH' ? shift : {});
+  my ($cb, @items) = @_;
+
+  my @start = map { $_->$cb } splice @items, 0,
+    $options->{concurrency} // @items;
+  my $proto = $class->resolve($start[0]);
+
+  my (@trigger, @wait);
+  for my $item (@items) {
+    my $p = $proto->clone;
+    push @trigger, $p;
+    push @wait, $p->then(sub { local $_ = $item; $_->$cb });
+  }
+
+  my @all = map {
+    $proto->clone->resolve($_)->then(
+      sub { shift(@trigger)->resolve if @trigger; @_ },
+      sub { @trigger = (); $proto->clone->reject($_[0]) },
+    )
+  } (@start, @wait);
+
+  return $class->all(@all);
+}
+
 sub race {
   my ($class, @promises) = @_;
   my $new = $promises[0]->clone;
@@ -289,6 +314,33 @@ reason.
     my @value_or_reason = @_;
     say "We are done!";
   });
+
+=head2 map
+
+  my $promise = Mojo::Promise->map(sub { ... }, @items);
+  my $promise = Mojo::Promise->map({concurrency => 3}, sub { ... }, @items);
+
+Apply a function that returns a L<Mojo::Promise> to each item in a list of
+items while optionally limiting concurrency. Returns a L<Mojo::Promise> that
+collects the results in the same manner as L</all>.
+
+Note that if any item's promise is rejected, any remaining items which have not
+yet been mapped will not be.
+
+  Mojo::Promise->map({concurrency => 3}, sub { $ua->get_p($_) }, @urls)
+    ->then(sub{ say $_->[0]->res->dom->at('title')->text for @_ });
+
+These options are currently available:
+
+=over 2
+
+=item concurrency
+
+  concurrency => 3
+
+The maximum number of items are in progress at the same time.
+
+=back
 
 =head2 race
 

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -122,11 +122,12 @@ sub _finally {
 
 sub _settle {
   my ($self, $status) = (shift, shift);
-  $self = $self->new unless ref $self;
+  my $thenable = blessed $_[0] && $_[0]->can('then');
+  $self = $thenable ? $_[0]->clone : $self->new unless ref $self;
 
   $_[0]->then(sub { $self->resolve(@_); () }, sub { $self->reject(@_); () })
     and return $self
-    if blessed $_[0] && $_[0]->can('then');
+    if $thenable;
 
   return $self if $self->{result};
 

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -280,4 +280,14 @@ is_deeply \@results, [], 'promise not resolved';
 is_deeply \@errors, [1], 'correct errors';
 is_deeply \@started, [1, 2, 3], 'only initial batch started';
 
+my $ok;
+$loop = Mojo::IOLoop->new;
+$promise
+  = Mojo::Promise->map(sub { Mojo::Promise->new(ioloop => $loop)->resolve }, 1);
+is $promise->ioloop, $loop, 'same loop';
+isnt $promise->ioloop, Mojo::IOLoop->singleton, 'not the singleton';
+$promise->then(sub{ $ok = 1; $loop->stop });
+$loop->start;
+ok $ok, 'loop completed';
+
 done_testing();


### PR DESCRIPTION
Add a map method that allows delaying of portions of a set of promises so as to limit concurrency.