### PR TITLE
Add minimum size to renderer compression

### DIFF
--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -14,6 +14,7 @@ has [qw(compress default_handler)];
 has default_format => 'html';
 has encoding       => 'UTF-8';
 has [qw(handlers helpers)] => sub { {} };
+has min_compress_size => '860';
 has paths => sub { [] };
 
 # Bundled templates
@@ -122,7 +123,7 @@ sub respond {
 
   # Gzip compression
   my $res = $c->res;
-  if ($self->compress) {
+  if ($self->compress && length($output) >= $self->min_compress_size) {
     my $headers = $res->headers;
     $headers->append(Vary => 'Accept-Encoding');
     my $gzip = ($c->req->headers->accept_encoding // '') =~ /gzip/i;
@@ -327,6 +328,15 @@ Registered handlers.
   $renderer   = $renderer->helpers({url_for => sub {...}});
 
 Registered helpers.
+
+=head2 min_compress_size
+
+  my $min   = $renderer->min_compress_size;
+  $renderer = $renderer->min_compress_size(1024);
+
+Minimum output size in bytes required for compression to be used if enabled,
+defaults to 860. Note that this attribute is EXPERIMENTAL and might change
+without warning!
 
 =head2 paths
 

--- a/t/mojolicious/renderer.t
+++ b/t/mojolicious/renderer.t
@@ -143,6 +143,17 @@ is $c->res->headers->content_encoding, 'whatever',
   'right "Content-Encoding" value';
 is $c->res->body, $output, 'same string';
 
+# Compression (below minimum length)
+$output = 'a' x 850;
+$c = $app->build_controller;
+$c->req->headers->accept_encoding('gzip');
+$renderer->respond($c, $output, 'html');
+is $c->res->headers->content_type, 'text/html;charset=UTF-8',
+  'right "Content-Type" value';
+ok !$c->res->headers->vary,             'no "Vary" value';
+ok !$c->res->headers->content_encoding, 'no "Content-Encoding" value';
+is $c->res->body, $output, 'same string';
+
 # Missing method (AUTOLOAD)
 my $class = ref $first->myapp;
 eval { $first->myapp->missing };


### PR DESCRIPTION
### Summary
Implements a minimum size of the output for compression via an attribute

### Motivation
Compression can be counter-productive on small inputs both in terms of output size and CPU time.

### References
Issue #1328 
