### PR TITLE
Silence "Ambiguous Scalar" Warnings

### DIFF
--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -213,11 +213,11 @@ sub _compile {
 
       # Escaped
       if (!$multi && ($op eq 'escp' && !$escape || $op eq 'expr' && $escape)) {
-        $blocks[-1] .= "\$_O .= _escape scalar + $value";
+        $blocks[-1] .= "no warnings 'ambiguous'; \$_O .= _escape scalar + $value";
       }
 
       # Raw
-      elsif (!$multi) { $blocks[-1] .= "\$_O .= scalar + $value" }
+      elsif (!$multi) { $blocks[-1] .= "no warnings 'ambiguous'; \$_O .= scalar + $value" }
 
       # Multi-line
       $multi = !$next || $next->[0] ne 'text';

--- a/t/mojo/template.t
+++ b/t/mojo/template.t
@@ -1189,4 +1189,12 @@ like $@, qr/invalid encoding/, 'right error';
 $mt = Mojo::Template->new(escape => sub { '+' . $_[0] });
 is $mt->render('<%== "hi" =%>'), '+hi', 'right escaped string';
 
+# No 'Use of "scalar" without parentheses is ambiguous' warnings
+$mt     = Mojo::Template->new;
+$output = $mt->render(<<'EOF');
+% use warnings FATAL => 'ambiguous';
+%= "ABC"
+EOF
+is $output, "ABC\n", 'no "ambiguous scalar" warning';
+
 done_testing();


### PR DESCRIPTION
### Summary
Silence `Warning: Use of "scalar" without parentheses is ambiguous at template path/to/template.html.ep line XXX` messages

### Motivation
I included a module that (like Mojolicious itself) enabled `use warnings` in its calling context.  Unfortunately, however, whenever that template included an `%= expression` (or `<%= expression %>`) it would issue a warning to STDERR.

I had originally looked into wrapping the "scalar + $value" like `scalar( + $value )`, and/or `scalar do { + $value }`, but that didn't work when the expression spanned multiple lines.  :-/

Then I tried adding just the `do {` to the opening statement, and the `}` before the semicolon, but *that* didn't work for, e.g., `%= $block->(--$i) if $i` — so I ended up just punting and prepending `no warnings 'ambiguous';` before the whole assignment.

"If it's stupid — but it works — it isn't stupid..."  ;-D