### PR TITLE
return result of GetOptionsFromArray in getopt().

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -148,8 +148,10 @@ sub getopt {
   my ($array, $opts) = map { ref $_[0] eq 'ARRAY' ? shift : $_ } \@ARGV, [];
   my $save = Getopt::Long::Configure(qw(default no_auto_abbrev no_ignore_case),
     @$opts);
-  GetOptionsFromArray $array, @_;
+  my $result = GetOptionsFromArray $array, @_;
   Getopt::Long::Configure($save);
+
+  return $result;
 }
 
 sub gunzip {

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -142,6 +142,26 @@ is_deeply $array, ['stuff'], 'right structure';
   is_deeply \@ARGV,    ['test'],   'right structure';
 }
 
+{
+  my $getopt_success = getopt ['--lang', 'de'], 'l|lang=s' => \my $lang;
+  is $lang, 'de';
+  is $getopt_success, 1;
+}
+
+{
+  local $SIG{__WARN__} = sub {};
+  my $getopt_success = getopt ['--lnag', 'de'], 'l|lang=s' => \my $lang;
+  is $lang, undef;
+  is $getopt_success, '';
+}
+
+{
+  local $SIG{__WARN__} = sub {};
+  my $getopt_success = getopt ['--lnag', 'de', '--lang', 'de'], 'l|lang=s' => \my $lang;
+  is $lang, 'de';
+  is $getopt_success, '';
+}
+
 # unindent
 is unindent(" test\n  123\n 456\n"), "test\n 123\n456\n",
   'right unindented result';

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -145,21 +145,21 @@ is_deeply $array, ['stuff'], 'right structure';
 {
   my $getopt_success = getopt ['--lang', 'de'], 'l|lang=s' => \my $lang;
   is $lang, 'de';
-  is $getopt_success, 1;
+  ok $getopt_success;
 }
 
 {
   local $SIG{__WARN__} = sub {};
   my $getopt_success = getopt ['--lnag', 'de'], 'l|lang=s' => \my $lang;
   is $lang, undef;
-  is $getopt_success, '';
+  ok !$getopt_success;
 }
 
 {
   local $SIG{__WARN__} = sub {};
   my $getopt_success = getopt ['--lnag', 'de', '--lang', 'de'], 'l|lang=s' => \my $lang;
   is $lang, 'de';
-  is $getopt_success, '';
+  ok !$getopt_success;
 }
 
 # unindent


### PR DESCRIPTION
That way the users of getopt can check whether the option parsing was successful or not.

### Summary

Currently it's not possible to check e.g. in a ::Command whether the option parsing was successful or not. But if you want to exit as early as possible this is necessary.

### Motivation

GetOptionsFromArray already has such a return value but it is not returned in getopt() as the Getopt::Long::Configure call is the last statement in the subroutine.
