### PR TITLE
Fall back to normal constructor if hash style arguments are provided

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -2,6 +2,7 @@ package Mojo::Promise;
 use Mojo::Base -base;
 
 use Mojo::IOLoop;
+use Mojo::Util 'deprecated';
 use Scalar::Util 'blessed';
 
 has ioloop => sub { Mojo::IOLoop->singleton }, weak => 1;
@@ -67,6 +68,10 @@ sub map {
 }
 
 sub new {
+  if (@_ > 2 or ref($_[1]) eq 'HASH') {
+    deprecated 'Mojo::Promise::new with attributes is DEPRECATED';
+    return shift->SUPER::new(@_);
+  }
   my $self = shift->SUPER::new;
   shift->(sub { $self->resolve(@_) }, sub { $self->reject(@_) }) if @_;
   return $self;


### PR DESCRIPTION
### Summary
Fall back to old behavior if more than one argument or hashref is given as argument

### Motivation
Maintain old behavior

### References
As discussed on IRC.