### PR TITLE
Fix Mojo::UserAgent request timeout on kept-alive connections

### DIFF
--- a/lib/Mojo/UserAgent.pm
+++ b/lib/Mojo/UserAgent.pm
@@ -225,7 +225,7 @@ sub _finish {
 
   # Remove request timeout and finish transaction
   return undef unless my $c = $self->{connections}{$id};
-  $c->{ioloop}->remove($c->{timeout}) if $c->{timeout};
+  $c->{ioloop}->remove(delete $c->{timeout}) if $c->{timeout};
   return $self->_reuse($id, $close) unless my $old = $c->{tx};
 
   # Premature connection close

--- a/t/mojo/user_agent.t
+++ b/t/mojo/user_agent.t
@@ -427,6 +427,15 @@ $ua->get(
 Mojo::IOLoop->start;
 ok !Mojo::IOLoop->stream($id), 'connection timed out';
 
+# Request timeout with keepalive
+$ua->request_timeout(3600);
+ok !$ua->get('/')->error, 'priming the keepalive connection';
+$ua->request_timeout(0.01);
+$tx = $ua->get('/timeout?timeout=5');
+is $tx->error->{message}, 'Request timeout', 'right error message';
+is $tx->error->{code}, undef, 'no status';
+$ua->request_timeout(0);
+
 # Response exceeding message size limit
 $ua->once(
   start => sub {


### PR DESCRIPTION
Make sure to delete the timer from the connection cache too, not just
the ioloop, so the next request on the same connection will add its
timeout.