### PR TITLE
Fix synchronizing non-blocking operations example

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -600,7 +600,7 @@ that create them for you.
     my $c = shift;
 
     # Create two promises
-    my $url   = Mojo::URL->new('fastapi.metacpan.org/v1/module/_search');
+    my $url   = Mojo::URL->new('http://fastapi.metacpan.org/v1/module/_search');
     my $mojo   = $c->ua->get_p($url->clone->query({q => 'mojo'}));
     my $minion = $c->ua->get_p($url->clone->query({q => 'minion'}));
 


### PR DESCRIPTION
### Summary
Fix synchronizing non-blocking operations example.

### Motivation
Passing a Mojo::URL without scheme to Mojo::UserAgent->get(_p) does not work because the UA tries to fetch from localhost (see debug below).

This works:
`perl -Mojo -E 'say g("mojolicious.org")->dom->at("title")->text'`

This does not work:
`MOJO_CLIENT_DEBUG=1 perl -Mojo -E 'say g(Mojo::URL->new("mojolicious.org"))->dom->at("title")->text'`

Debug:
```
-- Blocking request (mojolicious.org)
-- Connect 8a1756fbe6b9d5bb3d50ea46f85350ab (http://127.0.0.1:42889)
-- Client >>> Server (http://127.0.0.1:42889/mojolicious.org)
GET /mojolicious.org HTTP/1.1\x0d
Content-Length: 0\x0d
User-Agent: Mojolicious (Perl)\x0d
Host: 127.0.0.1:42889\x0d
Accept-Encoding: gzip\x0d
\x0d
```

Maybe mojolicious should also support `g(Mojo::URL->new("<url without scheme>"))` for better consistency.