### PR TITLE
Add range() to Mojo::Collection

### DIFF
--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -57,6 +57,16 @@ sub new {
   return bless [@_], ref $class || $class;
 }
 
+sub range {
+  my $self = shift;
+  my ($begin, $end)
+    = map { my $i = $_ < 0 ? @$self + $_ : $_; $i < 0 ? 0 : $i }
+    ($_[0] // 0, $_[1] // int @$self);
+  return $self->new if $begin >= @$self || $end == 0;
+  $end = @$self - 1 if $end >= @$self;
+  return $self->new(@$self[$begin .. $end]);
+}
+
 sub reduce {
   my $self = shift;
   @_ = (@_, @$self);
@@ -96,7 +106,7 @@ sub uniq {
   my ($self, $cb) = (shift, shift);
   my %seen;
   return $self->new(grep { !$seen{$_->$cb(@_) // ''}++ } @$self) if $cb;
-  return $self->new(grep { !$seen{$_          // ''}++ } @$self);
+  return $self->new(grep { !$seen{$_ // ''}++ } @$self);
 }
 
 sub with_roles { shift->Mojo::Base::with_roles(@_) }
@@ -280,6 +290,26 @@ passed to the callback, and is also available as C<$_>.
   my $collection = Mojo::Collection->new(1, 2, 3);
 
 Construct a new array-based L<Mojo::Collection> object.
+
+=head2 range
+
+  my $new = $collection->range($begin, $end);
+  my $new = $collection->range(0, 2);
+  my $new = $collection->range(-4, -1);
+  my $new = $collection->range;
+  my $new = $collection->range;
+
+Creates a new collection with the portion of the collection from C<$begin> to
+C<$end> - C<$end> not included. C<$begin> will default to "0" unless specified,
+and C<$end> will default to the L</size> of the collection. If C<$begin> is
+greater than the L</size> of the collection, then an empty collection will be
+returned. C<$begin> and C<$end> can also be negative, indicating an offset from
+the end of the collection.
+
+  # "C D E"
+  c('A', 'B', 'C', 'D', 'E')->range(2)->join(' ');
+  c('A', 'B', 'C', 'D', 'E')->range(2, -1)->join(' ');
+  c('A', 'B', 'C', 'D', 'E')->range(-3, -1)->join(' ');
 
 =head2 reduce
 

--- a/t/mojo/collection.t
+++ b/t/mojo/collection.t
@@ -96,6 +96,20 @@ is $collection->map('reverse')->map(join => "\n")->join("\n"),
 is $collection->map(join => '-')->join("\n"), "1-2-3\n4-5-6\n7-8-9",
   'right result';
 
+# range
+$collection = c(1 .. 5);
+is_deeply $collection->range(0)->to_array, [1 .. 5], 'right result';
+is_deeply $collection->range(0, 0)->to_array, [], 'right result';
+is_deeply $collection->range(0, 4)->to_array,  [1 .. 5], 'right result';
+is_deeply $collection->range(0, 10)->to_array, [1 .. 5], 'right result';
+is_deeply $collection->range(4)->to_array, [5], 'right result';
+is_deeply $collection->range(5)->to_array, [], 'right result';
+is_deeply $collection->range(5, 10)->to_array, [], 'right result';
+is_deeply $collection->range(-1, -1)->to_array, [5], 'right result';
+is_deeply $collection->range(-10, -7)->to_array, [], 'right result';
+is_deeply $collection->range(-10, 10)->to_array, [1 .. 5], 'right result';
+is_deeply $collection->range(-3)->to_array, [3 .. 5], 'right result';
+
 # reverse
 $collection = c(3, 2, 1);
 is_deeply $collection->reverse->to_array, [1, 2, 3], 'right order';
@@ -140,7 +154,7 @@ $collection = c(qw(Test perl Mojo));
 is_deeply $collection->sort(sub { uc(shift) cmp uc(shift) })->to_array,
   [qw(Mojo perl Test)], 'right order';
 $collection = c();
-is_deeply $collection->sort->to_array,                    [], 'no elements';
+is_deeply $collection->sort->to_array, [], 'no elements';
 is_deeply $collection->sort(sub { $a cmp $b })->to_array, [], 'no elements';
 
 # slice


### PR DESCRIPTION
### Summary
Method for Mojo::Collection to create new collections with the same API as `slice()` in JavaScript: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice

### Motivation
I often wanted `Mojo::Collection::slice()` to avoid returning `undef()` elements when specifying a range outside of the collection's size, and also allow specifying a range with negative indexes.

### References
This idea (finally) came to life from the discussions/PR below and conversations on IRC, earlier today.
https://github.com/mojolicious/mojo/issues/1350
https://github.com/mojolicious/mojo/pull/1360