### PR TITLE
Fix broken link to cipher string list (#1356, thanks daxim)

### DIFF
--- a/lib/Mojo/Server/Daemon.pm
+++ b/lib/Mojo/Server/Daemon.pm
@@ -406,7 +406,7 @@ Path to the TLS cert file, defaults to a built-in test certificate.
   ciphers=AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH
 
 TLS cipher specification string. For more information about the format see
-L<https://www.openssl.org/docs/manmaster/apps/ciphers.html#CIPHER-STRINGS>.
+L<https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-STRINGS>.
 
 =item fd
 


### PR DESCRIPTION
### Summary
Fixes a broken link in the Mojo::Daemon documentation.

### Motivation
Broken links are bad and non-useful

### References
Reported in github issue #1356 by daxim
