### PR TITLE
Fix missed example for query behaviour change in 8.0 (yuki-kimoto)

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -810,7 +810,7 @@ You can also use the helper L<Mojolicious::Plugin::DefaultHelpers/"url_with">
 to inherit query parameters from the current request.
 
   # "/list?q=mojo&page=2" if current request was for "/list?q=mojo&page=1"
-  $c->url_with->query([page => 2]);
+  $c->url_with->query({page => 2});
 
 =head2 write
 


### PR DESCRIPTION
### Summary
One of the examples for Mojo::URL->query behaviour was missed when it changed in 8.0. This corrects the example code.
I also did a (quick) check for other examples that may have been missed, but didn't find any more.

### Motivation
Examples in documentation should be correct.

### References
Reported by yuki-kimoto (GitHub #1365).
