### PR TITLE
Add -nst to .perltidyrc

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -11,3 +11,4 @@
 -sbt=2   # High square bracket tightness
 -wn      # Weld nested containers
 -isbc    # Don't indent comments without leading space
+-nst     # Don't output to STDOUT


### PR DESCRIPTION
### Summary
The -nst option disables -st which is enabled by -pbp, which causes the tidied code to be written to STDOUT instead of a a new file suffixed with `.tdy`. This means only one file can be tidied at a time, and the -st option is also incompatible with the -b option, which allows updating files in place, a workflow well suited for git.

Instead of `perltidy lib/Some/File.pm > lib/SomeFile.pm.tdy`, now just do `perltidy lib/Some/File.pm` and multiple files can be specified in one command.

`perltidy -b lib/Some/File.pm` will update the file(s) in place and create lib/Some/File.pm.bak.

`perltidy -b -bext=/ lib/Some/File.pm` will update the file(s) in place and delete the backup file(s) as long as there were no errors.

### Motivation
To make it easier for contributors to run perltidy on their contributions.

### References
https://github.com/mojolicious/json-validator/pull/162
