### PR TITLE
fix usage of setsid

### DIFF
--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -30,7 +30,7 @@ sub daemonize {
   # Fork and kill parent
   die "Can't fork: $!" unless defined(my $pid = fork);
   exit 0 if $pid;
-  POSIX::setsid or die "Can't start a new session: $!";
+  POSIX::setsid == -1 and die "Can't start a new session: $!";
 
   # Close filehandles
   open STDIN,  '<',  '/dev/null';


### PR DESCRIPTION
### Summary

Fix usage of setsid

### Motivation

POSIX::setsid returns -1, not undef on failure:
```
❯ perl -MPOSIX -le 'my $ret = POSIX::setsid; print "$ret: $!"'
-1: Operation not permitted
```

### References

N/A
