### PR TITLE
Can string match on object as well

### DIFF
--- a/lib/Mojo/Exception.pm
+++ b/lib/Mojo/Exception.pm
@@ -26,6 +26,7 @@ sub check {
 
   my ($default, $handler);
   my $is_obj = blessed $err;
+  my $can_re = !$is_obj || $is_obj && overload::Method($err, '""');
 CHECK: for (my $i = 0; $i < @spec; $i += 2) {
     my ($checks, $cb) = @spec[$i, $i + 1];
 
@@ -33,8 +34,8 @@ CHECK: for (my $i = 0; $i < @spec; $i += 2) {
 
     for my $c (ref $checks eq 'ARRAY' ? @$checks : $checks) {
       my $is_re = ref $c eq 'Regexp';
-      ($handler = $cb) and last CHECK if $is_obj  && !$is_re && $err->isa($c);
-      ($handler = $cb) and last CHECK if !$is_obj && $is_re  && $err =~ $c;
+      ($handler = $cb) and last CHECK if $is_obj && !$is_re && $err->isa($c);
+      ($handler = $cb) and last CHECK if $can_re && $err =~ $c;
     }
   }
 


### PR DESCRIPTION
### Summary
This change allow `check()` in Mojo::Exception to run regex checks on objects that can stringify. 

### Motivation
@kraih asked for it in #mojo on freenode, and I think it makes a lot of sense to be able check if for example a Mojo::Exception object match certain regexes, since it's a very generic exception object.

I chose to check if the object is string overloaded, so we don't match against strings that look like "Foo::Bar=HASH(0x7f8ab5804248)".