### PR TITLE
use re::is_regexp to detect regex refs

### DIFF
--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -1,6 +1,7 @@
 package Mojo::Collection;
 use Mojo::Base -strict;
 
+use re 'is_regexp';
 use Carp 'croak';
 use Exporter 'import';
 use List::Util;
@@ -30,7 +31,7 @@ sub each {
 sub first {
   my ($self, $cb) = (shift, shift);
   return $self->[0] unless $cb;
-  return List::Util::first { $_ =~ $cb } @$self if ref $cb eq 'Regexp';
+  return List::Util::first { $_ =~ $cb } @$self if is_regexp $cb;
   return List::Util::first { $_->$cb(@_) } @$self;
 }
 
@@ -38,7 +39,7 @@ sub flatten { $_[0]->new(_flatten(@{$_[0]})) }
 
 sub grep {
   my ($self, $cb) = (shift, shift);
-  return $self->new(grep { $_ =~ $cb } @$self) if ref $cb eq 'Regexp';
+  return $self->new(grep { $_ =~ $cb } @$self) if is_regexp $cb;
   return $self->new(grep { $_->$cb(@_) } @$self);
 }
 

--- a/lib/Mojolicious/Plugin/HeaderCondition.pm
+++ b/lib/Mojolicious/Plugin/HeaderCondition.pm
@@ -1,6 +1,8 @@
 package Mojolicious::Plugin::HeaderCondition;
 use Mojo::Base 'Mojolicious::Plugin';
 
+use re 'is_regexp';
+
 sub register {
   my ($self, $app) = @_;
 
@@ -13,8 +15,7 @@ sub register {
 
 sub _check {
   my ($value, $pattern) = @_;
-  return 1
-    if $value && $pattern && ref $pattern eq 'Regexp' && $value =~ $pattern;
+  return 1 if $value && $pattern && is_regexp($pattern) && $value =~ $pattern;
   return $value && defined $pattern && $pattern eq $value;
 }
 


### PR DESCRIPTION
### Summary
Use [is_regexp](https://perldoc.pl/re#is_regexp($ref)) to detect regex refs instead of checking for ref 'Regexp'.

### Motivation
Regex refs created by qr// are actually blessed into the 'Regexp' class. ref 'Regexp' can be fooled by blessing random things into 'Regexp', or by reblessing the regex ref into something else. is_regexp will always detect the underlying regex ref.

### References
https://github.com/mojolicious/mojo/pull/1377
