### PR TITLE
add private packages to no_index metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,9 +18,12 @@ WriteMakefile(
   META_MERGE   => {
     dynamic_config => 0,
     'meta-spec'    => {version => 2},
-    no_index       => {directory => ['examples', 't']},
-    prereqs        => {runtime => {requires => {perl => '5.010001'}}},
-    resources      => {
+    no_index       => {
+      directory => [qw(examples t)],
+      package   => [qw(Mojo::Exception::_Guard Mojo::Server::PSGI::_IO)],
+    },
+    prereqs   => {runtime => {requires => {perl => '5.010001'}}},
+    resources => {
       bugtracker => {web => 'https://github.com/mojolicious/mojo/issues'},
       homepage   => 'https://mojolicious.org',
       license    => ['http://www.opensource.org/licenses/artistic-license-2.0'],


### PR DESCRIPTION
### Summary
Prevent private packages from being indexed.

### Motivation
Packages starting with _ are not intended to be externally used or depended on, so they have no reason to be indexed on CPAN.

An alternative method is to put a newline after the 'package' keyword so PAUSE will ignore these packages, but this requires an exception for perltidy.

