### PR TITLE
hide private packages from PAUSE indexer

### DIFF
--- a/lib/Mojo/Exception.pm
+++ b/lib/Mojo/Exception.pm
@@ -156,7 +156,8 @@ sub _context {
   }
 }
 
-package Mojo::Exception::_Guard;
+package    # hide from PAUSE
+  Mojo::Exception::_Guard;
 use Mojo::Base -base;
 
 sub DESTROY { shift->{finally}->() }

--- a/lib/Mojo/Server/PSGI.pm
+++ b/lib/Mojo/Server/PSGI.pm
@@ -38,7 +38,8 @@ sub to_psgi_app {
   return sub { $self->run(@_) }
 }
 
-package Mojo::Server::PSGI::_IO;
+package    # hide from PAUSE
+  Mojo::Server::PSGI::_IO;
 use Mojo::Base -base;
 
 # Finish transaction


### PR DESCRIPTION
### Summary
Prevent private packages from being indexed. Alternative to #1380

### Motivation
Packages starting with _ are not intended to be externally used or depended on, so they have no reason to be indexed on CPAN.
