### PR TITLE
feature: form submission

### DIFF
--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -2267,6 +2267,17 @@ $dom = Mojo::DOM->new(<<EOF);
   <button name="o" value="O">No!</button>
   <input type="submit" name="p" value="P" />
 </form>
+<form><input type="submit" name="a" value="A"></form>
+<form>
+  <input type="button" name="b" value="B" disabled>
+  <input type="button" name="c" value="C">
+</form>
+<form><input type="image" name="c" value="C"></form>
+<form>
+  <button name="e" value="E" disabled>
+  <button name="d" value="D">
+</form>
+<form></form>
 EOF
 is $dom->at('p')->val,                         undef, 'no value';
 is $dom->at('input')->val,                     'A',   'right value';
@@ -2290,6 +2301,114 @@ is $dom->at('input[name=r]')->val, 'on',  'right value';
 is $dom->at('input[name=s]')->val, undef, 'no value';
 is $dom->at('input[name=t]')->val, '',    'right value';
 is $dom->at('input[name=u]')->val, undef, 'no value';
+my $form = {a => 'A', b => 'B', c => 'C', d => 'D', f => ['I', 'J'], m => 'M',
+  n => undef, p => 'P', q => undef, r => 'on', s => undef, t => '', u => undef};
+is_deeply $dom->at('form')->val('input[name=p]'), $form, 'correct form values';
+
+my $all_forms = $dom->find('form')->map(sub { $_->val });
+delete $form->{p};
+$form->{o} = 'O';
+is_deeply $all_forms, [$form, {a=>'A'}, {}, {'c.x'=>1, 'c.y'=>1}, {d=>'D'}, {}],
+  'all the forms';
+
+# various input button types, with and without selectors
+# image
+$dom = Mojo::DOM->new('<form><input type=image /></form>');
+is_deeply $dom->at('form')->val('input[type=image]'), {x => 1, y => 1},
+  'x + y coords';
+is_deeply $dom->at('form')->val(), {x => 1, y => 1},
+  'x + y coords';
+$dom = Mojo::DOM->new('<form><input type=image name=pic /></form>');
+is_deeply $dom->at('form')->val('input[name=pic]'),
+  {'pic.x' => 1, 'pic.y' => 1}, 'x + y coords';
+is_deeply $dom->at('form')->val(), {'pic.x' => 1, 'pic.y' => 1}, 'x + y coords';
+$dom = Mojo::DOM->new('<form><input type=image width=100 height=50 /></form>');
+my $image_form = $dom->at('form')->val();
+is_deeply [sort keys %$image_form], [qw{x y}], 'correct';
+ok $image_form->{x} >= 1 && $image_form->{x} <= 100, 'valid x value';
+ok $image_form->{y} >= 1 && $image_form->{y} <= 50, 'valid y value';
+
+# submit
+$dom = Mojo::DOM->new(<<EOF);
+<form><input type=submit name=example /><input name=car value=vw></form>
+EOF
+is_deeply $dom->at('form')->val('input[name=example]'),
+  {car => 'vw', example => 'Submit'}, 'valueless Submit';
+is_deeply $dom->at('form')->val(), {car => 'vw', example => 'Submit'},
+  'valueless Submit';
+# button - client side only cannot submit without javascript
+$dom = Mojo::DOM->new('<form><input type=button name=x value=y /></form>');
+is_deeply $dom->at('form')->val(), {}, 'not clicked, not included';
+is_deeply $dom->at('form')->val('input[name=x]'), {},
+  'clicked, button means not included';
+$dom = Mojo::DOM->new('<form><button type=reset name=x value=y /></form>');
+is_deeply $dom->at('form')->val(), {}, 'not clicked, not included';
+is_deeply $dom->at('form')->val('input[name=x]'), {},
+  'clicked, button means not included';
+$dom = Mojo::DOM->new('<form><button type=button name=x value=y /></form>');
+is_deeply $dom->at('form')->val(), {}, 'not clicked, not included';
+is_deeply $dom->at('form')->val('input[name=x]'), {},
+  'clicked, button means not included';
+
+# multiple submit options
+$dom = Mojo::DOM->new(<<EOF);
+<html>
+<head></head>
+<body>
+<div></div>
+<form action="/form">
+  <input type=submit name="sub0" formaction="/process-form" disabled />
+  <fieldset>
+    <input type=submit name="sub1" formaction="/process-form" />
+  </fieldset>
+  <input type=submit name="sub2" />
+  <input type=submit name="sub3" formmethod="post" />
+  <input type=text name=textual value=data />
+</form>
+</body>
+</html>
+EOF
+is_deeply $dom->at('form')->val(), {sub1 => 'Submit', textual => 'data'},
+  'correct default first submit item';
+is_deeply $dom->at('form')->val('input[name=sub0]'), {textual => 'data'},
+  'disabled buttons cannot be enabled';
+is_deeply $dom->at('form')->val('input[name=sub2]'),
+  {sub2 => 'Submit', textual => 'data'}, 'no clicks - no form?';
+is_deeply [$dom->at('form')->target('input[name=sub2]')],
+  [qw{GET /form url-encoded}], 'default action';
+is_deeply [$dom->at('form')->target('input[name=sub1]')],
+  [qw{GET /process-form url-encoded}], 'updated action';
+is_deeply [$dom->at('form')->target('input[name=sub3]')],
+  [qw{POST /form url-encoded}], 'updated method';
+is_deeply [$dom->at('form')->target('input[name=sub0]')], [], 'cannot submit';
+
+$dom = Mojo::DOM->new(<<EOF);
+<!-- https://html.spec.whatwg.org/multipage/form-elements.html#dom-fieldset-elements -->
+<form>
+<fieldset name="clubfields" disabled>
+ <legend> <label>
+  <input type=checkbox name=club onchange="form.clubfields.disabled = !checked">
+  Use Club Card
+ </label> </legend>
+ <p><label>Name on card: <input name=clubname required></label></p>
+ <p><label>Card num: <input name=clubnum required pattern="[-0-9]+"></label></p>
+ <p><label>Expiry date: <input name=clubexp type=month></label></p>
+</fieldset>
+</form>
+EOF
+
+is_deeply $dom->at('form')->val, {club => 'on'}, # todo: check this should be on
+  q{excluding those that are descendants of the fieldset}.
+  q{ element's first legend element child};
+delete $dom->at('fieldset')->tree->[2]{disabled};
+is_deeply $dom->at('form')->val, {club => 'on',
+  map { $_ => undef } qw{clubname clubnum clubexp}}, 'enabled fieldset';
+
+$dom = Mojo::DOM->new(<<EOF);
+<form action="/form"><input type=text name=enter value=user /></form>
+EOF
+is_deeply $dom->at('form')->val, {enter => 'user'}, 'no submit button';
+is_deeply [$dom->at('form')->target], [qw{GET /form url-encoded}], 'no submit';
 
 # PoCo example with whitespace-sensitive text
 $dom = Mojo::DOM->new(<<EOF);

--- a/t/mojo/forms.t
+++ b/t/mojo/forms.t
@@ -1,0 +1,131 @@
+use Mojo::Base -strict;
+
+BEGIN {
+  $ENV{MOJO_NO_NNR}  = $ENV{MOJO_NO_SOCKS} = $ENV{MOJO_NO_TLS} = 1;
+  $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
+}
+
+use Test::More;
+use Mojo::UserAgent;
+use Mojolicious::Lite;
+
+# Silence
+app->log->level('debug')->unsubscribe('message');
+
+get '/' => sub {
+  my $c = shift;
+  $c->render(template => 'index');
+};
+
+get '/foo' => sub {
+  my $c = shift;
+  $c->render(json => $c->req->query_params->to_hash);
+};
+
+my $ua = new_ok 'Mojo::UserAgent';
+my $tx = $ua->get('/');
+my $dom = $tx->result->dom;
+my $form = $dom->at('form');
+
+is $form->tag, 'form', 'correct element';
+my $exp = { a => 'A', b => 'B', c => 'C', d => 'D', f => ['I', 'J'], m => 'M',
+  n => undef, o => 'O', q => undef, r => 'on', s => undef, t => '', u => undef,
+};
+is_deeply $form->val, $exp, 'val';
+is_deeply [ $form->target('#submit-form') ], [qw{GET /foo url-encoded}], 'correct element';
+
+isa_ok $tx->submit(), 'Mojo::Transaction::HTTP';
+isa_ok $tx->submit('input[name=p]'), 'Mojo::Transaction::HTTP';
+is $tx->submit('#broken-id'), undef, 'no button with that id';
+is $tx->submit('input[name=pause]'), undef, 'disabled button';
+is $tx->submit('input[name=oooh]'), undef, 'not a submit button';
+
+my $submit_tx = $tx->submit('#submit-form');
+$ua->start($submit_tx);
+is_deeply $submit_tx->res->json, {'a' => 'A', 'b' => 'B', 'c' => 'C',
+  'd' => 'D', 'f' => ['I', 'J'], 'm' => 'M', 'o' => 'O', 'r' => 'on',
+  't' => ''}, 'expected response';
+
+$submit_tx = $tx->submit('#submit-form', a => 'Z', o => 'L', foo => 'bar');
+$ua->start($submit_tx);
+is_deeply $submit_tx->res->json, {'a' => 'Z', 'b' => 'B', 'c' => 'C',
+  'd' => 'D', 'f' => ['I', 'J'], 'm' => 'M', 'o' => 'L', 'r' => 'on',
+  't' => ''}, 'expected response - foo not included';
+
+
+$submit_tx = $tx->submit(a => 'X', 'm' => 'on');
+ok $submit_tx;
+$ua->start($submit_tx);
+is_deeply $submit_tx->res->json, {'a' => 'X', 'b' => 'B', 'c' => 'C',
+  'd' => 'D', 'f' => ['I', 'J'], 'm' => 'on', 'o' => 'O', 'r' => 'on',
+  't' => ''}, 'expected response';
+
+my $json = {};
+$ua->get_p('/')->then(sub {
+  my $tx     = shift;
+  my $submit = $tx->submit(a => 'x');
+  return $ua->start_p($submit);
+})->then(sub {
+  my $tx = shift;
+  $json = $tx->res->json;
+})->catch(sub {
+  my $err = shift;
+  warn "Connection error: $err";
+})->wait;
+
+is_deeply $json, {'a' => 'x', 'b' => 'B', 'c' => 'C', 'd' => 'D',
+  'f' => ['I', 'J'], 'm' => 'M', 'o' => 'O', 'r' => 'on', 't' => ''},
+  'expected response';
+
+done_testing;
+
+__DATA__
+@@ index.html.ep
+% layout 'default';
+% title 'Welcome';
+<h1>Welcome to the Mojolicious real-time web framework!</h1>
+<div>
+  <form action="/foo">
+    <p>Test</p>
+    <input type="text" name="a" value="A" />
+    <input type="checkbox" name="q">
+    <input type="checkbox" checked name="b" value="B">
+    <input type="radio" name="r">
+    <input type="radio" checked name="c" value="C">
+    <input name="s">
+    <input type="checkbox" name="t" value="">
+    <input type=text name="u">
+    <select multiple name="f">
+      <option value="F">G</option>
+      <optgroup>
+        <option>H</option>
+        <option selected>I</option>
+        <option selected disabled>V</option>
+      </optgroup>
+      <option value="J" selected>K</option>
+      <optgroup disabled>
+        <option selected>I2</option>
+      </optgroup>
+    </select>
+    <select name="n"><option>N</option></select>
+    <select multiple name="q"><option>Q</option></select>
+    <select name="y" disabled>
+      <option selected>Y</option>
+    </select>
+    <select name="d">
+      <option selected>R</option>
+      <option selected>D</option>
+    </select>
+    <textarea name="m">M</textarea>
+    <button name="o" value="O">No!</button>
+    <input type="submit" name="p" value="P" id="submit-form" />
+    <input type="submit" name="pause" value="||" disabled />
+    <button type=button name="oooh" value="Arrh">No!</button>
+  </form>
+</div>
+@@ layouts/default.html.ep
+<!DOCTYPE html>
+<html>
+  <head><title><%= title %></title></head>
+  <body><%= content %></body>
+</html>


### PR DESCRIPTION
### Summary
Adding the form submission codes. This includes `Mojo::DOM->val` updates, adding `Mojo::DOM->target` and `Mojo::Transaction::HTTP->submit` similar to discussion here and IRC.

```perl
my $ua = Mojo::UserAgent->new;
my $tx = $ua->get('/');
my $submit_tx = $tx->submit('#submit-form', username => 'fry', ...);
$ua->start($submit_tx);
```

This is a draft at the moment.
### Motivation
This seems like a generally useful thing to have

### References
* #1382 
* #1383
