### PR TITLE
Brotli compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
 install:
   - cpanm -n Cpanel::JSON::XS EV IO::Socket::Socks IO::Socket::SSL
   - cpanm -n Net::DNS::Native Role::Tiny Test::Pod Test::Pod::Coverage
-  - cpanm -n IO::Compress::Brotli
+  - if test -n "$(perl -e 'print $] >= 5.014')"; then cpanm -n IO::Compress::Brotli; fi
   - cpanm -n --installdeps .
 sudo: false
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
 install:
   - cpanm -n Cpanel::JSON::XS EV IO::Socket::Socks IO::Socket::SSL
   - cpanm -n Net::DNS::Native Role::Tiny Test::Pod Test::Pod::Coverage
+  - cpanm -n IO::Compress::Brotli
   - cpanm -n --installdeps .
 sudo: false
 notifications:

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -530,6 +530,15 @@ Mojo::Util - Portable utility functions
 
 L<Mojo::Util> provides portable utility functions for L<Mojo>.
 
+=head1 CONSTANTS
+
+L<Mojo::Util> relies on the following constants.
+
+=head2 IO_COMPRESS_BROTLI
+
+Set to true if L<IO::Compress::Brotli> is available, false otherwise. This
+decides whether the C<bro> and C<unbro> functions are exported to callers.
+
 =head1 FUNCTIONS
 
 L<Mojo::Util> implements the following functions, which can be imported

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -935,6 +935,8 @@ Andrey Kuzmin
 
 Andy Grundman
 
+Ankit Pati
+
 Aristotle Pagaltzis
 
 Ashley Dev

--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -4,6 +4,7 @@ use Mojo::Base 'Mojolicious::Command';
 use Mojo::IOLoop::Client;
 use Mojo::IOLoop::TLS;
 use Mojo::JSON;
+use Mojo::Util;
 use Mojolicious;
 
 has description => 'Show versions of available modules';
@@ -19,6 +20,8 @@ sub run {
   my $tls = Mojo::IOLoop::TLS->can_tls    ? $IO::Socket::SSL::VERSION  : 'n/a';
   my $nnr = Mojo::IOLoop::Client->can_nnr ? $Net::DNS::Native::VERSION : 'n/a';
   my $roles = Mojo::Base->ROLES ? $Role::Tiny::VERSION : 'n/a';
+  my $brotli
+    = Mojo::Util->IO_COMPRESS_BROTLI ? $IO::Compress::Brotli::VERSION : 'n/a';
 
   print <<EOF;
 CORE
@@ -26,12 +29,13 @@ CORE
   Mojolicious ($Mojolicious::VERSION, $Mojolicious::CODENAME)
 
 OPTIONAL
-  Cpanel::JSON::XS 4.09+  ($json)
-  EV 4.0+                 ($ev)
-  IO::Socket::Socks 0.64+ ($socks)
-  IO::Socket::SSL 2.009+  ($tls)
-  Net::DNS::Native 0.15+  ($nnr)
-  Role::Tiny 2.000001+    ($roles)
+  Cpanel::JSON::XS 4.09+         ($json)
+  EV 4.0+                        ($ev)
+  IO::Socket::Socks 0.64+        ($socks)
+  IO::Socket::SSL 2.009+         ($tls)
+  Net::DNS::Native 0.15+         ($nnr)
+  Role::Tiny 2.000001+           ($roles)
+  IO::Compress::Brotli 0.004001+ ($brotli)
 
 EOF
 

--- a/lib/Mojolicious/Guides/FAQ.pod
+++ b/lib/Mojolicious/Guides/FAQ.pod
@@ -35,8 +35,8 @@ L<Mojolicious::Guides::Contributing> that forbid dependencies, we do currently
 discourage adding non-optional ones in favor of a faster and more painless
 installation process. And we do in fact already use several optional CPAN
 modules such as L<Cpanel::JSON::XS>, L<EV>, L<IO::Socket::Socks>,
-L<IO::Socket::SSL>, L<Net::DNS::Native>, L<Plack> and L<Role::Tiny> to provide
-advanced functionality if possible.
+L<IO::Socket::SSL>, L<Net::DNS::Native>, L<Plack>, L<Role::Tiny>, and
+L<IO::Compress::Brotli> to provide advanced functionality if possible.
 
 =head2 Why reinvent wheels?
 

--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -127,10 +127,11 @@ sub respond {
     my $headers = $res->headers;
     $headers->append(Vary => 'Accept-Encoding');
 
-    my $br   = ($c->req->headers->accept_encoding // '') =~ /\bbr\b/i;
-    my $gzip = ($c->req->headers->accept_encoding // '') =~ /\bgzip\b/i;
-
     unless ($headers->content_encoding) {
+      my $aenc = $c->req->headers->accept_encoding // '';
+      my $br   = $aenc =~ /\bbr\b/i;
+      my $gzip = $aenc =~ /\bgzip\b/i;
+
       if (Mojo::Util::IO_COMPRESS_BROTLI && $br) {
 
         # Brotli compression

--- a/t/mojo/util_bro.t
+++ b/t/mojo/util_bro.t
@@ -1,0 +1,22 @@
+use Mojo::Base -strict;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use Test::More;
+use Mojo::Util;
+
+BEGIN {
+  plan skip_all => 'IO::Compress::Brotli 0.004001+ required for this test!'
+    unless Mojo::Util->IO_COMPRESS_BROTLI;
+}
+
+# bro/unbro
+my $uncompressed = 'a' x 1000;
+my $compressed   = Mojo::Util::bro($uncompressed);
+isnt $compressed, $uncompressed, 'string changed';
+ok length $compressed < length $uncompressed, 'string is shorter';
+my $result = Mojo::Util::unbro($compressed, 1_000);
+is $result, $uncompressed, 'same string';
+
+done_testing();

--- a/t/mojolicious/renderer_bro.t
+++ b/t/mojolicious/renderer_bro.t
@@ -1,0 +1,41 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Mojo::Util;
+use Mojolicious;
+
+BEGIN {
+  plan skip_all => 'IO::Compress::Brotli 0.004001+ required for this test!'
+    unless Mojo::Util->IO_COMPRESS_BROTLI;
+}
+
+my $app      = Mojolicious->new(secrets => ['works']);
+my $renderer = $app->renderer->default_format('test');
+my $output   = 'a' x 1000;
+
+$app->log->level('fatal');
+$renderer->compress(1);
+
+# Brotli Compression (enabled)
+my $c = $app->build_controller;
+$c->req->headers->accept_encoding('br');
+$renderer->respond($c, $output, 'html');
+is $c->res->headers->content_type, 'text/html;charset=UTF-8',
+  'right "Content-Type" value';
+is $c->res->headers->vary, 'Accept-Encoding', 'right "Vary" value';
+is $c->res->headers->content_encoding, 'br', 'right "Content-Encoding" value';
+isnt $c->res->body, $output, 'different string';
+is Mojo::Util::unbro($c->res->body, 1_000), $output, 'same string';
+
+# Brotli Compression (precedence)
+$c = $app->build_controller;
+$c->req->headers->accept_encoding('gzip, deflate, br');
+$renderer->respond($c, $output, 'html');
+is $c->res->headers->content_type, 'text/html;charset=UTF-8',
+  'right "Content-Type" value';
+is $c->res->headers->vary, 'Accept-Encoding', 'right "Vary" value';
+is $c->res->headers->content_encoding, 'br', 'right "Content-Encoding" value';
+isnt $c->res->body, $output, 'different string';
+is Mojo::Util::unbro($c->res->body, 1_000), $output, 'same string';
+
+done_testing();


### PR DESCRIPTION
### Summary
Add support for [`IO::Compress::Brotli`](https://metacpan.org/pod/IO::Compress::Brotli "MetaCPAN") to [`Mojolicious::Renderer`](https://mojolicious.org/perldoc/Mojolicious/Renderer "Mojolicious.org").

### Motivation
[`Mojolicious::Renderer`](https://mojolicious.org/perldoc/Mojolicious/Renderer "Mojolicious.org") already supports [`gzip`](https://mojolicious.org/perldoc/Mojolicious/Renderer#compress "Mojolicious.org"). [Brotli](https://en.wikipedia.org/wiki/Brotli "Wikipedia") is a newer, but mature compression algorithm, [developed by Google](https://github.com/google/brotli "GitHub"), and supported by [all major browsers](https://caniuse.com/#feat=brotli "Can I Use?"), and [command-line tools](https://daniel.haxx.se/blog/2017/11/29/curl-7-57-0-happiness "Curl").

Where possible, Brotli should be preferred over GZip, as it gives [latency reduction of around 37%](https://medium.com/oyotech/how-brotli-compression-gave-us-37-latency-improvement-14d41e50fee4 "OYO") in real-world usage. It does not harm clients who don’t speak Brotli because it is only a preferred format, with fallback to GZip and even uncompressed text always available.