### PR TITLE
generate longer request_ids, to avoid duplication

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -11,7 +11,7 @@ has env    => sub { {} };
 has method => 'GET';
 has [qw(proxy reverse_proxy)];
 has request_id => sub {
-  substr sha1_sum($SEED . ($COUNTER = ($COUNTER + 1) % 0xffffff)), 0, 8;
+  sha1_sum($SEED . ($COUNTER = ($COUNTER + 1) % 0xffffff));
 };
 has url       => sub { Mojo::URL->new };
 has via_proxy => 1;

--- a/t/mojo/request.t
+++ b/t/mojo/request.t
@@ -15,9 +15,9 @@ is $req->max_message_size, 16777216, 'right default';
 
 # Request ID
 my $id = Mojo::Message::Request->new->request_id;
-ok length $id >= 8, 'at least 8 characters';
+ok length $id >= 32, 'at least 32 characters';
 my $id2 = Mojo::Message::Request->new->request_id;
-ok length $id >= 8, 'at least 8 characters';
+ok length $id2 >= 32, 'at least 32 characters';
 isnt $id, $id2, 'different id';
 
 # Parse HTTP 1.1 message with huge "Cookie" header exceeding all limits


### PR DESCRIPTION
I have been seeing duplication occur frequently when request_ids are truncated. Instead, keep the entire md5sum string.