### PR TITLE
Warn against overcomplicated logic in config plugins

### DIFF
--- a/lib/Mojolicious/Plugin/Config.pm
+++ b/lib/Mojolicious/Plugin/Config.pm
@@ -110,6 +110,12 @@ will be detected automatically.
 If the configuration value C<config_override> has been set in
 L<Mojolicious/"config"> when this plugin is loaded, it will not do anything.
 
+Note that this plugin executes the configuration file as Perl code only because
+it is a convenient format, and not to encourage complex configuration logic
+within the file. You should not use it with untrusted input, nor do anything
+significantly more complicated than accessing the application's home directory
+for relative paths.
+
 The code of this plugin is a good example for learning to build new plugins,
 you're welcome to fork it.
 

--- a/lib/Mojolicious/Plugin/JSONConfig.pm
+++ b/lib/Mojolicious/Plugin/JSONConfig.pm
@@ -83,6 +83,11 @@ like C<$moniker.$mode.json>, which will be detected automatically.
 If the configuration value C<config_override> has been set in
 L<Mojolicious/"config"> when this plugin is loaded, it will not do anything.
 
+Note that this plugin allows embedded Perl templating only for convenience, and
+not to encourage complex configuration logic within the file. You should not
+use it with untrusted input, nor do anything significantly more complicated
+than accessing the application's home directory for relative paths.
+
 The code of this plugin is a good example for learning to build new plugins,
 you're welcome to fork it.
 


### PR DESCRIPTION
### Summary
Include a warning in the two config plugins against improper use of their embedded Perl convenience features.

### Motivation
Embedded Perl in configuration can be dangerous if misused, and a maintenance burden if overused.
