### PR TITLE
Protect from undef values in Mojo::File objects

### DIFF
--- a/lib/Mojo/File.pm
+++ b/lib/Mojo/File.pm
@@ -94,6 +94,7 @@ sub move_to {
 
 sub new {
   my $class = shift;
+  croak('Invalid path') if grep { !defined } @_;
   my $value = @_ == 1 ? $_[0] : @_ > 1 ? catfile @_ : canonpath getcwd;
   return bless \$value, ref $class || $class;
 }

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -295,6 +295,12 @@ utime $future, $future, $file->to_string;
 is $file->stat->mtime, $future, 'right mtime';
 isnt $file->touch->stat->mtime, $future, 'different mtime';
 
+# Dangerous paths
+eval { path('foo', undef, 'bar') };
+like $@, qr/Invalid path/, 'right error';
+eval { path(undef) };
+like $@, qr/Invalid path/, 'right error';
+
 # I/O
 $dir  = tempdir;
 $file = $dir->child('test.txt')->spurt('just works!');


### PR DESCRIPTION
It is currently very easy to delete the wrong directory by accident, like:
```perl
my $subdir = undef;
path('usr', 'share', $subdir)->remove_tree;
```
This would currently delete `usr/share` and only show a pretty insignificant warning about the `undef` value. I noticed the problem because we had a similar accident at work. 😉
```
$ perl -Mojo -E 'n { f("foo", "bar", "baz")->child("yada") } 1000000'
2.67053 wallclock secs ( 2.67 usr +  0.00 sys =  2.67 CPU) @ 374531.84/s (n=1000000)

$ perl -Ilib -Mojo -E 'n { f("foo", "bar", "baz")->child("yada") } 1000000'
2.80627 wallclock secs ( 2.81 usr +  0.00 sys =  2.81 CPU) @ 355871.89/s (n=1000000)
```
The performance cost is pretty minimal. I would have liked to include the empty string too, but unfortunately we depend on that currently for a [Mojo::Home hack](https://github.com/mojolicious/mojo/blob/master/lib/Mojo/Home.pm#L15) that i don't dare to change again.