### PR TITLE
require List::Util 1.50 and delegate for head and tail

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,8 +7,8 @@ use ExtUtils::MakeMaker;
 
 # JSON::PP 2.27103 first shipped with Perl 5.13.9
 # Time::Local 1.2 first shipped with Perl 5.13.9
-# List::Util 1.41 first shipped with Perl 5.21.4
 # IO::Socket::IP 0.37 first shipped with Perl 5.21.11
+# List::Util 1.50 first shipped with Perl 5.27.10
 WriteMakefile(
   NAME         => 'Mojolicious',
   VERSION_FROM => 'lib/Mojolicious.pm',
@@ -37,7 +37,7 @@ WriteMakefile(
   },
   PREREQ_PM => {
     'IO::Socket::IP' => '0.37',
-    'List::Util'     => '1.41',
+    'List::Util'     => '1.50',
     'JSON::PP'       => '2.27103',
     'Time::Local'    => '1.2'
   },

--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -43,12 +43,7 @@ sub grep {
   return $self->new(grep { $_->$cb(@_) } @$self);
 }
 
-sub head {
-  my ($self, $size) = @_;
-  return $self->new(@$self) if $size > @$self;
-  return $self->new(@$self[0 .. ($size - 1)]) if $size >= 0;
-  return $self->new(@$self[0 .. ($#$self + $size)]);
-}
+sub head { $_[0]->new(List::Util::head $_[1], @{$_[0]}) }
 
 sub join {
   Mojo::ByteStream->new(join $_[1] // '', map {"$_"} @{$_[0]});
@@ -99,12 +94,7 @@ sub sort {
   return $self->new(@sorted);
 }
 
-sub tail {
-  my ($self, $size) = @_;
-  return $self->new(@$self) if $size > @$self;
-  return $self->new(@$self[($#$self - ($size - 1)) .. $#$self]) if $size >= 0;
-  return $self->new(@$self[(0 - $size) .. $#$self]);
-}
+sub tail { $_[0]->new(List::Util::tail $_[1], @{$_[0]}) }
 
 sub tap { shift->Mojo::Base::tap(@_) }
 


### PR DESCRIPTION
### Summary
Delegate to the head and tail functions from List::Util 1.50.

Note that this raises the minimum Perl version that fatpacked Mojolicious will work on from 5.22 to 5.28, as List::Util cannot be fatpacked.

### Motivation
Code cleanliness and efficiency.

### References
#1360 
