### PR TITLE
require Cpanel::JSON::XS 4.09+ for JSON speedup and set allow_dupkeys

### DIFF
--- a/lib/Mojo/JSON.pm
+++ b/lib/Mojo/JSON.pm
@@ -10,7 +10,7 @@ use Scalar::Util 'blessed';
 # For better performance Cpanel::JSON::XS is required
 use constant JSON_XS => $ENV{MOJO_NO_JSON_XS}
   ? 0
-  : eval { require Cpanel::JSON::XS; Cpanel::JSON::XS->VERSION('4.04'); 1 };
+  : eval { require Cpanel::JSON::XS; Cpanel::JSON::XS->VERSION('4.09'); 1 };
 
 our @EXPORT_OK = qw(decode_json encode_json false from_json j to_json true);
 
@@ -33,7 +33,7 @@ if (JSON_XS) {
   my $BINARY = Cpanel::JSON::XS->new->utf8;
   my $TEXT   = Cpanel::JSON::XS->new;
   $_->canonical->allow_nonref->allow_unknown->allow_blessed->convert_blessed
-    ->stringify_infnan->escape_slash
+    ->stringify_infnan->escape_slash->allow_dupkeys
     for $BINARY, $TEXT;
   monkey_patch __PACKAGE__, 'encode_json', sub { $BINARY->encode($_[0]) };
   monkey_patch __PACKAGE__, 'decode_json', sub { $BINARY->decode($_[0]) };
@@ -339,7 +339,7 @@ The character C</> will always be escaped to prevent XSS attacks.
 
   "</script>" -> "<\/script>"
 
-For better performance the optional module L<Cpanel::JSON::XS> (4.04+) will be
+For better performance the optional module L<Cpanel::JSON::XS> (4.09+) will be
 used automatically if possible. This can also be disabled with the
 C<MOJO_NO_JSON_XS> environment variable.
 

--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -26,7 +26,7 @@ CORE
   Mojolicious ($Mojolicious::VERSION, $Mojolicious::CODENAME)
 
 OPTIONAL
-  Cpanel::JSON::XS 4.04+  ($json)
+  Cpanel::JSON::XS 4.09+  ($json)
   EV 4.0+                 ($ev)
   IO::Socket::Socks 0.64+ ($socks)
   IO::Socket::SSL 2.009+  ($tls)

--- a/t/mojo/json_xs.t
+++ b/t/mojo/json_xs.t
@@ -4,7 +4,7 @@ use Test::More;
 use Mojo::JSON qw(decode_json encode_json false from_json j to_json true);
 
 BEGIN {
-  plan skip_all => 'Cpanel::JSON::XS 4.04+ required for this test!'
+  plan skip_all => 'Cpanel::JSON::XS 4.09+ required for this test!'
     unless Mojo::JSON->JSON_XS;
 }
 
@@ -71,5 +71,9 @@ like encode_json({test => -sin(9**9**9)}), qr/^{"test":".*"}$/,
 
 # "escape_slash"
 is_deeply encode_json('/test/123'), '"\/test\/123"', 'escaped slash';
+
+# "allow_dupkeys"
+is_deeply decode_json('{"test":1,"test":2}'), {test => 2},
+  'no duplicate keys error';
 
 done_testing();


### PR DESCRIPTION
### Summary
Recent versions of Cpanel::JSON::XS throw an exception when decoding duplicate keys. allow_dupkeys was added in 4.09 to disable this behavior which is incompatible with Mojo::JSON.

### Motivation
Behavior compatibility with Cpanel::JSON::XS passthrough.
