### PR TITLE
IOLoop::Stream warnings: Use of uninitialized value $self->{buffer}

### DIFF
--- a/lib/Mojo/IOLoop/Stream.pm
+++ b/lib/Mojo/IOLoop/Stream.pm
@@ -40,7 +40,7 @@ sub is_readable {
 sub is_writing {
   my $self = shift;
   return undef unless $self->{handle};
-  return !!length($self->{buffer}) || $self->has_subscribers('drain');
+  return !!length($self->{buffer} // '') || $self->has_subscribers('drain');
 }
 
 sub new { shift->SUPER::new(handle => shift, timeout => 15) }


### PR DESCRIPTION
Use of uninitialized value in length at /xxxxxx/lib/perl5/lib/perl5/Mojo/IOLoop/Stream.pm line 43

### Summary
DESCRIBE THE BIG PICTURE OF YOUR CHANGES HERE

### Motivation
EXPLAIN WHY YOU BELIEVE THESE CHANGES ARE NECESSARY HERE

### References
LIST RELEVANT ISSUES, PULL REQUESTS AND IRC/MAILING-LIST DISCUSSIONS HERE
