### PR TITLE
set userinfo using Mojo::URL in Mojo::UserAgent Basic auth example

### DIFF
--- a/lib/Mojo/UserAgent.pm
+++ b/lib/Mojo/UserAgent.pm
@@ -385,7 +385,8 @@ Mojo::UserAgent - Non-blocking I/O HTTP and WebSocket user agent
   my $tx = $ua->put('[::1]:3000' => {'Content-Type' => 'text/plain'} => 'Hi!');
 
   # Quick JSON API request with Basic authentication
-  my $value = $ua->get('https://sri:t3st@example.com/test.json')->result->json;
+  my $url = Mojo::URL->new('https://example.com/test.json')->userinfo('sri:☃');
+  my $value = $ua->get($url)->result->json;
 
   # JSON POST (application/json) with TLS certificate authentication
   my $tx = $ua->cert('tls.crt')->key('tls.key')


### PR DESCRIPTION
### Summary
Basic auth commonly uses username and password values from external sources, so they should be set using the Mojo::URL userinfo method rather than directly in the URL where they need to be escaped.

### Motivation
More correct example for a common use case

### References
IRC discussion
