### PR TITLE
Add curfile constructor for Mojo::File and recommend its usage

### DIFF
--- a/lib/Mojo/File.pm
+++ b/lib/Mojo/File.pm
@@ -20,7 +20,7 @@ use File::Temp ();
 use IO::File   ();
 use Mojo::Collection;
 
-our @EXPORT_OK = ('path', 'tempdir', 'tempfile');
+our @EXPORT_OK = ('curfile', 'path', 'tempdir', 'tempfile');
 
 sub basename { File::Basename::basename ${shift()}, @_ }
 
@@ -37,6 +37,8 @@ sub copy_to {
   copy($$self, $to) or croak qq{Can't copy file "$$self" to "$to": $!};
   return $self->new(-d $to ? ($to, File::Basename::basename $self) : $to);
 }
+
+sub curfile { __PACKAGE__->new((caller)[1])->realpath }
 
 sub dirname { $_[0]->new(scalar File::Basename::dirname ${$_[0]}) }
 
@@ -208,6 +210,13 @@ friendly API for dealing with different operating systems.
 
 L<Mojo::File> implements the following functions, which can be imported
 individually.
+
+=head2 curfile
+
+  my $path = curfile;
+
+Construct a new scalar-based L<Mojo::File> object for the absolute path to the
+current source file.
 
 =head2 path
 

--- a/lib/Mojo/IOLoop/TLS.pm
+++ b/lib/Mojo/IOLoop/TLS.pm
@@ -1,7 +1,7 @@
 package Mojo::IOLoop::TLS;
 use Mojo::Base 'Mojo::EventEmitter';
 
-use Mojo::File 'path';
+use Mojo::File 'curfile';
 use Mojo::IOLoop;
 use Scalar::Util 'weaken';
 
@@ -17,8 +17,8 @@ has reactor => sub { Mojo::IOLoop->singleton->reactor }, weak => 1;
 # To regenerate the certificate run this command (28.06.2019)
 # openssl req -x509 -newkey rsa:4096 -nodes -sha256 -out server.crt \
 #   -keyout server.key -days 7300 -subj '/CN=localhost'
-my $CERT = path(__FILE__)->sibling('resources', 'server.crt')->to_string;
-my $KEY  = path(__FILE__)->sibling('resources', 'server.key')->to_string;
+my $CERT = curfile->sibling('resources', 'server.crt')->to_string;
+my $KEY  = curfile->sibling('resources', 'server.key')->to_string;
 
 sub DESTROY { shift->_cleanup }
 

--- a/lib/Mojolicious/Command/Author/generate/app.pm
+++ b/lib/Mojolicious/Command/Author/generate/app.pm
@@ -113,8 +113,8 @@ __DATA__
 use strict;
 use warnings;
 
-use FindBin;
-BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
+use Mojo::File 'curfile';
+use lib curfile->dirname->sibling('lib')->to_string;
 use Mojolicious::Commands;
 
 # Start command line interface for application

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -1753,7 +1753,7 @@ installed application so they can be excluded.
   package MyApp;
   use Mojo::Base 'Mojolicious';
 
-  use Mojo::File 'path';
+  use Mojo::File 'curfile';
   use Mojo::Home;
 
   # Every CPAN module needs a version
@@ -1763,7 +1763,7 @@ installed application so they can be excluded.
     my $self = shift;
 
     # Switch to installable home directory
-    $self->home(Mojo::Home->new(path(__FILE__)->sibling('MyApp')));
+    $self->home(Mojo::Home->new(curfile->sibling('MyApp')));
 
     # Switch to installable "public" directory
     $self->static->paths->[0] = $self->home->child('public');
@@ -1789,8 +1789,8 @@ to the proper shebang during installation.
   use strict;
   use warnings;
 
-  use FindBin;
-  BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
+  use Mojo::File 'curfile';
+  use lib curfile->dirname->sibling('lib')->to_string;
   use Mojolicious::Commands;
 
   # Start command line interface for application

--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -341,8 +341,8 @@ L<Mojo::DOM>.
   use Test::Mojo;
 
   # Include application
-  use FindBin;
-  require "$FindBin::Bin/../myapp.pl";
+  use Mojo::File 'curfile';
+  require curfile->dirname->sibling('myapp.pl');
 
   # Allow 302 redirect responses
   my $t = Test::Mojo->new;
@@ -747,16 +747,17 @@ C<my_app> to follow the CPAN standard.
   $ mkdir script
   $ mv myapp.pl script/my_app
 
-Just a few small details change, instead of L<lib> we now use L<FindBin> and
-C<@INC>, allowing us to start the application from outside its home directory.
+Just a few small details change, instead of a relative path to L<lib> we now
+use L<Mojo::File> to get an absolute path, allowing us to start the application
+from outside its home directory.
 
   #!/usr/bin/env perl
 
   use strict;
   use warnings;
 
-  use FindBin;
-  BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
+  use Mojo::File 'curfile';
+  use lib curfile->dirname->sibling('lib')->to_string;
   use Mojolicious::Commands;
 
   # Start command line interface for application

--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -1170,13 +1170,13 @@ when C<register> is called.
   package Mojolicious::Plugin::AlertAssets;
   use Mojo::Base 'Mojolicious::Plugin';
 
-  use Mojo::File 'path';
+  use Mojo::File 'curfile';
 
   sub register {
     my ($self, $app) = @_;
 
     # Append "templates" and "public" directories
-    my $base = path(__FILE__)->sibling('AlertAssets');
+    my $base = curfile->sibling('AlertAssets');
     push @{$app->renderer->paths}, $base->child('templates')->to_string;
     push @{$app->static->paths},   $base->child('public')->to_string;
   }

--- a/lib/Mojolicious/Guides/Tutorial.pod
+++ b/lib/Mojolicious/Guides/Tutorial.pod
@@ -1003,11 +1003,11 @@ with normal Perl tests like C<t/basic.t>, which can be a lot of fun thanks to
 L<Test::Mojo>.
 
   use Test::More;
-  use Mojo::File 'path';
+  use Mojo::File 'curfile';
   use Test::Mojo;
 
   # Portably point to "../myapp.pl"
-  my $script = path(__FILE__)->dirname->sibling('myapp.pl');
+  my $script = curfile->dirname->sibling('myapp.pl');
 
   my $t = Test::Mojo->new($script);
   $t->get_ok('/')->status_is(200)->content_like(qr/Funky/);

--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -3,7 +3,7 @@ use Mojo::Base -base;
 
 use Mojo::Cache;
 use Mojo::DynamicMethods;
-use Mojo::File 'path';
+use Mojo::File qw(curfile path);
 use Mojo::JSON 'encode_json';
 use Mojo::Loader 'data_section';
 use Mojo::Util qw(decamelize encode gzip md5_sum monkey_patch);
@@ -18,7 +18,7 @@ has min_compress_size      => 860;
 has paths                  => sub { [] };
 
 # Bundled templates
-my $TEMPLATES = path(__FILE__)->sibling('resources', 'templates');
+my $TEMPLATES = curfile->sibling('resources', 'templates');
 
 sub DESTROY { Mojo::Util::_teardown($_) for @{shift->{namespaces}} }
 

--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -4,12 +4,12 @@ use Mojo::Base -base;
 use Mojo::Asset::File;
 use Mojo::Asset::Memory;
 use Mojo::Date;
-use Mojo::File 'path';
+use Mojo::File qw(curfile path);
 use Mojo::Loader qw(data_section file_is_binary);
 use Mojo::Util qw(encode md5_sum trim);
 
 # Bundled files
-my $PUBLIC = path(__FILE__)->sibling('resources', 'public');
+my $PUBLIC = curfile->sibling('resources', 'public');
 my %EXTRA  = $PUBLIC->list_tree->map(
   sub { join('/', @{$_->to_rel($PUBLIC)}), $_->realpath->to_string })->each;
 

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -928,8 +928,8 @@ configuration plugins like L<Mojolicious::Plugin::Config> and
 L<Mojolicious::Plugin::JSONConfig> for tests.
 
   # Load application script relative to the "t" directory
-  use Mojo::File 'path';
-  my $t = Test::Mojo->new(path(__FILE__)->dirname->sibling('myapp.pl'));
+  use Mojo::File 'curfile';
+  my $t = Test::Mojo->new(curfile->dirname->sibling('myapp.pl'));
 
 =head2 options_ok
 

--- a/t/mojo/base.t
+++ b/t/mojo/base.t
@@ -2,8 +2,8 @@ use Mojo::Base -strict;
 
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 package Mojo::BaseTest;
 use Mojo::Base -strict;

--- a/t/mojo/bytestream.t
+++ b/t/mojo/bytestream.t
@@ -1,7 +1,6 @@
 use Mojo::Base -strict;
 
 use Test::More;
-use FindBin;
 use Mojo::ByteStream 'b';
 
 # Tap into method chain

--- a/t/mojo/daemon.t
+++ b/t/mojo/daemon.t
@@ -6,9 +6,8 @@ BEGIN {
 }
 
 use Test::More;
-use FindBin;
 use IO::Socket::INET;
-use Mojo::File 'path';
+use Mojo::File qw(curfile path);
 use Mojo::IOLoop;
 use Mojo::Log;
 use Mojo::Server::Daemon;
@@ -79,14 +78,14 @@ is_deeply $app->config, {foo => 'bar', baz => 'yada', test => 23},
 
 # Loading
 my $daemon = Mojo::Server::Daemon->new;
-my $path   = "$FindBin::Bin/lib/../lib/myapp.pl";
+my $path   = curfile->sibling('lib', '..', 'lib', 'myapp.pl');
 is ref $daemon->load_app($path), 'Mojolicious::Lite', 'right reference';
 is $daemon->app->config('script'), path($path)->to_abs, 'right script name';
 is ref $daemon->build_app('TestApp'), 'TestApp', 'right reference';
 is ref $daemon->app, 'TestApp', 'right reference';
 
 # Load broken app
-my $bin = $FindBin::Bin;
+my $bin = curfile->dirname;
 eval { Mojo::Server::Daemon->new->load_app("$bin/lib/Mojo/LoaderTest/A.pm"); };
 like $@, qr/did not return an application object/, 'right error';
 eval {

--- a/t/mojo/daemon_ipv6_tls.t
+++ b/t/mojo/daemon_ipv6_tls.t
@@ -5,8 +5,8 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Test::More;
 use Mojo::IOLoop::TLS;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 plan skip_all => 'set TEST_IPV6 to enable this test (developer only!)'
   unless $ENV{TEST_IPV6} || $ENV{TEST_ALL};

--- a/t/mojo/exception.t
+++ b/t/mojo/exception.t
@@ -2,7 +2,7 @@ use Mojo::Base -strict;
 
 use Test::More;
 use Mojo::Exception qw(check raise);
-use Mojo::File 'path';
+use Mojo::File 'curfile';
 
 package MojoTest::X::Foo;
 use Mojo::Base 'Mojo::Exception';
@@ -79,7 +79,7 @@ like wrapper1(1)->frames->[0][3], qr/wrapper2/, 'right subroutine';
 like wrapper1(2)->frames->[0][3], qr/wrapper1/, 'right subroutine';
 
 # Inspect (UTF-8)
-my $file = path(__FILE__)->sibling('exception', 'utf8.txt');
+my $file = curfile->sibling('exception', 'utf8.txt');
 $e = Mojo::Exception->new("Whatever at $file line 3.");
 is_deeply $e->lines_before, [], 'no lines';
 is_deeply $e->line,         [], 'no line';

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -54,13 +54,13 @@ is path('file.t')->basename('.t'), basename('file.t', '.t'), 'same path';
 is path('file.t')->to_abs->dirname, scalar dirname(rel2abs 'file.t'),
   'same path';
 
-# Checks
-ok path(__FILE__)->to_abs->is_abs, 'path is absolute';
-ok !path('file.t')->is_abs, 'path is not absolute';
-
 # Current file
 ok curfile->is_abs, 'path is absolute';
 is curfile, realpath(__FILE__), 'same path';
+
+# Checks
+ok path(__FILE__)->to_abs->is_abs, 'path is absolute';
+ok !path('file.t')->is_abs, 'path is not absolute';
 
 # Temporary directory
 my $dir  = tempdir;
@@ -197,8 +197,8 @@ SKIP: {
 
 # List
 is_deeply path('does_not_exist')->list->to_array, [], 'no files';
-is_deeply path(__FILE__)->list->to_array,         [], 'no files';
-my $lib   = path(__FILE__)->sibling('lib', 'Mojo');
+is_deeply curfile->list->to_array,                [], 'no files';
+my $lib   = curfile->sibling('lib', 'Mojo');
 my @files = map { path($lib)->child(split '/') } (
   'DeprecationTest.pm',  'LoaderException.pm',
   'LoaderException2.pm', 'TestConnectProxy.pm'
@@ -221,7 +221,7 @@ is_deeply path($lib)->list({dir => 1, hidden => 1})->map('to_string')->to_array,
 
 # List tree
 is_deeply path('does_not_exist')->list_tree->to_array, [], 'no files';
-is_deeply path(__FILE__)->list_tree->to_array,         [], 'no files';
+is_deeply curfile->list_tree->to_array,                [], 'no files';
 @files = map { path($lib)->child(split '/') } (
   'BaseTest/Base1.pm',  'BaseTest/Base2.pm',
   'BaseTest/Base3.pm',  'DeprecationTest.pm',

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -6,7 +6,7 @@ use Fcntl 'O_RDONLY';
 use File::Basename qw(basename dirname);
 use File::Spec::Functions qw(abs2rel canonpath catfile rel2abs splitdir);
 use File::Temp;
-use Mojo::File qw(path tempdir tempfile);
+use Mojo::File qw(curfile path tempdir tempfile);
 use Mojo::Util 'encode';
 
 # Constructor
@@ -57,6 +57,10 @@ is path('file.t')->to_abs->dirname, scalar dirname(rel2abs 'file.t'),
 # Checks
 ok path(__FILE__)->to_abs->is_abs, 'path is absolute';
 ok !path('file.t')->is_abs, 'path is not absolute';
+
+# Current file
+ok curfile->is_abs, 'path is absolute';
+is curfile, realpath(__FILE__), 'same path';
 
 # Temporary directory
 my $dir  = tempdir;

--- a/t/mojo/home.t
+++ b/t/mojo/home.t
@@ -3,8 +3,7 @@ use Mojo::Base -strict;
 BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
-use FindBin;
-use Mojo::File 'path';
+use Mojo::File qw(curfile path);
 use Mojo::HelloWorld;
 use Mojo::Home;
 
@@ -60,8 +59,8 @@ my $home = Mojo::Home->new->detect;
 is_deeply $home->to_array, path->to_abs->to_array, 'right path detected';
 
 # Path generation
-$home = Mojo::Home->new($FindBin::Bin);
-my $path = path($FindBin::Bin);
+$home = Mojo::Home->new(curfile->dirname);
+my $path = curfile->dirname;
 is $home->rel_file('foo.txt'), $path->child('foo.txt'), 'right path';
 is $home->rel_file('foo/bar.txt'), $path->child('foo', 'bar.txt'), 'right path';
 is $home->rel_file('foo/bar.txt')->basename, 'bar.txt', 'right result';

--- a/t/mojo/hypnotoad.t
+++ b/t/mojo/hypnotoad.t
@@ -7,9 +7,8 @@ use Test::More;
 plan skip_all => 'set TEST_HYPNOTOAD to enable this test (developer only!)'
   unless $ENV{TEST_HYPNOTOAD} || $ENV{TEST_ALL};
 
-use FindBin;
 use IO::Socket::INET;
-use Mojo::File 'tempdir';
+use Mojo::File qw(curfile tempdir);
 use Mojo::IOLoop::Server;
 use Mojo::Server::Hypnotoad;
 use Mojo::UserAgent;
@@ -95,7 +94,7 @@ app->start;
 EOF
 
 # Start
-my $prefix = "$FindBin::Bin/../../script";
+my $prefix = curfile->dirname->dirname->sibling('script');
 open my $start, '-|', $^X, "$prefix/hypnotoad", $script;
 sleep 3;
 sleep 1 while !_port($port2);

--- a/t/mojo/loader.t
+++ b/t/mojo/loader.t
@@ -4,8 +4,8 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use Mojo::Loader
   qw(data_section file_is_binary find_packages find_modules load_class);

--- a/t/mojo/morbo.t
+++ b/t/mojo/morbo.t
@@ -7,8 +7,8 @@ use Test::More;
 plan skip_all => 'set TEST_MORBO to enable this test (developer only!)'
   unless $ENV{TEST_MORBO} || $ENV{TEST_ALL};
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use IO::Socket::INET;
 use Mojo::File 'tempdir';
@@ -38,7 +38,7 @@ EOF
 
 # Start
 my $port   = Mojo::IOLoop::Server->generate_port;
-my $prefix = "$FindBin::Bin/../../script";
+my $prefix = curfile->dirname->dirname->sibling('script');
 my $pid    = open my $server, '-|', $^X, "$prefix/morbo", '-l',
   "http://127.0.0.1:$port", $script;
 sleep 1 while !_port($port);

--- a/t/mojo/prefork.t
+++ b/t/mojo/prefork.t
@@ -7,7 +7,7 @@ use Test::More;
 plan skip_all => 'set TEST_PREFORK to enable this test (developer only!)'
   unless $ENV{TEST_PREFORK} || $ENV{TEST_ALL};
 
-use Mojo::File qw(path tempdir);
+use Mojo::File qw(curfile path tempdir);
 use Mojo::IOLoop::Server;
 use Mojo::Server::Prefork;
 use Mojo::UserAgent;
@@ -32,7 +32,7 @@ undef $prefork;
 ok !-e $file, 'file has been cleaned up';
 
 # Bad PID file
-my $bad = path(__FILE__)->sibling('does_not_exist', 'test.pid');
+my $bad = curfile->sibling('does_not_exist', 'test.pid');
 $prefork = Mojo::Server::Prefork->new(pid_file => $bad);
 $prefork->app->log->level('debug')->unsubscribe('message');
 my $log = '';

--- a/t/mojo/template.t
+++ b/t/mojo/template.t
@@ -1,7 +1,7 @@
 use Mojo::Base -strict;
 
 use Test::More;
-use Mojo::File 'path';
+use Mojo::File qw(curfile path);
 use Mojo::Template;
 
 package MyTemplateExporter;
@@ -1125,13 +1125,13 @@ EOF
 
 # File
 $mt = Mojo::Template->new;
-my $file = path(__FILE__)->sibling('templates', 'test.mt');
+my $file = curfile->sibling('templates', 'test.mt');
 $output = $mt->render_file($file, 3);
 like $output, qr/23\nHello World!/, 'file';
 
 # Exception in file
 $mt     = Mojo::Template->new;
-$file   = path(__FILE__)->sibling('templates', 'exception.mt');
+$file   = curfile->sibling('templates', 'exception.mt');
 $output = $mt->render_file($file);
 isa_ok $output, 'Mojo::Exception', 'right exception';
 like $output->message, qr/exception\.mt line 2/, 'message contains filename';
@@ -1159,7 +1159,7 @@ like "$output", qr/foo\.mt from DATA section line 2/, 'right result';
 
 # Exception with UTF-8 context
 $mt     = Mojo::Template->new;
-$file   = path(__FILE__)->sibling('templates', 'utf8_exception.mt');
+$file   = curfile->sibling('templates', 'utf8_exception.mt');
 $output = $mt->render_file($file);
 isa_ok $output, 'Mojo::Exception', 'right exception';
 is $output->lines_before->[0][1], '☃', 'right line';
@@ -1178,7 +1178,7 @@ is $output->lines_after->[0], undef, 'no lines after';
 
 # Different encodings
 $mt   = Mojo::Template->new(encoding => 'shift_jis');
-$file = path(__FILE__)->sibling('templates', 'utf8_exception.mt');
+$file = curfile->sibling('templates', 'utf8_exception.mt');
 ok !eval { $mt->render_file($file) }, 'file not rendered';
 like $@, qr/invalid encoding/, 'right error';
 

--- a/t/mojo/user_agent_unix.t
+++ b/t/mojo/user_agent_unix.t
@@ -3,11 +3,10 @@ use Mojo::Base -strict;
 BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
-use Mojo::File 'tempdir';
+use Mojo::File qw(curfile tempdir);
 use IO::Socket::UNIX;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use lib curfile->sibling('lib')->to_string;
 
 plan skip_all => 'set TEST_UNIX to enable this test (developer only!)'
   unless $ENV{TEST_UNIX} || $ENV{TEST_ALL};

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -1,11 +1,10 @@
 use Mojo::Base -strict;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use Test::More;
 use Mojo::ByteStream 'b';
-use Mojo::File 'path';
 use Mojo::DeprecationTest;
 use Sub::Util 'subname';
 
@@ -116,7 +115,7 @@ is_deeply split_cookie_header($header), $tree, 'right result';
 
 # extract_usage
 is extract_usage, "extract_usage test!\n", 'right result';
-is extract_usage(path($FindBin::Bin, 'lib', 'myapp.pl')),
+is extract_usage(curfile->sibling('lib', 'myapp.pl')),
   "USAGE: myapp.pl daemon\n\n test\n123\n", 'right result';
 
 =head1 SYNOPSIS

--- a/t/mojo/websocket_proxy.t
+++ b/t/mojo/websocket_proxy.t
@@ -4,8 +4,8 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use Mojo::IOLoop;
 use Mojo::IOLoop::Server;

--- a/t/mojo/websocket_proxy_tls.t
+++ b/t/mojo/websocket_proxy_tls.t
@@ -5,8 +5,8 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Test::More;
 use Mojo::IOLoop::TLS;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 plan skip_all => 'set TEST_TLS to enable this test (developer only!)'
   unless $ENV{TEST_TLS} || $ENV{TEST_ALL};

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -9,8 +9,8 @@ BEGIN {
 use Test::Mojo;
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use Mojo::Asset::File;
 use Mojo::Date;
@@ -407,7 +407,7 @@ like $log, qr/Controller "MojoliciousTest::Another" does not exist/,
 $t->app->log->unsubscribe(message => $cb);
 
 # Check Last-Modified header for static files
-my $path = path($FindBin::Bin, 'public_dev', 'hello.txt');
+my $path = curfile->sibling('public_dev', 'hello.txt');
 my $size = Mojo::Asset::File->new(path => $path)->size;
 my $mtime
   = Mojo::Date->new(Mojo::Asset::File->new(path => $path)->mtime)->to_string;

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -7,8 +7,8 @@ BEGIN {
 
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use Mojo::File qw(path tempdir);
 

--- a/t/mojolicious/dispatcher_lite_app.t
+++ b/t/mojolicious/dispatcher_lite_app.t
@@ -5,8 +5,8 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Test::Mojo;
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use Mojo::Message::Response;
 use Mojolicious::Lite;

--- a/t/mojolicious/embedded_app.t
+++ b/t/mojolicious/embedded_app.t
@@ -6,6 +6,7 @@ BEGIN {
 }
 
 use Test::More;
+use Mojo::File 'curfile';
 use Mojolicious::Lite;
 use Test::Mojo;
 
@@ -13,8 +14,7 @@ use Test::Mojo;
 app->secrets(['very secr3t!']);
 
 # Mount full external application a few times
-use FindBin;
-my $external = "$FindBin::Bin/external/script/my_app";
+my $external = curfile->sibling('external', 'script', 'my_app');
 plugin Mount => {'/x/1' => $external};
 plugin(Mount => ('/x/♥' => $external));
 plugin Mount => {'MOJOLICIOUS.ORG/' => $external};

--- a/t/mojolicious/embedded_lite_app.t
+++ b/t/mojolicious/embedded_lite_app.t
@@ -7,8 +7,8 @@ BEGIN {
 
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use Mojolicious::Lite;
 use Test::Mojo;
@@ -75,14 +75,14 @@ plugin 'PluginWithEmbeddedApp';
 app->routes->namespaces(['MyTestApp']);
 
 # Mount full external application a few times
-my $external = "$FindBin::Bin/external/myapp.pl";
+my $external = curfile->sibling('external', 'myapp.pl');
 plugin Mount => {'/x/1' => $external};
 my $route = plugin(Mount => ('/x/♥' => $external))->to(message => 'works 2!');
 is $route->to->{message}, 'works 2!', 'right message';
 is $route->pattern->defaults->{app}->same_name, 'myapp', 'right name';
-plugin Mount => {'/y/1'            => "$FindBin::Bin/external/myapp2.pl"};
+plugin Mount => {'/y/1' => curfile->sibling('external', 'myapp2.pl')};
 plugin Mount => {'mojolicious.org' => $external};
-plugin(Mount => ('/y/♥' => "$FindBin::Bin/external/myapp2.pl"))
+plugin(Mount => ('/y/♥' => curfile->sibling('external', 'myapp2.pl')))
   ->to(message => 'works 3!');
 plugin Mount => {'MOJOLICIOUS.ORG/' => $external};
 plugin Mount => {'*.example.com'    => $external};

--- a/t/mojolicious/external/script/my_app
+++ b/t/mojolicious/external/script/my_app
@@ -3,8 +3,8 @@
 use strict;
 use warnings;
 
-use FindBin;
-BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
+use Mojo::File 'curfile';
+use lib curfile->dirname->sibling('lib')->to_string;
 use Mojolicious::Commands;
 
 # Start command line interface for application

--- a/t/mojolicious/external_app.t
+++ b/t/mojolicious/external_app.t
@@ -7,8 +7,8 @@ BEGIN {
 
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/external/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('external', 'lib')->to_string;
 
 use Test::Mojo;
 

--- a/t/mojolicious/external_lite_app.t
+++ b/t/mojolicious/external_lite_app.t
@@ -8,9 +8,9 @@ BEGIN {
 use Test::More;
 
 use Test::Mojo;
-use Mojo::File 'path';
+use Mojo::File 'curfile';
 
-my $t = Test::Mojo->new(path(__FILE__)->dirname->child('external', 'myapp.pl'));
+my $t = Test::Mojo->new(curfile->sibling('external', 'myapp.pl'));
 
 # Template from myapp.pl
 $t->get_ok('/')->status_is(200)->content_is(<<'EOF');

--- a/t/mojolicious/json_config_lite_app.t
+++ b/t/mojolicious/json_config_lite_app.t
@@ -7,7 +7,7 @@ BEGIN {
 
 use Test::Mojo;
 use Test::More;
-use Mojo::File 'path';
+use Mojo::File 'curfile';
 use Mojolicious::Lite;
 
 # Default
@@ -21,7 +21,7 @@ like $@, qr/JSON/, 'right error';
 # Load plugins
 my $config
   = plugin j_s_o_n_config => {default => {foo => 'baz', hello => 'there'}};
-my $path = path(__FILE__)->to_abs->sibling('json_config_lite_app_abs.json');
+my $path = curfile->sibling('json_config_lite_app_abs.json');
 plugin JSONConfig => {file => $path};
 is $config->{foo},          'bar',            'right value';
 is $config->{hello},        'there',          'right value';

--- a/t/mojolicious/layouted_lite_app.t
+++ b/t/mojolicious/layouted_lite_app.t
@@ -5,8 +5,8 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Test::Mojo;
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 use Mojolicious::Lite;
 

--- a/t/mojolicious/production_app.t
+++ b/t/mojolicious/production_app.t
@@ -8,8 +8,8 @@ BEGIN {
 use Test::Mojo;
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 my $t = Test::Mojo->new('MojoliciousTest');
 

--- a/t/mojolicious/static_lite_app.t
+++ b/t/mojolicious/static_lite_app.t
@@ -6,7 +6,7 @@ use Test::Mojo;
 use Test::More;
 use Mojo::Asset::Memory;
 use Mojo::Date;
-use Mojo::File 'path';
+use Mojo::File 'curfile';
 use Mojolicious::Lite;
 
 hook after_static => sub { shift->app->log->debug('Static file served') };
@@ -36,7 +36,7 @@ get '/asset' => sub {
 
 get '/file' => sub {
   my $c = shift;
-  $c->reply->file(path(__FILE__)->dirname->child('templates2', '42.html.ep'));
+  $c->reply->file(curfile->sibling('templates2', '42.html.ep'));
 };
 
 my $t = Test::Mojo->new;

--- a/t/mojolicious/testing_app.t
+++ b/t/mojolicious/testing_app.t
@@ -8,8 +8,8 @@ BEGIN {
 use Test::Mojo;
 use Test::More;
 
-use FindBin;
-use lib "$FindBin::Bin/lib";
+use Mojo::File 'curfile';
+use lib curfile->sibling('lib')->to_string;
 
 my $t       = Test::Mojo->new('MojoliciousTest');
 my $success = '';


### PR DESCRIPTION
### Summary
The curfile constructor for Mojo::File allows one to succinctly retrieve the cleaned-up absolute file path to the current source file.

### Motivation
The mechanism of curfile has a number of advantages over what has previously been used:
* It is shorter and easier to remember than writing `path(__FILE__)->realpath`.
* Calling realpath ensures that it is both an absolute path and resolves any symlinks. Many use cases, especially when adding to `@INC`, should always use the absolute path. Resolving symlinks may be important if the file is loaded via a symlink but references files next to its real path. This shortcut makes it less likely that this step will be forgotten.
* It is less prone to error than FindBin, as it does not depend on what script was executed initially or proper usage of FindBin->again, and is not affected by the presence of executables in PATH or bugs in FindBin shipped with old Perls.

Additionally, the documented recommendation for adding the project-local lib directory to `@INC` has been changed to use `lib`, since this is a clearer equivalent to `unshift @INC`, plus includes any arch or version specific directories if present. Explicit stringification is needed here as blessed references in `@INC` have a special meaning.

### References
Discussion in IRC
