### PR TITLE
Only create one Mojo::File object for curfile

### DIFF
--- a/lib/Mojo/File.pm
+++ b/lib/Mojo/File.pm
@@ -38,7 +38,7 @@ sub copy_to {
   return $self->new(-d $to ? ($to, File::Basename::basename $self) : $to);
 }
 
-sub curfile { __PACKAGE__->new((caller)[1])->realpath }
+sub curfile { __PACKAGE__->new(Cwd::realpath((caller)[1])) }
 
 sub dirname { $_[0]->new(scalar File::Basename::dirname ${$_[0]}) }
 


### PR DESCRIPTION
### Summary
Call Cwd::realpath directly, avoiding instantiating an intermediary Mojo::File object.

### Motivation
Optimization

### References

