### PR TITLE
Fix Test::Mojo example code

### DIFF
--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -342,7 +342,7 @@ L<Mojo::DOM>.
 
   # Include application
   use Mojo::File 'curfile';
-  require curfile->dirname->sibling('myapp.pl');
+  require(curfile->dirname->sibling('myapp.pl'));
 
   # Allow 302 redirect responses
   my $t = Test::Mojo->new;


### PR DESCRIPTION
### Summary
Fixes this error in Test::Mojo example code

> Can't locate object method "dirname" via package "curfile" ...

My perl version:

> This is perl 5, version 28, subversion 0 (v5.28.0) built for x86_64-linux