### PR TITLE
With empty roles

### DIFF
--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -153,6 +153,7 @@ sub tap {
 sub with_roles {
   Carp::croak 'Role::Tiny 2.000001+ is required for roles' unless ROLES;
   my ($self, @roles) = @_;
+  return $self unless @roles;
 
   return Role::Tiny->create_class_with_roles($self,
     map { /^\+(.+)$/ ? "${self}::Role::$1" : $_ } @roles)

--- a/t/mojo/roles.t
+++ b/t/mojo/roles.t
@@ -58,6 +58,16 @@ my $obj = Mojo::RoleTest->new(name => 'Ted');
 is $obj->name,  'Ted',       'attribute';
 is $obj->hello, 'hello Ted', 'method';
 
+# Empty roles
+my $fred = Mojo::RoleTest->with_roles()->new(name => 'Fred');
+is $fred->name,  'Fred',       'attribute';
+is $fred->hello, 'hello Fred', 'method';
+
+# Empty object roles
+my $obj_empty = $obj->with_roles();
+is $obj_empty->name,  'Ted',       'attribute';
+is $obj_empty->hello, 'hello Ted', 'method';
+
 # Single role
 my $obj2 = Mojo::RoleTest->with_roles('Mojo::RoleTest::Role::LOUD')->new;
 is $obj2->hello, 'HEY! BOB!!!', 'role method';


### PR DESCRIPTION
### Summary
Allow `My::Class->with_roles()->new()`  # empty list

### Motivation
A) It doesn't hurt anything, and

B) I defined a base class that accepted an array of roles to [optionally] include...  When that list was empty, though, `with_roles()` caused the whole program to die.  :-(