### PR TITLE
add support for weakly-validating ETags

### DIFF
--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -508,6 +508,7 @@ Alias for L<Mojolicious::Controller/"render_to_string">.
 
   my $bool = $c->is_fresh;
   my $bool = $c->is_fresh(etag => 'abc');
+  my $bool = $c->is_fresh(etag => 'W/"def"');
   my $bool = $c->is_fresh(last_modified => $epoch);
 
 Check freshness of request by comparing the C<If-None-Match> and

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -457,6 +457,11 @@ my $etag = $t->tx->res->headers->etag;
 $t->get_ok('/hello.txt' => {'If-None-Match' => $etag})->status_is(304)
   ->header_is(Server => 'Mojolicious (Perl)')->content_is('');
 
+# Check weak If-None-Match against strong ETag
+$t->get_ok('/hello.txt' => {'If-None-Match' => qq{W/"$etag"}})->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_like(qr/Hello Mojo from a development static file!/);
+
 # Check If-None-Match and If-Last-Modified
 $t->get_ok(
   '/hello.txt' => {'If-None-Match' => $etag, 'If-Last-Modified' => $mtime})


### PR DESCRIPTION
### Summary
Add support in `is_fresh` for ETag and If-Modified-Since headers of the form `W/"foo"`.

### Motivation
Essentially, weak validation is not supported at all, and it is not easy to work around either:
1. It is not possible to use the `is_fresh` function to render a correct weak ETag, as they are rendered with double-quotes added, which would turn a call like `headers->etag('W/'.$checksum)` into `ETag: "W/abc"` instead of the correct `ETag: W/"abc"`.
2. It is not possible to use `is_fresh` to compare a calculated checksum of "abc" against a passed-in ETag of `W/"abc"`. One would have to perform the comparisons manually, essentially duplicating the functionality of `is_fresh`.

### References
The specification and handling of weak etags are described here:
* https://en.wikipedia.org/wiki/HTTP_ETag#Strong_and_weak_validation.
* https://www.w3.org/Protocols/HTTP/1.1/rfc2616bis/issues/#i71
* https://tools.ietf.org/html/rfc2616#section-13.3.3
* https://tools.ietf.org/html/rfc7232#section-2.3

