### PR TITLE
Auto-load plugins defined in MOJO_PLUGINS

### DIFF
--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -172,7 +172,8 @@ sub new {
   $r->hide(qw(stash tx url_for write write_chunk));
 
   $self->plugin($_)
-    for qw(HeaderCondition DefaultHelpers TagHelpers EPLRenderer EPRenderer);
+    for qw(HeaderCondition DefaultHelpers TagHelpers EPLRenderer EPRenderer),
+    split ';', $ENV{MOJO_PLUGINS} || '';
 
   # Exception handling should be first in chain
   $self->hook(around_dispatch => \&_exception);


### PR DESCRIPTION

### Summary
Auto-load plugins defined in MOJO_PLUGINS environment variable.

### Motivation
Use case:
I have a plugin based on [Doug Bell's post about Reverse Proxy]( https://mojolicious.io/blog/2019/03/18/reverse-proxy-with-path/) and I want to be able to download / install an app and not have to modify it in order to use this plugin.
This small change will auto-load any plugins defined in the MOJO_PLUGINS environment variable.

### References
None.
If this is an acceptable feature, I'll add test and documentation and update the PR.  If not, close it.