### PR TITLE
Do not use STDOUT as a bareword in daemonize

### DIFF
--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -35,7 +35,7 @@ sub daemonize {
   # Close filehandles
   open STDIN,  '<',  '/dev/null';
   open STDOUT, '>',  '/dev/null';
-  open STDERR, '>&', STDOUT;
+  open STDERR, '>&', *STDOUT;
 }
 
 sub load_app {


### PR DESCRIPTION
### Summary
Fix issue noticed with Perl 5.30
`Bareword "STDOUT" not allowed while "strict subs" in use at .../Mojo/Server.pm line 38.`
