### PR TITLE
fix mojo get index command to not rely on removed Mojo::Collection->slice

### DIFF
--- a/lib/Mojolicious/Command/get.pm
+++ b/lib/Mojolicious/Command/get.pm
@@ -1,6 +1,7 @@
 package Mojolicious::Command::get;
 use Mojo::Base 'Mojolicious::Command';
 
+use Mojo::Collection 'c';
 use Mojo::DOM;
 use Mojo::IOLoop;
 use Mojo::JSON qw(to_json j);
@@ -108,7 +109,7 @@ sub _select {
   while (defined(my $command = shift @args)) {
 
     # Number
-    ($results = $results->slice($command)) and next if $command =~ /^\d+$/;
+    ($results = c($results->[$command])) and next if $command =~ /^\d+$/;
 
     # Text
     return _say($results->map('text')->each) if $command eq 'text';

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -151,14 +151,14 @@ $buffer = '';
 }
 like $buffer, qr/Your Mojo is working!/, 'right output';
 my $template
-  = '<p><%= param "just" %> <%= $c->req->headers->header("X-Test") %></p>';
+  = '<p></p><p><%= param "just" %> <%= $c->req->headers->header("X-Test") %></p>';
 $get->app->plugins->once(
   before_dispatch => sub { shift->render(inline => $template) });
 $buffer = '';
 {
   open my $handle, '>', \$buffer;
   local *STDOUT = $handle;
-  $get->run('-f', 'just=works', '-H', 'X-Test: fine', '/html', 'p', 'text');
+  $get->run('-f', 'just=works', '-H', 'X-Test: fine', '/html', 'p', 1, 'text');
 }
 like $buffer, qr/works fine/, 'right output';
 $get->app->plugins->once(


### PR DESCRIPTION
### Summary
The mojo get command still had an instance of the recently removed slice method. This replaces it with creating a new collection of that index since that's all it was doing.