### PR TITLE
support a behaviour like 'with' when using roles

### DIFF
--- a/t/mojo/roles.t
+++ b/t/mojo/roles.t
@@ -46,10 +46,24 @@ use Mojo::Base -role;
 
 sub hello {'hello mojo!'}
 
-package Mojo::RoleApplied;
-use Mojo::Base -base;
+package Mojo::RoleListApplied::Role::LOUD;
+use Role::Tiny;
 
-__PACKAGE__->with_roles('Mojo::RoleTest::Hello', { apply_to_package => 1 } );
+sub yell {'HEY!'}
+
+package Mojo::RoleApplied::Role::LOUD;
+use Role::Tiny;
+
+sub yell {'HEY!'}
+
+package Mojo::RoleListApplied;
+use Mojo::Base -base, -with => ['Mojo::RoleTest::Hello', '+LOUD'];
+
+package Mojo::RoleApplied;
+use Mojo::Base -base, -with => '+LOUD';
+
+package Mojo::RolePathApplied;
+use Mojo::Base -base, -with => 'Mojo::RoleTest::Hello';
 
 package main;
 
@@ -130,8 +144,15 @@ my $file = Mojo::File->with_roles('Mojo::RoleTest::Hello')->new;
 is $file->hello, 'hello mojo!', 'right result';
 
 # role applied to package, do not create a new class
-my $applied = Mojo::RoleApplied->new;
-is $applied->hello, 'hello mojo!';
+my $list_applied = Mojo::RoleListApplied->new;
+is $list_applied->hello, 'hello mojo!';
+is $list_applied->yell, 'HEY!';
+
+my $role_applied = Mojo::RoleApplied->new;
+is $role_applied->yell, 'HEY!';
+
+my $path_applied = Mojo::RolePathApplied->new;
+is $path_applied->hello, 'hello mojo!';
 
 done_testing();
 

--- a/t/mojo/roles.t
+++ b/t/mojo/roles.t
@@ -46,6 +46,11 @@ use Mojo::Base -role;
 
 sub hello {'hello mojo!'}
 
+package Mojo::RoleApplied;
+use Mojo::Base -base;
+
+__PACKAGE__->with_roles('Mojo::RoleTest::Hello', { apply_to_package => 1 } );
+
 package main;
 
 use Mojo::ByteStream;
@@ -123,6 +128,10 @@ my $dom = Mojo::DOM->with_roles('Mojo::RoleTest::Hello')->new;
 is $dom->hello, 'hello mojo!', 'right result';
 my $file = Mojo::File->with_roles('Mojo::RoleTest::Hello')->new;
 is $file->hello, 'hello mojo!', 'right result';
+
+# role applied to package, do not create a new class
+my $applied = Mojo::RoleApplied->new;
+is $applied->hello, 'hello mojo!';
 
 done_testing();
 


### PR DESCRIPTION
### Summary
Currently Mojo::Base's with_roles creates a new class, but we often need to apply the roles
to the package. So this is basically the behavior of Moose's `with` and/or `Role::Tiny::With`

### Motivation
We do not want to apply the roles when we create a new object. We want the role behavior included in the classes.

### References

