### PR TITLE
Avoid broken EV version in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - TEST_UNIX=1
     - TEST_TLS=1
 install:
-  - cpanm -n Cpanel::JSON::XS EV IO::Socket::Socks IO::Socket::SSL
+  - cpanm -n Cpanel::JSON::XS EV~"!= 4.28" IO::Socket::Socks IO::Socket::SSL
   - cpanm -n Net::DNS::Native Role::Tiny Test::Pod Test::Pod::Coverage
   - cpanm -n --installdeps .
 sudo: false


### PR DESCRIPTION
### Summary
The version specification should hopefully avoid attempting to install this version that does not build on certain Travis CI images.

### Motivation
Allow CI to continue on all versions

### References
*https://travis-ci.com/mojolicious/mojo/jobs/258411899
*http://www.cpantesters.org/cpan/report/7e952514-0b25-11ea-8efb-bf05dbb5ea62