### PR TITLE
Fail fast if asked to listen on invalid unix+http URL

### DIFF
--- a/lib/Mojo/Server/Daemon.pm
+++ b/lib/Mojo/Server/Daemon.pm
@@ -171,7 +171,11 @@ sub _listen {
   my $query   = $url->query;
   my $options = {backlog => $self->backlog};
   $options->{$_} = $query->param($_) for qw(fd single_accept reuse);
-  if ($proto eq 'http+unix') { $options->{path} = $url->host }
+  if ($proto eq 'http+unix') {
+    $options->{path} = $url->host;
+    croak qq{Socket path must be specified in host portion of URL}
+      unless defined $options->{path} && length $options->{path};
+  }
   else {
     if ((my $host = $url->host) ne '*') { $options->{address} = $host }
     if (my $port = $url->port) { $options->{port} = $port }


### PR DESCRIPTION
### Summary

Currently, if Mojo::Server::Daemon is asked to listen on a http+unix URL that lacks a Host portion, it silently falls back to listening on TCP:*, but still prints that it is listening on the requested URL.  This change causes the daemon to abort with a helpful error so the user can correct the URL.

### Motivation

The current behavior could possibly cause security problems if a sensitive service listens on a public IP instead of a unix socket.

But more likely, I just want to help the next person who runs into examples of [malformed URLs][1] so they don't have to go digging through the code to find out why it isn't working.

### References

[1] https://github.com/mojolicious/mojo/wiki/WHM-Easy-Apache-4-Hypnotoad-with-Unix-Sockets

Listens on TCP *:
```
app->start('daemon', -l => 'http+unix:test.sock');
```

Listens on `./test.sock`:
```
app->start('daemon', -l => 'http+unix://test.sock');
```

