### PR TITLE
Missing $ sign to loop variable in the docs

### DIFF
--- a/lib/Mojo/IOLoop/Delay.pm
+++ b/lib/Mojo/IOLoop/Delay.pm
@@ -100,7 +100,7 @@ style.
 
   # These deep nested closures are often referred to as "Callback Hell"
   Mojo::IOLoop->timer(3 => sub {
-    my loop = shift;
+    my $loop = shift;
 
     say '3 seconds';
     Mojo::IOLoop->timer(3 => sub {


### PR DESCRIPTION
### Summary
Small documentation fix in Mojo::IOLoop::Delay
