### PR TITLE
default to Content-Type: application/octet-stream

### DIFF
--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -40,7 +40,7 @@ sub content_type {
   return undef if $headers->content_type;
 
   my $type = $o->{file} ? $self->file_type($o->{file}) : $self->type($o->{ext});
-  $headers->content_type($type // $self->type('txt'));
+  $headers->content_type($type // 'application/octet-stream');
 }
 
 sub detect {

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -394,7 +394,7 @@ $t->get_ok('/' => {'X-Test' => 'Hi there!'})->status_is(404)
 # Static file /another/file (no extension)
 $t->get_ok('/another/file')->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')
-  ->content_type_is('text/plain;charset=UTF-8')
+  ->content_type_is('application/octet-stream')
   ->content_like(qr/Hello Mojolicious!/);
 
 # Static directory /another

--- a/t/mojolicious/layouted_lite_app.t
+++ b/t/mojolicious/layouted_lite_app.t
@@ -230,7 +230,7 @@ $t->get_ok('/localized/include')->status_is(200)
 # Filter
 $t->get_ok('/plain/reverse')->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')
-  ->content_type_is('text/plain;charset=UTF-8')->content_is('oof!olleH');
+  ->content_type_is('application/octet-stream')->content_is('oof!olleH');
 
 # Layout in render call
 $t->get_ok('/outerlayout')->status_is(200)

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -779,7 +779,7 @@ $t->get_ok('/to_string')->status_is(200)->content_is('beforeafter');
 
 # Render static file outside of public directory
 $t->get_ok('/source')->status_is(200)
-  ->content_type_is('text/plain;charset=UTF-8')->header_isnt('X-Missing' => 1)
+  ->content_type_is('application/octet-stream')->header_isnt('X-Missing' => 1)
   ->content_like(qr!get_ok\('/source!);
 
 # File does not exist

--- a/t/mojolicious/static_lite_app.t
+++ b/t/mojolicious/static_lite_app.t
@@ -204,7 +204,7 @@ $t->get_ok('/asset' => {'Range' => 'bytes=3-5'})->status_is(206)
 
 # File
 $t->get_ok('/file' => {'Range' => 'bytes=4-9'})->status_is(206)
-  ->content_type_is('text/plain;charset=UTF-8')
+  ->content_type_is('application/octet-stream')
   ->header_is(Server => 'Mojolicious (Perl)')->content_is('answer');
 
 # Empty file

--- a/t/mojolicious/types.t
+++ b/t/mojolicious/types.t
@@ -97,7 +97,7 @@ $t->content_type($c, {ext => 'html'});
 is $c->res->headers->content_type, 'text/html;charset=UTF-8', 'right type';
 $c->res->headers->remove('Content-Type');
 $t->content_type($c, {ext => 'unknown'});
-is $c->res->headers->content_type, 'text/plain;charset=UTF-8', 'right type';
+is $c->res->headers->content_type, 'application/octet-stream', 'right type';
 $c->res->headers->remove('Content-Type');
 $t->content_type($c, {file => 'foo/bar.png'});
 is $c->res->headers->content_type, 'image/png', 'right type';


### PR DESCRIPTION
### Summary

Mojolicious::Types::content_type used to return `text/plain;charset=UTF-8`
for unknown types. Use `application/octet-stream` as default instead.

### Motivation

`Content-Type: text/plain;charset=UTF-8` may confuse browsers if returned
with binary data.

### References

Fixes: mojolicious/mojo#1441
