### PR TITLE
Add ability to test HTML attribute values with Test::Mojo

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -30,6 +30,30 @@ sub app {
   return $self;
 }
 
+sub attr_is {
+  my ($self, $selector, $attribute, $value, $desc) = @_;
+  return $self->_test('is', $self->_attr($selector, $attribute),
+    $value, _desc($desc, qq{exact match for attribute "$attribute" at selector "$selector"}));
+}
+
+sub attr_isnt {
+  my ($self, $selector, $attribute, $value, $desc) = @_;
+  return $self->_test('isnt', $self->_attr($selector, $attribute),
+    $value, _desc($desc, qq{no match for attribute "$attribute" at selector "$selector"}));
+}
+
+sub attr_like {
+  my ($self, $selector, $attribute, $regex, $desc) = @_;
+  return $self->_test('like', $self->_attr($selector, $attribute),
+    $regex, _desc($desc, qq{similar match for attribute "$attribute" at selector "$selector"}));
+}
+
+sub attr_unlike {
+  my ($self, $selector, $attribute, $regex, $desc) = @_;
+  return $self->_test('unlike', $self->_attr($selector, $attribute),
+    $regex, _desc($desc, qq{no similar match for attribute "$attribute" at selector "$selector"}));
+}
+
 sub content_is {
   my ($self, $value, $desc) = @_;
   return $self->_test('is', $self->tx->res->text,
@@ -337,6 +361,13 @@ sub websocket_ok {
   return $self->_request_ok($self->ua->build_websocket_tx(@_), $_[0]);
 }
 
+sub _attr {
+  my ($self, $selector, $attribute) = @_;
+  return '' unless my $e = $self->tx->res->dom->at($selector);
+  return '' unless my $attr_value = $e->attr($attribute);
+  return $attr_value;
+}
+
 sub _build_ok {
   my ($self, $method, $url) = (shift, shift, shift);
   local $Test::Builder::Level = $Test::Builder::Level + 1;
@@ -589,6 +620,36 @@ Access application with L<Mojo::UserAgent::Server/"app">.
   $t->app->hook(after_dispatch => sub { $stash = shift->stash });
   $t->get_ok('/hello')->status_is(200);
   is $stash->{foo}, 'bar', 'right value';
+
+=head2 attr_is
+
+  $t = $t->attr_is('img.cat', 'alt', 'Grumpy cat');
+  $t = $t->attr_is('img.cat', 'alt', 'Grumpy cat', 'right alt text');
+
+Checks text content of attribute with L<Mojo::DOM/"attr"> at the CSS selectors
+first matching HTML/XML element for exact match with L<Mojo::DOM/"at">.
+
+=head2 attr_isnt
+
+  $t = $t->attr_isnt('img.cat', 'alt', 'Calm cat');
+  $t = $t->attr_isnt('img.cat', 'alt', 'Calm cat', 'different alt text');
+
+Opposite of L</"attr_is">.
+
+=head2 attr_like
+
+  $t = $t->attr_like('img.cat', 'alt', qr/Grumpy/);
+  $t = $t->attr_like('img.cat', 'alt', qr/Grumpy/, 'right alt text');
+
+Checks text content of attribute with L<Mojo::DOM/"attr"> at the CSS selectors
+first matching HTML/XML element for similar match with L<Mojo::DOM/"at">.
+
+=head2 attr_unlike
+
+  $t = $t->attr_unlike('img.cat', 'alt', qr/Calm/);
+  $t = $t->attr_unlike('img.cat', 'alt', qr/Calm/, 'different alt text');
+
+Opposite of L</"attr_like">.
 
 =head2 content_is
 

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -222,6 +222,17 @@ $t->get_ok($url => {'X-Test' => 'Hi there!'})->status_isnt(404)->status_is(200)
   ->text_like('p', qr/fun/, 'with description')->text_unlike('p', qr/boring/)
   ->text_unlike('p', qr/boring/, 'with description');
 
+# Foo::joy (testing HTML attributes in template)
+$t->get_ok('/fun/joy')->status_is(200)
+  ->attr_is('p.joy', 'style' ,'background-color: darkred;')
+  ->attr_is('p.joy', 'style' ,'background-color: darkred;', 'with description')
+  ->attr_isnt('p.joy', 'style' ,'float: left;')
+  ->attr_isnt('p.joy', 'style' ,'float: left;', 'with description')
+  ->attr_like('p.joy', 'style' ,qr/color/)
+  ->attr_like('p.joy', 'style' ,qr/color/, 'with description')
+  ->attr_unlike('p.joy', 'style' ,qr/^float/)
+  ->attr_unlike('p.joy', 'style' ,qr/^float/, 'with description');
+
 # Foo::baz (missing action without template)
 $log = '';
 $cb  = $t->app->log->on(message => sub { $log .= pop });

--- a/t/mojolicious/lib/MojoliciousTest.pm
+++ b/t/mojolicious/lib/MojoliciousTest.pm
@@ -77,6 +77,9 @@ sub startup {
   # /happy/fun/time
   $r->route('/happy')->fun('/time')->to('foo#fun');
 
+  # /fun/joy
+  $r->fun('/joy')->to('foo#joy');
+
   # /stash_config
   $r->route('/stash_config')
     ->to(controller => 'foo', action => 'config', config => {test => 123});

--- a/t/mojolicious/lib/MojoliciousTest/Foo.pm
+++ b/t/mojolicious/lib/MojoliciousTest/Foo.pm
@@ -10,6 +10,8 @@ sub config {
 
 sub fun { shift->render }
 
+sub joy { shift->render }
+
 sub index {
   my $self = shift;
   $self->layout('default');
@@ -99,6 +101,9 @@ __DATA__
 
 @@ foo/fun.html.ep
 <p>Have fun!</p>\
+
+@@ foo/joy.html.ep
+<p class="joy" style="background-color: darkred;">Joy for all!</p>\
 
 @@ just/some/template.html.epl
 Development template with high precedence.


### PR DESCRIPTION
### Summary
Allow to test values of HTML attributes with test methods

### Motivation
In one of projects I need to test value in HTML attribute which is generated.
I don't like idea of concatenating strings in tests, so decided that having test methods for HTML attributes will be good addition to Test::Mojo 
