### PR TITLE
Add full async/await support to Mojolicious

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
     applications, independently of the web framework.
     * Full stack HTTP and WebSocket client/server implementation with IPv6, TLS,
       SNI, IDNA, HTTP/SOCKS5 proxy, UNIX domain socket, Comet (long polling),
-      Promises/A+, keep-alive, connection pooling, timeout, cookie, multipart,
-      and gzip compression support.
+      Promises/A+, async/await, keep-alive, connection pooling, timeout, cookie,
+      multipart, and gzip compression support.
     * Built-in non-blocking I/O web server, supporting multiple event loops as
       well as optional pre-forking and hot deployment, perfect for building
       highly scalable web services.

--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -21,7 +21,7 @@ use constant ROLES =>
   !!(eval { require Role::Tiny; Role::Tiny->VERSION('2.000001'); 1 });
 
 # async/await support requires Future::AsyncAwait X.XX+
-use constant ASYNC => !!(eval {
+use constant ASYNC => $ENV{MOJO_NO_ASYNC} ? 0 : !!(eval {
   require Future::AsyncAwait;
   Future::AsyncAwait->VERSION('0.000001');
   1;

--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -12,6 +12,7 @@ use Scalar::Util ();
 
 # Defer to runtime so Mojo::Util can use "-strict"
 require Mojo::Util;
+require Mojo::Promise;
 
 # Only Perl 5.14+ requires it on demand
 use IO::Handle ();

--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -20,7 +20,7 @@ use IO::Handle ();
 use constant ROLES =>
   !!(eval { require Role::Tiny; Role::Tiny->VERSION('2.000001'); 1 });
 
-# async/await support requires Future::AsyncAwait::Frozen 0.35+
+# async/await support requires Future::AsyncAwait::Frozen 0.36+
 use constant ASYNC => $ENV{MOJO_NO_ASYNC} ? 0 : !!(eval {
   require Future::AsyncAwait::Frozen;
   Future::AsyncAwait::Frozen->VERSION('0.000001');
@@ -129,7 +129,7 @@ sub import {
 
     # async/await
     elsif ($flag eq '-async') {
-      Carp::croak 'Future::AsyncAwait::Frozen 0.35+ is required for async/await'
+      Carp::croak 'Future::AsyncAwait::Frozen 0.36+ is required for async/await'
         unless ASYNC;
       Future::AsyncAwait::Frozen->import_into($caller,
         future_class => 'Mojo::Promise');
@@ -272,7 +272,7 @@ enable support for L<subroutine signatures|perlsub/"Signatures">.
   use Mojo::Base 'SomeBaseClass', -signatures;
   use Mojo::Base -role, -signatures;
 
-If you have L<Future::AsyncAwait::Frozen> 0.35+ installed you can also use the
+If you have L<Future::AsyncAwait::Frozen> 0.36+ installed you can also use the
 C<-async> flag to activate the C<async> and C<await> keywords to deal much more
 efficiently with promises. Note that this feature is B<EXPERIMENTAL> and might
 change without warning!

--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -20,10 +20,10 @@ use IO::Handle ();
 use constant ROLES =>
   !!(eval { require Role::Tiny; Role::Tiny->VERSION('2.000001'); 1 });
 
-# async/await support requires Future::AsyncAwait X.XX+
+# async/await support requires Future::AsyncAwait::Frozen 0.35+
 use constant ASYNC => $ENV{MOJO_NO_ASYNC} ? 0 : !!(eval {
-  require Future::AsyncAwait;
-  Future::AsyncAwait->VERSION('0.000001');
+  require Future::AsyncAwait::Frozen;
+  Future::AsyncAwait::Frozen->VERSION('0.000001');
   1;
 });
 
@@ -129,9 +129,10 @@ sub import {
 
     # async/await
     elsif ($flag eq '-async') {
-      Carp::croak 'Future::AsyncAwait X.XX+ is required for async/await'
+      Carp::croak 'Future::AsyncAwait::Frozen 0.35+ is required for async/await'
         unless ASYNC;
-      Future::AsyncAwait->import_into($caller, future_class => 'Mojo::Promise');
+      Future::AsyncAwait::Frozen->import_into($caller,
+        future_class => 'Mojo::Promise');
     }
 
     # Signatures (Perl 5.20+)
@@ -271,8 +272,8 @@ enable support for L<subroutine signatures|perlsub/"Signatures">.
   use Mojo::Base 'SomeBaseClass', -signatures;
   use Mojo::Base -role, -signatures;
 
-If you have L<Future::AsyncAwait> X.XX+ installed you can also use the C<-async>
-flag to activate the C<async> and C<await> keywords to deal much more
+If you have L<Future::AsyncAwait::Frozen> 0.35+ installed you can also use the
+C<-async> flag to activate the C<async> and C<await> keywords to deal much more
 efficiently with promises. Note that this feature is B<EXPERIMENTAL> and might
 change without warning!
 

--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -278,7 +278,7 @@ change without warning!
 
   # Also enable async/await
   use Mojo::Base -strict, -async;
-  use Mojo::Base -base, -signature, -async;
+  use Mojo::Base -base, -signatures, -async;
 
 This will also disable experimental warnings on versions of Perl where this
 feature was still experimental.

--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -131,9 +131,7 @@ sub import {
     elsif ($flag eq '-async') {
       Carp::croak 'Future::AsyncAwait X.XX+ is required for async/await'
         unless ASYNC;
-      eval "package $caller;"
-        . " Future::AsyncAwait->import(future_class => 'Mojo::Promise'); 1"
-        or die $@;
+      Future::AsyncAwait->import_into($caller, future_class => 'Mojo::Promise');
     }
 
     # Signatures (Perl 5.20+)
@@ -272,6 +270,15 @@ enable support for L<subroutine signatures|perlsub/"Signatures">.
   use Mojo::Base -base, -signatures;
   use Mojo::Base 'SomeBaseClass', -signatures;
   use Mojo::Base -role, -signatures;
+
+If you have L<Future::AsyncAwait> X.XX+ installed you can also use the C<-async>
+flag to activate the C<async> and C<await> keywords to deal much more
+efficiently with promises. Note that this feature is B<EXPERIMENTAL> and might
+change without warning!
+
+  # Also enable async/await
+  use Mojo::Base -strict, -async;
+  use Mojo::Base -base, -signature, -async;
 
 This will also disable experimental warnings on versions of Perl where this
 feature was still experimental.

--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -12,7 +12,6 @@ use Scalar::Util ();
 
 # Defer to runtime so Mojo::Util can use "-strict"
 require Mojo::Util;
-require Mojo::Promise;
 
 # Only Perl 5.14+ requires it on demand
 use IO::Handle ();

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -202,7 +202,9 @@ sub _timer {
 sub done { shift->resolve(@_) }
 
 sub get {
-  my @results = @{shift->{result} // []};
+  my $self    = shift;
+  my @results = @{$self->{result} // []};
+  die $results[0] unless $self->{status} eq 'resolve';
   return wantarray ? @results : $results[0];
 }
 

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -26,6 +26,9 @@ sub AWAIT_IS_READY {
   return !!$self->{result} && !@{$self->{resolve}} && !@{$self->{reject}};
 }
 
+sub AWAIT_NEW_DONE { shift->resolve(@_) }
+sub AWAIT_NEW_FAIL { shift->reject(@_) }
+
 sub AWAIT_ON_CANCEL { }
 sub AWAIT_ON_READY  { shift->finally(@_) }
 

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -196,6 +196,22 @@ sub _timer {
   return $self;
 }
 
+#
+# async/await hacks (please fix this LeoNerd!)
+#
+sub done { shift->resolve(@_) }
+
+sub get {
+  my @results = @{shift->{result} // []};
+  return wantarray ? @results : $results[0];
+}
+
+sub is_cancelled {undef}
+sub is_ready     { !!shift->{result} }
+sub on_cancel    { }
+sub on_ready     { shift->finally(@_) }
+sub fail         { shift->reject(@_) }
+
 1;
 
 =encoding utf8

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -207,6 +207,8 @@ sub _timer {
 *on_cancel    = \&AWAIT_ON_CANCEL;
 *on_ready     = \&AWAIT_ON_READY;
 
+sub AWAIT_CLONE { shift->clone }
+
 sub AWAIT_DONE { shift->resolve(@_) }
 sub AWAIT_FAIL { shift->reject(@_) }
 

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -7,6 +7,28 @@ use Scalar::Util 'blessed';
 
 has ioloop => sub { Mojo::IOLoop->singleton }, weak => 1;
 
+sub AWAIT_CLONE { shift->clone }
+
+sub AWAIT_DONE { shift->resolve(@_) }
+sub AWAIT_FAIL { shift->reject(@_) }
+
+sub AWAIT_GET {
+  my $self    = shift;
+  my @results = @{$self->{result} // []};
+  die $results[0] unless $self->{status} eq 'resolve';
+  return wantarray ? @results : $results[0];
+}
+
+sub AWAIT_IS_CANCELLED {undef}
+
+sub AWAIT_IS_READY {
+  my $self = shift;
+  return !!$self->{result} && !@{$self->{resolve}} && !@{$self->{reject}};
+}
+
+sub AWAIT_ON_CANCEL { }
+sub AWAIT_ON_READY  { shift->finally(@_) }
+
 sub all         { _all(2, @_) }
 sub all_settled { _all(0, @_) }
 sub any         { _all(3, @_) }
@@ -195,28 +217,6 @@ sub _timer {
   $self->ioloop->timer($after => sub { $self->$method(@result) });
   return $self;
 }
-
-sub AWAIT_CLONE { shift->clone }
-
-sub AWAIT_DONE { shift->resolve(@_) }
-sub AWAIT_FAIL { shift->reject(@_) }
-
-sub AWAIT_GET {
-  my $self    = shift;
-  my @results = @{$self->{result} // []};
-  die $results[0] unless $self->{status} eq 'resolve';
-  return wantarray ? @results : $results[0];
-}
-
-sub AWAIT_IS_CANCELLED {undef}
-
-sub AWAIT_IS_READY {
-  my $self = shift;
-  return !!$self->{result} && !@{$self->{resolve}} && !@{$self->{reject}};
-}
-
-sub AWAIT_ON_CANCEL { }
-sub AWAIT_ON_READY  { shift->finally(@_) }
 
 1;
 

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -199,20 +199,33 @@ sub _timer {
 #
 # async/await hacks (please fix this LeoNerd!)
 #
-sub done { shift->resolve(@_) }
+*done         = \&AWAIT_DONE;
+*fail         = \&AWAIT_FAIL;
+*get          = \&AWAIT_GET;
+*is_cancelled = \&AWAIT_IS_CANCELLED;
+*is_ready     = \&AWAIT_IS_READY;
+*on_cancel    = \&AWAIT_ON_CANCEL;
+*on_ready     = \&AWAIT_ON_READY;
 
-sub get {
+sub AWAIT_DONE { shift->resolve(@_) }
+sub AWAIT_FAIL { shift->reject(@_) }
+
+sub AWAIT_GET {
   my $self    = shift;
   my @results = @{$self->{result} // []};
   die $results[0] unless $self->{status} eq 'resolve';
   return wantarray ? @results : $results[0];
 }
 
-sub is_cancelled {undef}
-sub is_ready     { !!$_[0]{result} && !@{$_[0]{resolve}} && !@{$_[0]{reject}} }
-sub on_cancel    { }
-sub on_ready     { shift->finally(@_) }
-sub fail         { shift->reject(@_) }
+sub AWAIT_IS_CANCELLED {undef}
+
+sub AWAIT_IS_READY {
+  my $self = shift;
+  return !!$self->{result} && !@{$self->{resolve}} && !@{$self->{reject}};
+}
+
+sub AWAIT_ON_CANCEL { }
+sub AWAIT_ON_READY  { shift->finally(@_) }
 
 1;
 

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -196,17 +196,6 @@ sub _timer {
   return $self;
 }
 
-#
-# async/await hacks (please fix this LeoNerd!)
-#
-*done         = \&AWAIT_DONE;
-*fail         = \&AWAIT_FAIL;
-*get          = \&AWAIT_GET;
-*is_cancelled = \&AWAIT_IS_CANCELLED;
-*is_ready     = \&AWAIT_IS_READY;
-*on_cancel    = \&AWAIT_ON_CANCEL;
-*on_ready     = \&AWAIT_ON_READY;
-
 sub AWAIT_CLONE { shift->clone }
 
 sub AWAIT_DONE { shift->resolve(@_) }

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -209,7 +209,7 @@ sub get {
 }
 
 sub is_cancelled {undef}
-sub is_ready     { !!shift->{result} }
+sub is_ready     { !!$_[0]{result} && !@{$_[0]{resolve}} && !@{$_[0]{reject}} }
 sub on_cancel    { }
 sub on_ready     { shift->finally(@_) }
 sub fail         { shift->reject(@_) }

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -201,6 +201,7 @@ sub _action {
   my ($next, $c, $action, $last) = @_;
   my $val = $action->($c);
   $val->catch(sub { $c->helpers->reply->exception(shift) })
+    ->finally(sub { undef $val })
     if Scalar::Util::blessed $val && $val->isa('Mojo::Promise');
   return $val;
 }

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -199,10 +199,12 @@ sub startup { }
 
 sub _action {
   my ($next, $c, $action, $last) = @_;
+
   my $val = $action->($c);
   $val->catch(sub { $c->helpers->reply->exception(shift) })
     ->finally(sub { undef $val })
     if Scalar::Util::blessed $val && $val->isa('Mojo::Promise');
+
   return $val;
 }
 

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -137,7 +137,7 @@ sub handler {
 
   # Dispatcher has to be last in the chain
   ++$self->{dispatch}
-    and $self->hook(around_action   => sub { $_[2]($_[1]) })
+    and $self->hook(around_action   => \&_action)
     and $self->hook(around_dispatch => sub { $_[1]->app->dispatch($_[1]) })
     unless $self->{dispatch};
 
@@ -196,6 +196,14 @@ sub start {
 }
 
 sub startup { }
+
+sub _action {
+  my ($next, $c, $action, $last) = @_;
+  my $val = $action->($c);
+  $val->catch(sub { $c->helpers->reply->exception(shift) })
+    if Scalar::Util::blessed $val && $val->isa('Mojo::Promise');
+  return $val;
+}
 
 sub _die { CORE::die ref $_[0] ? $_[0] : Mojo::Exception->new(shift)->trace }
 

--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -18,8 +18,8 @@ sub run {
     = Mojo::IOLoop::Client->can_socks ? $IO::Socket::Socks::VERSION : 'n/a';
   my $tls = Mojo::IOLoop::TLS->can_tls    ? $IO::Socket::SSL::VERSION  : 'n/a';
   my $nnr = Mojo::IOLoop::Client->can_nnr ? $Net::DNS::Native::VERSION : 'n/a';
-  my $roles = Mojo::Base->ROLES ? $Role::Tiny::VERSION         : 'n/a';
-  my $async = Mojo::Base->ASYNC ? $Future::AsyncAwait::VERSION : 'n/a';
+  my $roles = Mojo::Base->ROLES ? $Role::Tiny::VERSION                 : 'n/a';
+  my $async = Mojo::Base->ASYNC ? $Future::AsyncAwait::Frozen::VERSION : 'n/a';
 
   print <<EOF;
 CORE
@@ -27,13 +27,13 @@ CORE
   Mojolicious ($Mojolicious::VERSION, $Mojolicious::CODENAME)
 
 OPTIONAL
-  Cpanel::JSON::XS 4.09+   ($json)
-  EV 4.0+                  ($ev)
-  IO::Socket::Socks 0.64+  ($socks)
-  IO::Socket::SSL 2.009+   ($tls)
-  Net::DNS::Native 0.15+   ($nnr)
-  Role::Tiny 2.000001+     ($roles)
-  Future::AsyncAwait X.XX+ ($async)
+  Cpanel::JSON::XS 4.09+           ($json)
+  EV 4.0+                          ($ev)
+  IO::Socket::Socks 0.64+          ($socks)
+  IO::Socket::SSL 2.009+           ($tls)
+  Net::DNS::Native 0.15+           ($nnr)
+  Role::Tiny 2.000001+             ($roles)
+  Future::AsyncAwait::Frozen 0.35+ ($async)
 
 EOF
 

--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -33,7 +33,7 @@ OPTIONAL
   IO::Socket::SSL 2.009+           ($tls)
   Net::DNS::Native 0.15+           ($nnr)
   Role::Tiny 2.000001+             ($roles)
-  Future::AsyncAwait::Frozen 0.35+ ($async)
+  Future::AsyncAwait::Frozen 0.36+ ($async)
 
 EOF
 

--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -18,7 +18,8 @@ sub run {
     = Mojo::IOLoop::Client->can_socks ? $IO::Socket::Socks::VERSION : 'n/a';
   my $tls = Mojo::IOLoop::TLS->can_tls    ? $IO::Socket::SSL::VERSION  : 'n/a';
   my $nnr = Mojo::IOLoop::Client->can_nnr ? $Net::DNS::Native::VERSION : 'n/a';
-  my $roles = Mojo::Base->ROLES ? $Role::Tiny::VERSION : 'n/a';
+  my $roles = Mojo::Base->ROLES ? $Role::Tiny::VERSION         : 'n/a';
+  my $async = Mojo::Base->ASYNC ? $Future::AsyncAwait::VERSION : 'n/a';
 
   print <<EOF;
 CORE
@@ -26,12 +27,13 @@ CORE
   Mojolicious ($Mojolicious::VERSION, $Mojolicious::CODENAME)
 
 OPTIONAL
-  Cpanel::JSON::XS 4.09+  ($json)
-  EV 4.0+                 ($ev)
-  IO::Socket::Socks 0.64+ ($socks)
-  IO::Socket::SSL 2.009+  ($tls)
-  Net::DNS::Native 0.15+  ($nnr)
-  Role::Tiny 2.000001+    ($roles)
+  Cpanel::JSON::XS 4.09+   ($json)
+  EV 4.0+                  ($ev)
+  IO::Socket::Socks 0.64+  ($socks)
+  IO::Socket::SSL 2.009+   ($tls)
+  Net::DNS::Native 0.15+   ($nnr)
+  Role::Tiny 2.000001+     ($roles)
+  Future::AsyncAwait X.XX+ ($async)
 
 EOF
 

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -649,6 +649,86 @@ Promises have three states, they start out as C<pending> and you call
 L<Mojo::Promise/"resolve"> to transition them to C<fulfilled>, or
 L<Mojo::Promise/"reject"> to transition them to C<rejected>.
 
+=head2 async/await
+
+And if you have L<Future::AsyncAwait> installed you can make using promises even
+easier. The C<async> and C<await> keywords are enabled with the C<-async> flag
+of L<Mojo::Base>, and make the use of closures with promises completely
+optional.
+
+  use Mojo::Base -strict, -async;
+
+The C<async> keyword is placed before the C<sub> keyword, and means that this
+function always returns a promise. Returned values that are not L<Mojo::Promise>
+objects will be wrapped in a resolved promise automatically.
+
+  use Mojo::Base -strict, -async;
+
+  async sub hello_p {
+    return 'Hello Mojo!';
+  }
+
+  hello_p()->then(sub { say @_ })->wait;
+
+The C<await> keyword on the other hand makes Perl wait for the promise to be
+settled. It then returns the fulfillment values or throws an exception with the
+rejection reason. While waiting, the event loop is free to perform other tasks
+however, so no resources are wasted.
+
+  use Mojo::Base -strict, -signatures, -async;
+  use Mojo::UserAgent;
+  use Mojo::URL;
+
+  my $ua = Mojo::UserAgent->new;
+
+  # Search MetaCPAN non-blocking for multiple terms
+  async sub search_cpan_p ($terms) {
+    my $url = Mojo::URL->new('http://fastapi.metacpan.org/v1/module/_search');
+    for my $term (@$terms) {
+      my $tx = await $ua->get_p($url->clone->query({q => $term}));
+      say $tx->result->json('/hits/hits/0/_source/release');
+    }
+  }
+
+  search_cpan_p(['mojo', 'minion'])->wait;
+
+That also means that you can use normal Perl exception handling again. Even many
+3rd party exception handling modules from CPAN work just fine.
+
+  use Mojo::Base -strict, -async;
+  use Mojo::Promise;
+
+  # Catch a non-blocking exception
+  async sub hello_p {
+    eval { await Mojo::Promise->reject('This is an exception') };
+    if (my $err = $@) { warn "Error: $err" }
+  }
+
+  hello_p()->wait;
+
+And it works just the same in L<Mojolicious> and L<Mojolicious::Lite>
+applications. Just declare your actions with the C<async> keyword and use
+C<await> to wait for promises to be C<fulfilled> or C<rejected>.
+
+  use Mojolicious::Lite -signatures, -async;
+
+  # Request HTML titles from two sites non-blocking
+  get '/' => async sub ($c) {
+    my $mojo_tx    = await $c->ua->get_p('https://mojolicious.org');
+    my $mojo_title = $mojo_tx->result->dom->at('title')->text;
+
+    my $cpan_tx    = await $c->ua->get_p('https://metacpan.org');
+    my $cpan_title = $cpan_tx->result->dom->at('title')->text;
+
+    $c->render(json => {mojo => $mojo_title, cpan => $cpan_title});
+  };
+
+  app->start;
+
+Promises returned by actions will automatically get the default L<Mojolicious>
+exception handler attached. Making it much harder to ever miss a non-blocking
+exception again, even if you forgot to handle it yourself.
+
 =head2 Timers
 
 Timers, another primary feature of the event loop, are created with

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -651,10 +651,10 @@ L<Mojo::Promise/"reject"> to transition them to C<rejected>.
 
 =head2 async/await
 
-And if you have L<Future::AsyncAwait> installed you can make using promises even
-easier. The C<async> and C<await> keywords are enabled with the C<-async> flag
-of L<Mojo::Base>, and make the use of closures with promises completely
-optional.
+And if you have L<Future::AsyncAwait::Frozen> installed you can make using
+promises even easier. The C<async> and C<await> keywords are enabled with the
+C<-async> flag of L<Mojo::Base>, and make the use of closures with promises
+completely optional.
 
   use Mojo::Base -strict, -async;
 

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -30,6 +30,16 @@ get '/three' => async sub {
   $c->render(text => "$first$second$third");
 };
 
+get '/four' => async sub {
+  my $c = shift;
+
+  my $text     = await Mojo::Promise->resolve('fail');
+  my $rejected = Mojo::Promise->reject('this went perfectly');
+  eval { await $rejected };
+  if ($@) { $c->render(text => $@, status => 500) }
+  else    { $c->render(text => $text) }
+};
+
 my $ua = Mojo::UserAgent->new;
 
 async sub test_one {
@@ -64,5 +74,10 @@ is $text, 'also works!', 'right content';
 # Application with async/await action
 $tx = $ua->get('/three');
 is $tx->res->body, 'this works too!', 'right content';
+
+# Exception handling and async/await
+$tx = $ua->get('/four');
+is $tx->res->code, 500, 'right code';
+like $tx->res->body, qr/this went perfectly/, 'right content';
 
 done_testing();

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -48,7 +48,7 @@ get '/four' => async sub {
   else      { $c->render(text => $text) }
 };
 
-my $ua = Mojo::UserAgent->new;
+my $ua = Mojo::UserAgent->new(ioloop => Mojo::IOLoop->singleton);
 
 async sub test_one {
   await $ua->get_p('/one');

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -50,14 +50,13 @@ get '/four' => async sub {
 
   my $text = await Mojo::Promise->resolve('fail');
   eval { await $c->defer_reject_p('this went perfectly') };
-  if   ($@) { $c->render(text => $@, status => 500) }
-  else      { $c->render(text => $text) }
+  if   (my $err = $@) { $c->render(text => $err, status => 500) }
+  else                { $c->render(text => $text) }
 };
 
 get '/five' => async sub {
   my $c       = shift;
-  my $runaway = Mojo::Promise->new;
-  Mojo::IOLoop->next_tick(sub { $runaway->reject('runaway too') });
+  my $runaway = $c->defer_reject_p('runaway too');
   await $c->defer_resolve_p('fail');
   await $runaway;
 };

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -48,9 +48,8 @@ get '/three' => async sub {
 get '/four' => async sub {
   my $c = shift;
 
-  # TODO: Remove "scalar" once this is fixed in Future::AsyncAwait
   my $text = await Mojo::Promise->resolve('fail');
-  eval { await scalar $c->defer_reject_p('this went perfectly') };
+  eval { await $c->defer_reject_p('this went perfectly') };
   if   ($@) { $c->render(text => $@, status => 500) }
   else      { $c->render(text => $text) }
 };

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -20,6 +20,14 @@ get '/one' => {text => 'works!'};
 
 get '/two' => {text => 'also'};
 
+get '/three' => async sub {
+  my $c      = shift;
+  my $first  = await Mojo::Promise->resolve('this ');
+  my $second = await Mojo::Promise->resolve('works');
+  my $third  = await Mojo::Promise->resolve(' too!');
+  $c->render(text => "$first$second$third");
+};
+
 my $ua = Mojo::UserAgent->new;
 
 async sub test_one {
@@ -50,5 +58,9 @@ is $tx->res->body, 'works!', 'right content';
 my $text;
 test_two(' ')->then(sub { $text = shift })->catch(sub { warn @_ })->wait;
 is $text, 'also works!', 'right content';
+
+# Application with async/await action
+$tx = $ua->get('/three');
+is $tx->res->body, 'this works too!', 'right content';
 
 done_testing();

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -80,9 +80,10 @@ async sub test_two {
 }
 
 async sub test_three {
+  my $ok = shift;
   return Mojo::Promise->new(sub {
     my ($resolve, $reject) = @_;
-    Mojo::IOLoop->next_tick(sub { $resolve->('value') });
+    Mojo::IOLoop->next_tick(sub { ($ok ? $resolve : $reject)->('value') });
   });
 }
 
@@ -115,7 +116,10 @@ like $tx->res->body, qr/runaway too/, 'right content';
 
 # Async function body returning a promise
 $text = undef;
-test_three()->then(sub { $text = shift })->catch(sub { warn @_ })->wait;
+test_three(1)->then(sub { $text = shift })->catch(sub { warn @_ })->wait;
+is $text, 'value', 'right content';
+$text = undef;
+test_three(0)->then(sub { warn @_ })->catch(sub { $text = shift })->wait;
 is $text, 'value', 'right content';
 
 done_testing();

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -7,7 +7,7 @@ use Test::More;
 BEGIN {
   plan skip_all => 'set TEST_ASYNC_AWAIT to enable this test (developer only!)'
     unless $ENV{TEST_ASYNC_AWAIT} || $ENV{TEST_ALL};
-  plan skip_all => 'Future::AsyncAwait::Frozen 0.35+ required for this test!'
+  plan skip_all => 'Future::AsyncAwait::Frozen 0.36+ required for this test!'
     unless Mojo::Base->ASYNC;
 }
 use Mojo::Base -async;

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -7,7 +7,7 @@ use Test::More;
 BEGIN {
   plan skip_all => 'set TEST_ASYNC_AWAIT to enable this test (developer only!)'
     unless $ENV{TEST_ASYNC_AWAIT} || $ENV{TEST_ALL};
-  plan skip_all => 'Future::AsyncAwait X.XX+ required for this test!'
+  plan skip_all => 'Future::AsyncAwait::Frozen 0.35+ required for this test!'
     unless Mojo::Base->ASYNC;
 }
 use Mojo::Base -async;

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -79,6 +79,13 @@ async sub test_two {
   return $text;
 }
 
+async sub test_three {
+  return Mojo::Promise->new(sub {
+    my ($resolve, $reject) = @_;
+    Mojo::IOLoop->next_tick(sub { $resolve->('value') });
+  });
+}
+
 # Basic async/await
 my $promise = test_one();
 isa_ok $promise, 'Mojo::Promise', 'right class';
@@ -105,5 +112,10 @@ like $tx->res->body, qr/this went perfectly/, 'right content';
 $tx = $ua->get('/five');
 is $tx->res->code,   500,             'right code';
 like $tx->res->body, qr/runaway too/, 'right content';
+
+# Async function body returning a promise
+$text = undef;
+test_three()->then(sub { $text = shift })->catch(sub { warn @_ })->wait;
+is $text, 'value', 'right content';
 
 done_testing();

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -26,6 +26,13 @@ helper defer_resolve_p => sub {
   return $promise;
 };
 
+helper defer_reject_p => sub {
+  my ($c, $msg) = @_;
+  my $promise = Mojo::Promise->new;
+  Mojo::IOLoop->next_tick(sub { $promise->reject($msg) });
+  return $promise;
+};
+
 get '/one' => {text => 'works!'};
 
 get '/two' => {text => 'also'};
@@ -41,9 +48,9 @@ get '/three' => async sub {
 get '/four' => async sub {
   my $c = shift;
 
-  my $text     = await Mojo::Promise->resolve('fail');
-  my $rejected = Mojo::Promise->reject('this went perfectly');
-  eval { await $rejected };
+  my $text    = await Mojo::Promise->resolve('fail');
+  my $promise = $c->defer_reject_p('this went perfectly');
+  eval { await $promise };
   if   ($@) { $c->render(text => $@, status => 500) }
   else      { $c->render(text => $text) }
 };

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -1,0 +1,54 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+
+plan skip_all => 'set TEST_ASYNC_AWAIT to enable this test (developer only!)'
+  unless $ENV{TEST_ASYNC_AWAIT} || $ENV{TEST_ALL};
+plan skip_all => 'Future::AsyncAwait X.XX required for this test!'
+  unless eval { require Future::AsyncAwait };
+
+use Future::AsyncAwait future_class => 'Mojo::Promise';
+use Mojo::UserAgent;
+use Mojolicious::Lite;
+
+# Silence
+app->log->level('fatal');
+
+get '/one' => {text => 'works!'};
+
+get '/two' => {text => 'also'};
+
+my $ua = Mojo::UserAgent->new;
+
+async sub test_one {
+  await $ua->get_p('/one');
+}
+
+async sub test_two {
+  my $separator = shift;
+
+  my $text = '';
+  my $two  = await $ua->get_p('/two');
+  $text .= $two->res->body;
+  my $one = await $ua->get_p('/one');
+  $text .= $separator . $one->res->body;
+
+  return $text;
+}
+
+# Basic async/await
+my $promise = test_one();
+isa_ok $promise, 'Mojo::Promise', 'right class';
+my $tx;
+$promise->then(sub { $tx = shift })->catch(sub { warn @_ });
+$promise->wait;
+is $tx->res->body, 'works!', 'right content';
+
+# Multiple awaits
+my $text;
+test_two(' ')->then(sub { $text = shift })->catch(sub { warn @_ })->wait;
+is $text, 'also works!', 'right content';
+
+done_testing();

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -4,12 +4,14 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
 
-plan skip_all => 'set TEST_ASYNC_AWAIT to enable this test (developer only!)'
-  unless $ENV{TEST_ASYNC_AWAIT} || $ENV{TEST_ALL};
-plan skip_all => 'Future::AsyncAwait X.XX required for this test!'
-  unless eval { require Future::AsyncAwait };
+BEGIN {
+  plan skip_all => 'set TEST_ASYNC_AWAIT to enable this test (developer only!)'
+    unless $ENV{TEST_ASYNC_AWAIT} || $ENV{TEST_ALL};
+  plan skip_all => 'Future::AsyncAwait X.XX+ required for this test!'
+    unless Mojo::Base->ASYNC;
+}
+use Mojo::Base -async;
 
-use Future::AsyncAwait future_class => 'Mojo::Promise';
 use Mojo::UserAgent;
 use Mojolicious::Lite;
 

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -7,6 +7,13 @@ plan skip_all => 'set TEST_POD to enable this test (developer only!)'
 plan skip_all => 'Test::Pod::Coverage 1.04+ required for this test!'
   unless eval 'use Test::Pod::Coverage 1.04; 1';
 
-my @await = qw(done get is_cancelled is_ready on_cancel on_ready fail);
+# async/await hooks
+my @await = (
+  qw(AWAIT_DONE AWAIT_FAIL AWAIT_GET AWAIT_IS_CANCELLED AWAIT_IS_READY),
+  qw(AWAIT_ON_CANCEL AWAIT_ON_READY)
+);
+
+# async/await hacks (please fix LeoNerd)
+push @await, qw(done get is_cancelled is_ready on_cancel on_ready fail);
 
 all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', 'success', @await]});

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -7,4 +7,6 @@ plan skip_all => 'set TEST_POD to enable this test (developer only!)'
 plan skip_all => 'Test::Pod::Coverage 1.04+ required for this test!'
   unless eval 'use Test::Pod::Coverage 1.04; 1';
 
-all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', 'success']});
+my @await = qw(done get is_cancelled is_ready on_cancel on_ready fail);
+
+all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', 'success', @await]});

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -10,7 +10,8 @@ plan skip_all => 'Test::Pod::Coverage 1.04+ required for this test!'
 # async/await hooks
 my @await = (
   qw(AWAIT_CLONE AWAIT_DONE AWAIT_FAIL AWAIT_GET AWAIT_IS_CANCELLED),
-  qw(AWAIT_IS_READY AWAIT_ON_CANCEL AWAIT_ON_READY)
+  qw(AWAIT_IS_READY AWAIT_NEW_DONE AWAIT_NEW_FAIL AWAIT_ON_CANCEL),
+  qw(AWAIT_ON_READY)
 );
 
-all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', 'success', @await]});
+all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', @await, 'success']});

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -13,7 +13,4 @@ my @await = (
   qw(AWAIT_IS_READY AWAIT_ON_CANCEL AWAIT_ON_READY)
 );
 
-# async/await hacks (please fix LeoNerd)
-push @await, qw(done get is_cancelled is_ready on_cancel on_ready fail);
-
 all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', 'success', @await]});

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -9,8 +9,8 @@ plan skip_all => 'Test::Pod::Coverage 1.04+ required for this test!'
 
 # async/await hooks
 my @await = (
-  qw(AWAIT_DONE AWAIT_FAIL AWAIT_GET AWAIT_IS_CANCELLED AWAIT_IS_READY),
-  qw(AWAIT_ON_CANCEL AWAIT_ON_READY)
+  qw(AWAIT_CLONE AWAIT_DONE AWAIT_FAIL AWAIT_GET AWAIT_IS_CANCELLED),
+  qw(AWAIT_IS_READY AWAIT_ON_CANCEL AWAIT_ON_READY)
 );
 
 # async/await hacks (please fix LeoNerd)


### PR DESCRIPTION
For now this patch uses a frozen fork of `Future::AsyncAwait`, and the feature as a whole is marked as experimental. That will allow our users to start playing with `async`/`await`, and give @leonerd more time to figure out what he wants the stable `AWAIT_*` protocol to look like.