### PR TITLE
Allow for async functions to be used almost everywhere

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -172,9 +172,10 @@ sub _all {
 }
 
 sub _await {
-  my ($method, $class, @args) = @_;
-  my $promise = $class->$method(@args);
-  return $promise->finally(sub { undef $promise });
+  my ($method, $class) = (shift, shift);
+  my $promise = $class->$method(@_);
+  $promise->{cycle} = $promise;
+  return $promise;
 }
 
 sub _defer {
@@ -182,7 +183,7 @@ sub _defer {
 
   return unless my $result = $self->{result};
   my $cbs = $self->{status} eq 'resolve' ? $self->{resolve} : $self->{reject};
-  @{$self}{qw(resolve reject)} = ([], []);
+  @{$self}{qw(cycle resolve reject)} = (undef, [], []);
 
   $self->ioloop->next_tick(sub { $_->(@$result) for @$cbs });
 }

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -199,12 +199,9 @@ sub startup { }
 
 sub _action {
   my ($next, $c, $action, $last) = @_;
-
   my $val = $action->($c);
   $val->catch(sub { $c->helpers->reply->exception(shift) })
-    ->finally(sub { undef $val })
     if Scalar::Util::blessed $val && $val->isa('Mojo::Promise');
-
   return $val;
 }
 


### PR DESCRIPTION
This is an alternative to #1452. It has the advantage that async functions work pretty much everywhere automatically. It does have the downside that it deactivates the `Future::AsyncAwait` feature for detecting unhandled promises however. So it becomes much easier to miss exceptions in async functions.
