### PR TITLE
Fix typo URL in travis-ci Build Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </a>
 </p>
 
- # [![Build Status](https://travis-ci.com/mojolicious/mojo.svg?branch=master)](https://travis-ci.com/mojoliocus/mojo) [![Windows build status](https://ci.appveyor.com/api/projects/status/b748ehchfsd4edac?svg=true)](https://ci.appveyor.com/project/kraih73737/mojo)
+ # [![Build Status](https://travis-ci.com/mojolicious/mojo.svg?branch=master)](https://travis-ci.com/mojolicious/mojo) [![Windows build status](https://ci.appveyor.com/api/projects/status/b748ehchfsd4edac?svg=true)](https://ci.appveyor.com/project/kraih73737/mojo)
 
   Mojolicious is a fresh take on Perl web development, based on years of
   experience developing the Catalyst framework, and utilizing the latest


### PR DESCRIPTION
### Summary
Fix a typo of URL in Link Build Status Travis-CI

### Motivation
Correctness
