### PR TITLE
Improve error output from json_is and json_like

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -191,23 +191,29 @@ sub header_unlike {
     $regex, $desc);
 }
 
+sub _does_json_contain {
+  my ($self, $p) = @_;
+  Mojo::JSON::Pointer->new($self->tx->res->json)->contains($p);
+}
+
 sub json_has {
   my ($self, $p, $desc) = @_;
   $desc = _desc($desc, qq{has value for JSON Pointer "$p"});
-  return $self->_test('ok',
-    !!Mojo::JSON::Pointer->new($self->tx->res->json)->contains($p), $desc);
+  return $self->_test('ok', !!_does_json_contain($self, $p), $desc);
 }
 
 sub json_hasnt {
   my ($self, $p, $desc) = @_;
   $desc = _desc($desc, qq{has no value for JSON Pointer "$p"});
-  return $self->_test('ok',
-    !Mojo::JSON::Pointer->new($self->tx->res->json)->contains($p), $desc);
+  return $self->_test('ok', !_does_json_contain($self, $p), $desc);
 }
 
 sub json_is {
   my $self = shift;
   my ($p, $data) = @_ > 1 ? (shift, shift) : ('', shift);
+  if($p && !_does_json_contain($self, $p)) {
+      return $self->_test('fail', "no data for pointer $p");
+  }
   my $desc = _desc(shift, qq{exact match for JSON Pointer "$p"});
   return $self->_test('is_deeply', $self->tx->res->json($p), $data, $desc);
 }

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -220,8 +220,11 @@ sub json_is {
 
 sub json_like {
   my ($self, $p, $regex, $desc) = @_;
-  return $self->_test('like', $self->tx->res->json($p),
-    $regex, _desc($desc, qq{similar match for JSON Pointer "$p"}));
+  $desc = _desc($desc, qq{similar match for JSON Pointer "$p"});
+  if($p && !_does_json_contain($self, $p)) {
+      return $self->_test('fail', $desc);
+  }
+  return $self->_test('like', $self->tx->res->json($p), $regex, $desc);
 }
 
 sub json_message_has {

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -211,10 +211,10 @@ sub json_hasnt {
 sub json_is {
   my $self = shift;
   my ($p, $data) = @_ > 1 ? (shift, shift) : ('', shift);
-  if($p && !_does_json_contain($self, $p)) {
-      return $self->_test('fail', "no data for pointer $p");
-  }
   my $desc = _desc(shift, qq{exact match for JSON Pointer "$p"});
+  if($p && !_does_json_contain($self, $p)) {
+      return $self->_test('fail', $desc);
+  }
   return $self->_test('is_deeply', $self->tx->res->json($p), $data, $desc);
 }
 

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -30,6 +30,7 @@ my @is_deeply_expects = (
 );
 *Test::More::is_deeply = sub {
     $call_counter{is_deeply}++;
+    die("is_deeply() called more times than we expect\n") unless(@is_deeply_expects);
     $orig_is_deeply->(\@_, shift(@is_deeply_expects), 'is_deeply() called correctly');
 };
 
@@ -40,11 +41,13 @@ my @is_deeply_expects = (
 
 my $t = Test::Mojo->new;
 
-# these should Just Pass, calling is_deeply each time
+# these should Just Pass, calling is_deeply each time. Note that in @is_deeply_expects
+# above the first two args passed to is_deeply should be the same
 $t->get_ok('/testdata')->json_is({ fruit   => 'lemon' });
 $t->get_ok('/testdata')->json_is( '/fruit' => 'lemon' );
 
-# these should Just Fail, calling is_deeply each time
+# these should Just Fail, calling is_deeply each time. In @is_deeply_expects you can
+# see that is_deeply is asked to compare different structures
 $t->get_ok('/testdata')->json_is({ fruit   => 'bat' });
 $t->get_ok('/testdata')->json_is( '/fruit' => 'bat' );
 
@@ -58,5 +61,4 @@ is($call_counter{is_deeply}, 5,
   "is_deeply() only called five times for six tests");
 is($call_counter{fail},      1,
   "fail() called once (and only once!) when error was caught");
-
 done_testing();

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -1,0 +1,63 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::Mojo;
+use Test::More;
+use Mojo::JSON qw(false true);
+use Mojolicious::Lite;
+
+get '/testdata' => sub {
+  my $c = shift;
+  $c->render(json => { fruit => 'lemon' });
+};
+
+no warnings 'redefine';
+my $orig_is_deeply = Test::More->can('is_deeply');
+my %call_counter = (
+    is_deeply => 0,
+    fail      => 0,
+);
+my $fail_message;
+
+# we're going to test that is_deeply is called as we expect each time.
+# later we'll also test that it's called the expected number of times.
+my @is_deeply_expects = (
+    [{ fruit   => 'lemon' }, { fruit  => 'lemon' }, 'exact match for JSON Pointer ""'],
+    ['lemon',                'lemon',               'exact match for JSON Pointer "/fruit"'],
+    [{ fruit   => 'lemon' }, { fruit  => 'bat' },   'exact match for JSON Pointer ""'],
+    ['lemon',                'bat',                 'exact match for JSON Pointer "/fruit"'],
+    [{ fruit   => 'lemon' }, { animal => 'bat' },   'exact match for JSON Pointer ""'],
+);
+*Test::More::is_deeply = sub {
+    $call_counter{is_deeply}++;
+    $orig_is_deeply->(\@_, shift(@is_deeply_expects), 'is_deeply() called correctly');
+};
+
+*Test::More::fail = sub {
+    $call_counter{fail}++;
+    ok($_[0] eq 'no data for pointer /animal', "fail() called correctly");
+};
+
+my $t = Test::Mojo->new;
+
+# these should Just Pass, calling is_deeply each time
+$t->get_ok('/testdata')->json_is({ fruit   => 'lemon' });
+$t->get_ok('/testdata')->json_is( '/fruit' => 'lemon' );
+
+# these should Just Fail, calling is_deeply each time
+$t->get_ok('/testdata')->json_is({ fruit   => 'bat' });
+$t->get_ok('/testdata')->json_is( '/fruit' => 'bat' );
+
+# these should whine about the data not existing. Neither should
+# talk about 'undef'. The first will call is_deeply, the second
+# will just fail
+$t->get_ok('/testdata')->json_is({ animal   => 'bat' });
+$t->get_ok('/testdata')->json_is( '/animal' => 'bat' );
+
+is($call_counter{is_deeply}, 5,
+  "is_deeply() only called five times for six tests");
+is($call_counter{fail},      1,
+  "fail() called once (and only once!) when error was caught");
+
+done_testing();

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -34,7 +34,7 @@ my @is_deeply_expects = (
     $orig_is_deeply->(\@_, shift(@is_deeply_expects), 'is_deeply() called correctly');
 };
 
-*Test::More::fail = sub {
+*Test::More::fail = sub (;$) {
     $call_counter{fail}++;
     ok($_[0] eq 'no data for pointer /animal', "fail() called correctly");
 };

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -33,10 +33,13 @@ my @is_deeply_expects = (
     die("is_deeply() called more times than we expect\n") unless(@is_deeply_expects);
     $orig_is_deeply->(\@_, shift(@is_deeply_expects), 'is_deeply() called correctly');
 };
-
+my @fail_expects = (
+    'exact match for JSON Pointer "/animal"'
+);
 *Test::More::fail = sub (;$) {
     $call_counter{fail}++;
-    ok($_[0] eq 'no data for pointer /animal', "fail() called correctly");
+    die("fail() called more times than we expect\n") unless(@fail_expects);
+    is($_[0], shift(@fail_expects), "fail() called correctly");
 };
 
 my $t = Test::Mojo->new;
@@ -51,9 +54,10 @@ $t->get_ok('/testdata')->json_is( '/fruit' => 'lemon' );
 $t->get_ok('/testdata')->json_is({ fruit   => 'bat' });
 $t->get_ok('/testdata')->json_is( '/fruit' => 'bat' );
 
-# these should whine about the data not existing. Neither should
-# talk about 'undef'. The first will call is_deeply, the second
-# will just fail
+# the first of these will call is_deeply, the second will notice that there's nothing
+# to compare (/animal doesn't exist in the JSON) so will call fail() instead to make
+# sure is_deeply doesn't magic up an undef and whine misleadingly about that
+# is_deeply, the second will just fail
 $t->get_ok('/testdata')->json_is({ animal   => 'bat' });
 $t->get_ok('/testdata')->json_is( '/animal' => 'bat' );
 
@@ -61,4 +65,23 @@ is($call_counter{is_deeply}, 5,
   "is_deeply() only called five times for six tests");
 is($call_counter{fail},      1,
   "fail() called once (and only once!) when error was caught");
+
+# sanity checks to make sure we respect the user's test descriptions
+note("Repeat some of those but with a custom test description, make sure that is respected");
+%call_counter = (is_deeply => 0, fail => 0);
+@is_deeply_expects = (
+    [{ fruit => 'lemon' }, { animal => 'bat' }, 'user supplied description for is_deeply'],
+);
+@fail_expects = ('user supplied description for fail');
+
+# the surprising '' is because Test::Mojo assumes that two args means pointer and
+# data. You *must* provide three args if you want it to notice a description. ''
+# is the pointer to the root of the document, the default if only one arg is supplied.
+$t->get_ok('/testdata')->json_is('', { animal   => 'bat' },
+    "user supplied description for is_deeply");
+$t->get_ok('/testdata')->json_is('/animal' => 'bat',
+    "user supplied description for fail");
+is($call_counter{is_deeply}, 1, "is_deeply() called once");
+is($call_counter{fail},      1, "fail() called once");
+
 done_testing();

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -18,7 +18,6 @@ my %call_counter = (
     is_deeply => 0,
     fail      => 0,
 );
-my $fail_message;
 
 # we're going to test that is_deeply is called as we expect each time.
 # later we'll also test that it's called the expected number of times.

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -57,7 +57,6 @@ $t->get_ok('/testdata')->json_is( '/fruit' => 'bat' );
 # the first of these will call is_deeply, the second will notice that there's nothing
 # to compare (/animal doesn't exist in the JSON) so will call fail() instead to make
 # sure is_deeply doesn't magic up an undef and whine misleadingly about that
-# is_deeply, the second will just fail
 $t->get_ok('/testdata')->json_is({ animal   => 'bat' });
 $t->get_ok('/testdata')->json_is( '/animal' => 'bat' );
 

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -14,73 +14,105 @@ get '/testdata' => sub {
 
 no warnings 'redefine';
 my $orig_is_deeply = Test::More->can('is_deeply');
-my %call_counter = (
-    is_deeply => 0,
-    fail      => 0,
-);
+my $orig_like      = Test::More->can('like');
 
-# we're going to test that is_deeply is called as we expect each time.
-# later we'll also test that it's called the expected number of times.
-my @is_deeply_expects = (
-    [{ fruit   => 'lemon' }, { fruit  => 'lemon' }, 'exact match for JSON Pointer ""'],
-    ['lemon',                'lemon',               'exact match for JSON Pointer "/fruit"'],
-    [{ fruit   => 'lemon' }, { fruit  => 'bat' },   'exact match for JSON Pointer ""'],
-    ['lemon',                'bat',                 'exact match for JSON Pointer "/fruit"'],
-    [{ fruit   => 'lemon' }, { animal => 'bat' },   'exact match for JSON Pointer ""'],
-);
+my(%call_counter, @is_deeply_expects, @fail_expects, @like_expects);
 *Test::More::is_deeply = sub {
     $call_counter{is_deeply}++;
     die("is_deeply() called more times than we expect\n") unless(@is_deeply_expects);
     $orig_is_deeply->(\@_, shift(@is_deeply_expects), 'is_deeply() called correctly');
 };
-my @fail_expects = (
-    'exact match for JSON Pointer "/animal"'
-);
 *Test::More::fail = sub (;$) {
     $call_counter{fail}++;
     die("fail() called more times than we expect\n") unless(@fail_expects);
     is($_[0], shift(@fail_expects), "fail() called correctly");
 };
+*Test::More::like = sub ($$;$) {
+    $call_counter{like}++;
+    die("like() called more times than we expect\n") unless(@like_expects);
+    $orig_is_deeply->(\@_, shift(@like_expects), 'like() called correctly');
+};
 
 my $t = Test::Mojo->new;
 
-# these should Just Pass, calling is_deeply each time. Note that in @is_deeply_expects
-# above the first two args passed to is_deeply should be the same
-$t->get_ok('/testdata')->json_is({ fruit   => 'lemon' });
-$t->get_ok('/testdata')->json_is( '/fruit' => 'lemon' );
-
-# these should Just Fail, calling is_deeply each time. In @is_deeply_expects you can
-# see that is_deeply is asked to compare different structures
-$t->get_ok('/testdata')->json_is({ fruit   => 'bat' });
-$t->get_ok('/testdata')->json_is( '/fruit' => 'bat' );
-
-# the first of these will call is_deeply, the second will notice that there's nothing
-# to compare (/animal doesn't exist in the JSON) so will call fail() instead to make
-# sure is_deeply doesn't magic up an undef and whine misleadingly about that
-$t->get_ok('/testdata')->json_is({ animal   => 'bat' });
-$t->get_ok('/testdata')->json_is( '/animal' => 'bat' );
-
-is($call_counter{is_deeply}, 5,
-  "is_deeply() only called five times for six tests");
-is($call_counter{fail},      1,
-  "fail() called once (and only once!) when error was caught");
-
-# sanity checks to make sure we respect the user's test descriptions
-note("Repeat some of those but with a custom test description, make sure that is respected");
-%call_counter = (is_deeply => 0, fail => 0);
-@is_deeply_expects = (
-    [{ fruit => 'lemon' }, { animal => 'bat' }, 'user supplied description for is_deeply'],
-);
-@fail_expects = ('user supplied description for fail');
-
-# the surprising '' is because Test::Mojo assumes that two args means pointer and
-# data. You *must* provide three args if you want it to notice a description. ''
-# is the pointer to the root of the document, the default if only one arg is supplied.
-$t->get_ok('/testdata')->json_is('', { animal   => 'bat' },
-    "user supplied description for is_deeply");
-$t->get_ok('/testdata')->json_is('/animal' => 'bat',
-    "user supplied description for fail");
-is($call_counter{is_deeply}, 1, "is_deeply() called once");
-is($call_counter{fail},      1, "fail() called once");
-
+json_is();
+json_like();
 done_testing();
+
+sub json_is {
+    note("json_is tests");
+    # we're going to test that is_deeply is called as we expect each time.
+    # we'll also test that it's called the expected number of times.
+    %call_counter = (is_deeply => 0, fail => 0, like => 0);
+    @is_deeply_expects = (
+        [{ fruit => 'lemon' }, { fruit  => 'lemon' }, 'exact match for JSON Pointer ""'],
+        ['lemon',              'lemon',               'exact match for JSON Pointer "/fruit"'],
+        [{ fruit => 'lemon' }, { fruit  => 'bat' },   'exact match for JSON Pointer ""'],
+        ['lemon',              'bat',                 'exact match for JSON Pointer "/fruit"'],
+        [{ fruit => 'lemon' }, { animal => 'bat' },   'exact match for JSON Pointer ""'],
+        [{ fruit => 'lemon' }, { animal => 'bat' },   'user supplied description for is_deeply'],
+    );
+    @fail_expects = (
+        'exact match for JSON Pointer "/animal"',
+        'user supplied description for fail',
+    );
+    # these should Just Pass, calling is_deeply each time. Note that in @is_deeply_expects
+    # above the first two args passed to is_deeply should be the same
+    $t->get_ok('/testdata')->json_is({ fruit   => 'lemon' });
+    $t->get_ok('/testdata')->json_is( '/fruit' => 'lemon' );
+    
+    # these should Just Fail, calling is_deeply each time. In @is_deeply_expects you can
+    # see that is_deeply is asked to compare different structures
+    $t->get_ok('/testdata')->json_is({ fruit   => 'bat' });
+    $t->get_ok('/testdata')->json_is( '/fruit' => 'bat' );
+    
+    # the first of these will call is_deeply, the second will notice that there's nothing
+    # to compare (/animal doesn't exist in the JSON) so will call fail() instead to make
+    # sure is_deeply doesn't magic up an undef and whine misleadingly about that
+    $t->get_ok('/testdata')->json_is({ animal   => 'bat' });
+    $t->get_ok('/testdata')->json_is( '/animal' => 'bat' );
+    
+    # the surprising '' is because Test::Mojo assumes that two args means pointer and
+    # data. You *must* provide three args if you want it to notice a description. ''
+    # is the pointer to the root of the document, the default if only one arg is supplied.
+    $t->get_ok('/testdata')->json_is('', { animal   => 'bat' },
+        "user supplied description for is_deeply");
+    $t->get_ok('/testdata')->json_is('/animal' => 'bat',
+        "user supplied description for fail");
+
+    $orig_is_deeply->(
+        \%call_counter,
+        { is_deeply => 6, fail => 2, like => 0 },
+        "is_deeply() and fail() called the right number of times"
+    );
+}
+
+sub json_like {
+    note("json_like tests");
+    %call_counter = (like => 0, fail => 0, is_deeply => 0);
+    @like_expects = (
+        ['lemon', qr{mon}, 'similar match for JSON Pointer "/fruit"'],
+        ['lemon', qr{mon}, 'Yes mon'],
+        ['lemon', qr{Jose}, 'similar match for JSON Pointer "/fruit"'],
+        ['lemon', qr{Jose}, 'No way'],
+    );
+    @fail_expects = (
+        'similar match for JSON Pointer "/animal"',
+        'totally Gothic'
+    );
+    # These should pass, calling like() each time
+    $t->get_ok('/testdata')->json_like('/fruit', qr{mon});
+    $t->get_ok('/testdata')->json_like('/fruit', qr{mon}, 'Yes mon');
+    # These should fail, calling like() each time cos the pointer exists but data is wrong
+    $t->get_ok('/testdata')->json_like('/fruit', qr{Jose});
+    $t->get_ok('/testdata')->json_like('/fruit', qr{Jose}, 'No way');
+    # These should fail, calling fail() each time cos the pointer doesn't exist
+    $t->get_ok('/testdata')->json_like('/animal', qr{bat});
+    $t->get_ok('/testdata')->json_like('/animal', qr{bat}, 'totally Gothic');
+
+    $orig_is_deeply->(
+        \%call_counter,
+        { is_deeply => 0, fail => 2, like => 4 },
+        "like() and fail() called the right number of times"
+    );
+}


### PR DESCRIPTION
### Summary
Tweaked `Test::Mojo::json_is` and `Test::Mojo::json_like` to detect when a pointer is invalid, and to then just `fail()` instead of comparing data using `is_deeply()` or `like()`. The detection is done using what used to be the core of `json_has` and `json_hasnt`, which has been factored out.

Also added tests for `json_is` and `json_like`.

### Motivation
`...->json($p)` returns `undef` when $p points to lala-land, which leads to `is_deeply()` and `like()` trying to compare the desired value to undef, failing (usually) as expected, *but then erroneously talking about a comparison with undef in their explanations* as if the pointer was to an undef value instead of pointing to nothing at all. This may also lead to confusion when there are legitimate JSON `null`s in the data although I've not tested that.

### References
[issue 1456](https://github.com/mojolicious/mojo/issues/1456)