### PR TITLE
Test that Mojo::Promise conforms to the Future::AsyncAwait::Awaitable API

### DIFF
--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -23,7 +23,7 @@ use constant ROLES =>
 # async/await support requires Future::AsyncAwait 0.35+
 use constant ASYNC => $ENV{MOJO_NO_ASYNC} ? 0 : !!(eval {
   require Future::AsyncAwait;
-  Future::AsyncAwait->VERSION('0.35');
+  Future::AsyncAwait->VERSION('0.36');
   1;
 });
 
@@ -129,7 +129,7 @@ sub import {
 
     # async/await
     elsif ($flag eq '-async_await') {
-      Carp::croak 'Future::AsyncAwait 0.35+ is required for async/await'
+      Carp::croak 'Future::AsyncAwait 0.36+ is required for async/await'
         unless ASYNC;
       require Mojo::Promise;
       Future::AsyncAwait->import_into($caller, future_class => 'Mojo::Promise');
@@ -272,7 +272,7 @@ enable support for L<subroutine signatures|perlsub/"Signatures">.
   use Mojo::Base 'SomeBaseClass', -signatures;
   use Mojo::Base -role, -signatures;
 
-If you have L<Future::AsyncAwait> 0.35+ installed you can also use the
+If you have L<Future::AsyncAwait> 0.36+ installed you can also use the
 C<-async_await> flag to activate the C<async> and C<await> keywords to deal much
 more efficiently with promises. Note that this feature is B<EXPERIMENTAL> and
 might change without warning!

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -7,15 +7,22 @@ use Test::More;
 BEGIN {
   plan skip_all => 'set TEST_ASYNC_AWAIT to enable this test (developer only!)'
     unless $ENV{TEST_ASYNC_AWAIT} || $ENV{TEST_ALL};
-  plan skip_all => 'Future::AsyncAwait 0.35+ required for this test!'
+  plan skip_all => 'Future::AsyncAwait 0.36+ required for this test!'
     unless Mojo::Base->ASYNC;
 }
 use Mojo::Base -async_await;
 
+use Test::Future::AsyncAwait::Awaitable qw(test_awaitable);
 use Test::Mojo;
 use Mojo::Promise;
 use Mojo::UserAgent;
 use Mojolicious::Lite;
+
+test_awaitable(
+  'Mojo::Promise conforms to Awaitable API',
+  class => "Mojo::Promise",
+  force => sub { shift->wait },
+);
 
 # Silence
 app->log->level('fatal');


### PR DESCRIPTION
### Summary
Use `Test::Future::AsyncAwait::Awaitable` to test that `Mojo::Promise` conforms to the API expected by `Future::AsyncAwait`

### Motivation
This makes sure we don't accidentally break the `-async_await` feature.

### References
As suggested by LeoNerd on IRC
