### PR TITLE
Switch Linux OS to bionic 18.04 from Travis Default (xenial 16.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: perl
+dist: bionic
 matrix:
   include:
   - perl: "5.30"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: perl
+os: linux
+dist: bionic
 matrix:
   include:
   - perl: "5.30"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,20 @@
 language: perl
-os: linux
-dist: bionic
-matrix:
-  include:
-  - perl: "5.30"
-    dist: bionic
-  - perl: "5.28"
-    dist: bionic
-  - perl: "5.26"
-    dist: bionic
-  - perl: "5.24"
-    dist: bionic
-  - perl: "5.22"
-    dist: bionic
-  - perl: "5.20"
-    dist: bionic
-  - perl: "5.30"
-    dist: xenial
-  - perl: "5.28"
-    dist: xenial
-  - perl: "5.26"
-    dist: xenial
-  - perl: "5.24"
-    dist: xenial
-  - perl: "5.22"
-    dist: xenial
-  - perl: "5.20"
-    dist: trusty
-  - perl: "5.18"
-    dist: trusty
-  - perl: "5.16"
-    dist: trusty
-  - perl: "5.14"
-    dist: trusty
-  - perl: "5.12"
-    dist: trusty
-  - perl: "5.10"
-    dist: trusty
+dist:
+  - bionic
+  - xenial
+  - trusty 
+perl:
+  - "5.30"
+  - "5.28"
+  - "5.26"
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
 env:
   global:
     - HARNESS_OPTIONS=j9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
 language: perl
-dist: bionic
 matrix:
   include:
   - perl: "5.30"
+    dist: bionic
   - perl: "5.28"
+    dist: bionic
   - perl: "5.26"
+    dist: bionic
   - perl: "5.24"
+    dist: bionic
   - perl: "5.22"
+    dist: bionic
+  - perl: "5.20"
+    dist: bionic
+  - perl: "5.30"
+    dist: xenial
+  - perl: "5.28"
+    dist: xenial
+  - perl: "5.26"
+    dist: xenial
+  - perl: "5.24"
+    dist: xenial
+  - perl: "5.22"
+    dist: xenial
   - perl: "5.20"
     dist: trusty
   - perl: "5.18"


### PR DESCRIPTION
### Summary
Single line change to update OS version used by Travis CI.
By leaving at default setting Travis is choosing Ubuntu 16.04

### Motivation
Using xenial 16.04 is masking build errors on more recent OS versions.

### References
Fixes #1470 discovered by #1431, blocking PR #1468 

