### PR TITLE
Add check to travis.yml to detect perlbrew failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,27 @@ language: perl
 matrix:
   include:
   - perl: "5.30"
+    dist: bionic
   - perl: "5.28"
+    dist: bionic
   - perl: "5.26"
+    dist: bionic
   - perl: "5.24"
+    dist: bionic
   - perl: "5.22"
+    dist: bionic
+
+  - perl: "5.30"
+    dist: xenial
+  - perl: "5.28"
+    dist: xenial
+  - perl: "5.26"
+    dist: xenial
+  - perl: "5.24"
+    dist: xenial
+  - perl: "5.22"
+    dist: xenial
+
   - perl: "5.20"
     dist: trusty
   - perl: "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ env:
     - TEST_SUBPROCESS=1
     - TEST_UNIX=1
     - TEST_TLS=1
+before_install:
+  - which perl | grep perlbrew
 install:
   - cpanm -n Cpanel::JSON::XS EV~"!= 4.28" IO::Socket::Socks IO::Socket::SSL
   - cpanm -n Net::DNS::Native Role::Tiny Test::Pod Test::Pod::Coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
   - perl: "5.30"
     dist: bionic
-  - perl: "5.28"
+  - perl: "5.28.2"  # 5.28 temp fix, revert when travis fixes env
     dist: bionic
   - perl: "5.26"
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
   - perl: "5.30"
     dist: bionic
-  - perl: "5.28.2"  # 5.28 temp fix, revert when travis fixes env
+  - perl: "5.28"
     dist: bionic
   - perl: "5.26"
     dist: bionic

--- a/t/mojo/ioloop_tls.t
+++ b/t/mojo/ioloop_tls.t
@@ -303,7 +303,7 @@ ok $client_err, 'has error';
 
 # Ignore invalid client certificate
 $loop = Mojo::IOLoop->new;
-my $cipher;
+my ($cipher, $sslversion);
 ($server, $client, $client_err) = ();
 $id = $loop->server(
   address     => '127.0.0.1',
@@ -317,6 +317,7 @@ $id = $loop->server(
     my ($loop, $stream) = @_;
     $stream->on(close => sub { $loop->stop });
     $server = 'accepted';
+    $sslversion = $stream->handle->get_sslversion;
   }
 );
 $port = $loop->acceptor($id)->port;
@@ -338,7 +339,12 @@ $loop->start;
 is $server, 'accepted',  'right result';
 is $client, 'connected', 'right result';
 ok !$client_err, 'no error';
-is $cipher, 'AES256-SHA', 'AES256-SHA has been negotiatied';
+
+if ($sslversion eq 'TLSv1_3') {
+  is $cipher, 'TLS_AES_256_GCM_SHA384', 'TLS_AES_256_GCM_SHA384 has been negotiatied';
+} else {
+  is $cipher, 'AES256-SHA', 'AES256-SHA has been negotiatied';
+}
 
 # Ignore missing client certificate
 ($server, $client, $client_err) = ();

--- a/t/mojo/ioloop_tls.t
+++ b/t/mojo/ioloop_tls.t
@@ -355,6 +355,7 @@ $id = Mojo::IOLoop->server(
   tls_cert   => 't/mojo/certs/server.crt',
   tls_key    => 't/mojo/certs/server.key',
   tls_verify => 0x01,
+  tls_version => 'TLSv1_2',
   sub { $server = 'accepted' }
 );
 $port = Mojo::IOLoop->acceptor($id)->port;

--- a/t/mojo/tls.t
+++ b/t/mojo/tls.t
@@ -52,8 +52,14 @@ $client_result = $server_result = undef;
 $delay->then(sub { ($server_result, $client_result) = @_ });
 $delay->wait;
 is ref $client_result, 'IO::Socket::SSL', 'right class';
-is $client_result->get_cipher, 'AES256-SHA', 'AES256-SHA has been negotiatied';
 is ref $server_result, 'IO::Socket::SSL', 'right class';
-is $server_result->get_cipher, 'AES256-SHA', 'AES256-SHA has been negotiatied';
+
+if ($server_result->get_sslversion eq 'TLSv1_3') {
+  is $client_result->get_cipher, 'TLS_AES_256_GCM_SHA384', 'TLS_AES_256_GCM_SHA384 has been negotiatied';
+  is $server_result->get_cipher, 'TLS_AES_256_GCM_SHA384', 'TLS_AES_256_GCM_SHA384 has been negotiatied';
+} else {
+  is $client_result->get_cipher, 'AES256-SHA', 'AES256-SHA has been negotiatied';
+  is $server_result->get_cipher, 'AES256-SHA', 'AES256-SHA has been negotiatied';
+}
 
 done_testing;


### PR DESCRIPTION
### Summary
Just verifies version of perl is from perlbrew when in Travis-CI environment

### Motivation
Travis-CI's perl environments has occasional bugs which bypasses perlbrew and this will cause tests to pass that should instead fail.

### References
#1473 