### PR TITLE
Use local lib in generated tests

### DIFF
--- a/lib/Mojolicious/Command/Author/generate/app.pm
+++ b/lib/Mojolicious/Command/Author/generate/app.pm
@@ -173,6 +173,9 @@ sub welcome {
 @@ test
 use Mojo::Base -strict;
 
+use Mojo::File 'curfile';
+use lib curfile->dirname->sibling('lib')->to_string;
+
 use Test::More;
 use Test::Mojo;
 

--- a/lib/Mojolicious/Command/Author/generate/plugin.pm
+++ b/lib/Mojolicious/Command/Author/generate/plugin.pm
@@ -146,6 +146,9 @@ L<Mojolicious>, L<Mojolicious::Guides>, L<https://mojolicious.org>.
 @@ test
 use Mojo::Base -strict;
 
+use Mojo::File 'curfile';
+use lib curfile->dirname->sibling('lib')->to_string;
+
 use Test::More;
 use Mojolicious::Lite;
 use Test::Mojo;


### PR DESCRIPTION
### Summary
For tests generated by the generate command, have them use the local 'lib', just like the script/my_app of `mojo generate app`.

### Motivation
```
$ mojo generate app > /dev/null && cd my_app && prove t
t/basic.t .. Can't find application class "MyApp" in @INC.

$ mojo generate plugin > /dev/null && cd Mojolicious-Plugin-MyPlugin && prove t
t/basic.t .. Plugin "MyPlugin" missing, maybe you need to install it?
```
### References
LIST RELEVANT ISSUES, PULL REQUESTS AND IRC/MAILING-LIST DISCUSSIONS HERE
