### PR TITLE
Add lines to Mojo::File

### DIFF
--- a/lib/Mojo/File.pm
+++ b/lib/Mojo/File.pm
@@ -44,6 +44,8 @@ sub dirname { $_[0]->new(scalar File::Basename::dirname ${$_[0]}) }
 
 sub is_abs { file_name_is_absolute ${shift()} }
 
+sub lines { Mojo::Collection->new(split $/, shift->slurp) }
+
 sub list {
   my ($self, $options) = (shift, shift // {});
 
@@ -314,6 +316,13 @@ Check if the path is absolute.
 
   # False (on UNIX)
   path('.vimrc')->is_abs;
+
+=head2 lines
+
+  my $collection = $path->lines;
+
+Read the entire file, split it by C<$/> and return a L<Mojo::Collection> object
+containing the result.
 
 =head2 list
 

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -109,6 +109,10 @@ like $@, qr/^Can't open file/, 'right error';
 eval { $dir->child('foo')->make_path->spurt('fail') };
 like $@, qr/^Can't open file/, 'right error';
 
+# Lines
+is_deeply $file->spurt(join $/, 'test', '123')->lines->to_array,
+  ['test', '123'], 'right content';
+
 # Make path
 $dir = tempdir;
 my $subdir = $dir->child('foo', 'bar');


### PR DESCRIPTION
### Summary
Add a `lines` method to Mojo::File, returning a Mojo::Collection of the lines in a file

### Motivation
Modeled after [Path::Tiny](https://metacpan.org/pod/Path::Tiny#edit_lines,-edit_lines_utf8,-edit_lines_raw)'s `lines` method (albeit with no knobs), this is a nice addition helping with fluid code when dealing with files on a line-by-line basis.

### References