### PR TITLE
Change validation to consider the empty string a valid value

### DIFF
--- a/lib/Mojolicious/Validator.pm
+++ b/lib/Mojolicious/Validator.pm
@@ -59,7 +59,7 @@ sub _size {
   return $len < $min || $len > $max;
 }
 
-sub _trim { trim $_[2] // '' }
+sub _trim { defined $_[2] ? trim $_[2] : undef }
 
 1;
 

--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -75,7 +75,7 @@ sub optional {
     @input = map { $self->$cb($name, $_) } @input;
   }
   $self->output->{$name} = ref $input eq 'ARRAY' ? \@input : $input[0]
-    if @input && !grep { !length } @input;
+    if @input && !grep { !defined } @input;
 
   return $self->topic($name);
 }
@@ -265,9 +265,8 @@ Return an array reference with all names for values that passed validation.
   $v = $v->required('foo');
   $v = $v->required('foo', @filters);
 
-Change validation L</"topic">, apply filters, and make sure a value is present
-and not an empty string. All filters from L<Mojolicious::Validator/"FILTERS">
-are supported.
+Change validation L</"topic">, apply filters, and make sure a value is present.
+All filters from L<Mojolicious::Validator/"FILTERS"> are supported.
 
   # Trim value and check size
   $v->required('user', 'trim')->size(1, 15);

--- a/t/mojolicious/validation_lite_app.t
+++ b/t/mojolicious/validation_lite_app.t
@@ -82,6 +82,11 @@ ok !$v->in('c')->is_valid, 'not valid';
 is_deeply $v->output, {}, 'right result';
 ok $v->has_error, 'has error';
 
+# Empty string
+$v = $t->app->validation->input({foo => ''});
+ok $v->optional('foo')->is_valid, 'valid';
+is_deeply $v->output, {foo => ''}, 'right result';
+
 # Equal to
 $v = $t->app->validation->input({foo => 'bar', baz => 'bar', yada => 'yada'});
 ok $v->optional('foo')->equal_to('baz')->is_valid, 'valid';
@@ -220,8 +225,8 @@ ok !$v->optional('missing', 'trim')->is_valid, 'not valid';
 ok $v->optional('baz', 'trim')->like(qr/^\d$/)->is_valid, 'valid';
 is_deeply $v->output, {foo => 'bar', baz => [0, 1]}, 'right result';
 $v = $t->app->validation->input({nothing => '  ', more => [undef]});
-ok !$v->required('nothing', 'trim')->is_valid, 'not valid';
-is_deeply $v->output, {}, 'right result';
+ok $v->required('nothing', 'trim')->is_valid, 'valid';
+is_deeply $v->output, {nothing => ''}, 'right result';
 ok $v->required('nothing')->is_valid, 'valid';
 is_deeply $v->output, {nothing => '  '}, 'right result';
 ok !$v->optional('more', 'trim')->is_valid, 'not valid';
@@ -236,12 +241,13 @@ is_deeply $v->output, {foo => ['foo="bar"', 'foo="baz"']}, 'right result';
 # Multiple empty values
 $v = $t->app->validation;
 ok !$v->has_data, 'no data';
-$v->input({foo => ['', 'bar', ''], bar => ['', 'baz', '']});
+$v->input({foo => ['', 'bar', ''], bar => ['', 'baz', undef]});
 ok $v->has_data, 'has data';
-ok !$v->required('foo')->is_valid, 'not valid';
-is_deeply $v->output, {}, 'right result';
+ok $v->required('foo')->is_valid, 'valid';
+ok !$v->required('bar')->is_valid, 'not valid';
+is_deeply $v->output, {foo => ['', 'bar', '']}, 'right result';
 ok $v->has_error, 'has error';
-is_deeply $v->error('foo'), ['required'], 'right error';
+is_deeply $v->error('bar'), ['required'], 'right error';
 
 # "0"
 $v = $t->app->validation->input({0 => 0});


### PR DESCRIPTION
This appears to be the default assumption of our users. The empty
string can now be validated with regexes and other checks.
Additionally non-browser users and form elements without any value
at all can now be considered during validation.
