### PR TITLE
using base64url increases the request_id pool from 2^32 to 2^48

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -1,6 +1,7 @@
 package Mojo::Message::Request;
 use Mojo::Base 'Mojo::Message';
 
+use Digest::SHA qw(sha1_base64);
 use Mojo::Cookie::Request;
 use Mojo::Util qw(b64_encode b64_decode sha1_sum);
 use Mojo::URL;
@@ -11,7 +12,10 @@ has env    => sub { {} };
 has method => 'GET';
 has [qw(proxy reverse_proxy)];
 has request_id => sub {
-  substr sha1_sum($SEED . ($COUNTER = ($COUNTER + 1) % 0xffffff)), 0, 8;
+  my $b64
+    = substr(sha1_base64($SEED . ($COUNTER = ($COUNTER + 1) % 0xffffff)), 0, 8);
+  $b64 =~ tr!+/!-_!;
+  return $b64;
 };
 has url       => sub { Mojo::URL->new };
 has via_proxy => 1;


### PR DESCRIPTION
### Summary

Switch request_id from 8 hex characters to 8 base64url characters

### Motivation

8 characters is few enough that request ids repeat often enough to make log analysis on heavily used systems irritating sometimes ...

... but making the request id longer is kinda fugly and discussion in channel led to deciding we didn't want to do that ...

... but base64url gives 6 bits per character rather than 4, using [a-zA-Z0-9] plus '-' and '_' instead of '+' and '/' as normal base64, which IMO is still pretty damn readable ...

... and increases the number of theoretically possible request ids from 2^32 (4294967296) to 2^48 (281474976710656) ...

... and actually still looks nice to me:

    $ for i in $(seq 1 10); do perl -Ilib -Mnew=Mojo::Message::Request -E 'say $O->request_id'; done
    Tv02Ylba
    H_aK5Lil
    VKc-1hIN
    CC-Ak9yx
    fObm_n88
    YZPYxbwU
    NwjrXLDj
    BJU_pu8b
    UDGeCHLO
    7nvx9Yso

### References

https://tools.ietf.org/html/rfc4648#section-5
