### PR TITLE
Separate keep-alive and inactivity timeouts for all built-in web servers

### DIFF
--- a/lib/Mojo/IOLoop/Stream.pm
+++ b/lib/Mojo/IOLoop/Stream.pm
@@ -72,16 +72,24 @@ sub stop {
 }
 
 sub timeout {
-  my $self = shift;
+  my ($self, $timeout) = @_;
 
-  return $self->{timeout} unless @_;
+  return $self->{timeout} unless defined $timeout;
+  $self->{timeout} = $timeout;
 
   my $reactor = $self->reactor;
-  $reactor->remove(delete $self->{timer}) if $self->{timer};
-  return $self unless my $timeout = $self->{timeout} = shift;
-  weaken $self;
-  $self->{timer} = $reactor->timer(
-    $timeout => sub { delete $self->{timer}; $self->emit('timeout')->close });
+  if ($self->{timer}) {
+    if (!$self->{timeout}) { $reactor->remove(delete $self->{timer}) }
+    else                   { $reactor->again($self->{timer}, $self->{timeout}) }
+  }
+  else {
+    weaken $self;
+    $self->{timer} = $reactor->timer(
+      $timeout => sub {
+        $self and delete($self->{timer}) and $self->emit('timeout')->close;
+      }
+    );
+  }
 
   return $self;
 }

--- a/lib/Mojo/Reactor.pm
+++ b/lib/Mojo/Reactor.pm
@@ -87,9 +87,10 @@ the following new ones.
 =head2 again
 
   $reactor->again($id);
+  $reactor->again($id, 0.5);
 
-Restart timer. Meant to be overloaded in a subclass. Note that this method
-requires an active timer.
+Restart timer and optionally change the invocation time. Meant to be overloaded
+in a subclass. Note that this method requires an active timer.
 
 =head2 detect
 

--- a/lib/Mojo/Reactor/EV.pm
+++ b/lib/Mojo/Reactor/EV.pm
@@ -9,8 +9,10 @@ my $EV;
 sub DESTROY { undef $EV }
 
 sub again {
-  croak 'Timer not active' unless my $timer = shift->{timers}{shift()};
-  $timer->{watcher}->again;
+  my ($self, $id, $after) = @_;
+  croak 'Timer not active' unless my $timer = $self->{timers}{$id};
+  my $w = $timer->{watcher};
+  defined $after ? $w->set($after, $w->repeat ? $after : 0) : $w->again;
 }
 
 # We have to fall back to Mojo::Reactor::Poll, since EV is unique
@@ -131,8 +133,10 @@ implements the following new ones.
 =head2 again
 
   $reactor->again($id);
+  $reactor->again($id, 0.5);
 
-Restart timer. Note that this method requires an active timer.
+Restart timer and optionally change the invocation time. Note that this method
+requires an active timer.
 
 =head2 new
 

--- a/lib/Mojo/Server/Daemon.pm
+++ b/lib/Mojo/Server/Daemon.pm
@@ -15,6 +15,7 @@ has acceptors => sub { [] };
 has [qw(backlog max_clients silent)];
 has inactivity_timeout => sub { $ENV{MOJO_INACTIVITY_TIMEOUT} // 15 };
 has ioloop             => sub { Mojo::IOLoop->singleton };
+has keep_alive_timeout => sub { $ENV{MOJO_KEEP_ALIVE_TIMEOUT} // 10 };
 has listen       => sub { [split ',', $ENV{MOJO_LISTEN} || 'http://*:3000'] };
 has max_requests => 100;
 
@@ -78,7 +79,8 @@ sub _build_tx {
 
   my $tx = $self->build_tx->connection($id);
   $tx->res->headers->server('Mojolicious (Perl)');
-  my $handle = $self->ioloop->stream($id)->handle;
+  my $handle
+    = $self->ioloop->stream($id)->timeout($self->inactivity_timeout)->handle;
   unless ($handle->isa('IO::Socket::UNIX')) {
     $tx->local_address($handle->sockhost)->local_port($handle->sockport);
     $tx->remote_address($handle->peerhost)->remote_port($handle->peerport);
@@ -155,7 +157,8 @@ sub _finish {
   return $self->_remove($id) if $tx->error || !$tx->keep_alive;
 
   # Build new transaction for leftovers
-  return unless length(my $leftovers = $tx->req->content->leftovers);
+  return $self->ioloop->stream($id)->timeout($self->keep_alive_timeout)
+    unless length(my $leftovers = $tx->req->content->leftovers);
   $tx = $c->{tx} = $self->_build_tx($id, $c);
   $tx->server_read($leftovers);
 }
@@ -327,10 +330,10 @@ Listen backlog size, defaults to C<SOMAXCONN>.
   my $timeout = $daemon->inactivity_timeout;
   $daemon     = $daemon->inactivity_timeout(5);
 
-Maximum amount of time in seconds a connection can be inactive before getting
-closed, defaults to the value of the C<MOJO_INACTIVITY_TIMEOUT> environment
-variable or C<15>. Setting the value to C<0> will allow connections to be
-inactive indefinitely.
+Maximum amount of time in seconds a connection with an active request can be
+inactive before getting closed, defaults to the value of the
+C<MOJO_INACTIVITY_TIMEOUT> environment variable or C<15>. Setting the value to
+C<0> will allow connections to be inactive indefinitely.
 
 =head2 ioloop
 
@@ -339,6 +342,16 @@ inactive indefinitely.
 
 Event loop object to use for I/O operations, defaults to the global
 L<Mojo::IOLoop> singleton.
+
+=head2 keep_alive_timeout
+
+  my $timeout = $daemon->keep_alive_timeout;
+  $daemon     = $daemon->keep_alive_timeout(5);
+
+Maximum amount of time in seconds a connection without an active request can be
+inactive before getting closed, defaults to the value of the
+C<MOJO_KEEP_ALIVE_TIMEOUT> environment variable or C<10>. Setting the value to
+C<0> will allow connections to be inactive indefinitely.
 
 =head2 listen
 

--- a/lib/Mojo/Server/Hypnotoad.pm
+++ b/lib/Mojo/Server/Hypnotoad.pm
@@ -26,7 +26,8 @@ sub configure {
   $prefork->max_requests($c->{requests}) if $c->{requests};
   defined $c->{$_} and $prefork->$_($c->{$_})
     for qw(accepts backlog graceful_timeout heartbeat_interval),
-    qw(heartbeat_timeout inactivity_timeout listen pid_file spare workers);
+    qw(heartbeat_timeout inactivity_timeout keep_alive_timeout listen pid_file),
+    qw(spare workers);
 }
 
 sub run {
@@ -304,9 +305,19 @@ operation to block the event loop.
 
   inactivity_timeout => 10
 
-Maximum amount of time in seconds a connection can be inactive before getting
-closed, defaults to the value of L<Mojo::Server::Daemon/"inactivity_timeout">.
-Setting the value to C<0> will allow connections to be inactive indefinitely.
+Maximum amount of time in seconds a connection with an active request can be
+inactive before getting closed, defaults to the value of
+L<Mojo::Server::Daemon/"inactivity_timeout">. Setting the value to C<0> will
+allow connections to be inactive indefinitely.
+
+=head2 keep_alive_timeout
+
+  keep_alive_timeout => 5
+
+Maximum amount of time in seconds a connection without an active request can be
+inactive before getting closed, defaults to the value of
+L<Mojo::Server::Daemon/"keep_alive_timeout">. Setting the value to C<0> will
+allow connections to be inactive indefinitely.
 
 =head2 listen
 

--- a/lib/Mojolicious/Command/daemon.pm
+++ b/lib/Mojolicious/Command/daemon.pm
@@ -15,6 +15,7 @@ sub run {
     'b|backlog=i'            => sub { $daemon->backlog($_[1]) },
     'c|clients=i'            => sub { $daemon->max_clients($_[1]) },
     'i|inactivity-timeout=i' => sub { $daemon->inactivity_timeout($_[1]) },
+    'k|keep-alive-timeout=i' => sub { $daemon->keep_alive_timeout($_[1]) },
     'l|listen=s'             => \my @listen,
     'p|proxy'                => sub { $daemon->reverse_proxy(1) },
     'r|requests=i'           => sub { $daemon->max_requests($_[1]) };
@@ -52,6 +53,8 @@ Mojolicious::Command::daemon - Daemon command
                                          MOJO_HOME or auto-detection
     -i, --inactivity-timeout <seconds>   Inactivity timeout, defaults to the
                                          value of MOJO_INACTIVITY_TIMEOUT or 15
+    -k, --keep-alive-timeout <seconds>   Keep-alive timeout, defaults to the
+                                         value of MOJO_KEEP_ALIVE_TIMEOUT or 10
     -l, --listen <location>              One or more locations you want to
                                          listen on, defaults to the value of
                                          MOJO_LISTEN or "http://*:3000"

--- a/lib/Mojolicious/Command/prefork.pm
+++ b/lib/Mojolicious/Command/prefork.pm
@@ -20,6 +20,7 @@ sub run {
     'I|heartbeat-interval=i' => sub { $prefork->heartbeat_interval($_[1]) },
     'H|heartbeat-timeout=i'  => sub { $prefork->heartbeat_timeout($_[1]) },
     'i|inactivity-timeout=i' => sub { $prefork->inactivity_timeout($_[1]) },
+    'k|keep-alive-timeout=i' => sub { $prefork->keep_alive_timeout($_[1]) },
     'l|listen=s'             => \my @listen,
     'P|pid-file=s'           => sub { $prefork->pid_file($_[1]) },
     'p|proxy'                => sub { $prefork->reverse_proxy(1) },
@@ -65,6 +66,8 @@ Mojolicious::Command::prefork - Pre-fork command
                                          MOJO_HOME or auto-detection
     -i, --inactivity-timeout <seconds>   Inactivity timeout, defaults to the
                                          value of MOJO_INACTIVITY_TIMEOUT or 15
+    -k, --keep-alive-timeout <seconds>   Keep-alive timeout, defaults to the
+                                         value of MOJO_KEEP_ALIVE_TIMEOUT or 10
     -l, --listen <location>              One or more locations you want to
                                          listen on, defaults to the value of
                                          MOJO_LISTEN or "http://*:3000"

--- a/t/mojo/daemon.t
+++ b/t/mojo/daemon.t
@@ -33,13 +33,18 @@ my $tx = $ua->get('/');
 is $tx->res->code, 200,              'right status';
 is $tx->res->body, 'Hello TestApp!', 'right content';
 
-# Timeout
+# Timeouts
 {
   is(Mojo::Server::Daemon->new->inactivity_timeout, 15, 'right value');
   local $ENV{MOJO_INACTIVITY_TIMEOUT} = 25;
   is(Mojo::Server::Daemon->new->inactivity_timeout, 25, 'right value');
   $ENV{MOJO_INACTIVITY_TIMEOUT} = 0;
-  is(Mojo::Server::Daemon->new->inactivity_timeout, 0, 'right value');
+  is(Mojo::Server::Daemon->new->inactivity_timeout, 0,  'right value');
+  is(Mojo::Server::Daemon->new->keep_alive_timeout, 10, 'right value');
+  local $ENV{MOJO_KEEP_ALIVE_TIMEOUT} = 25;
+  is(Mojo::Server::Daemon->new->keep_alive_timeout, 25, 'right value');
+  $ENV{MOJO_KEEP_ALIVE_TIMEOUT} = 0;
+  is(Mojo::Server::Daemon->new->keep_alive_timeout, 0, 'right value');
 }
 
 # Listen
@@ -150,6 +155,15 @@ $app->routes->any(
   }
 );
 
+$app->routes->any(
+  '/timeout' => sub {
+    my $c  = shift;
+    my $id = $c->tx->connection;
+    $c->res->headers->header('X-Connection-ID' => $id);
+    $c->render(text => Mojo::IOLoop->stream($id)->timeout);
+  }
+);
+
 $app->routes->any('/*whatever' => {text => 'Whatever!'});
 
 # Normal request
@@ -234,6 +248,14 @@ ok $local_address, 'has local address';
 ok $local_port > 0, 'has local port';
 ok $remote_address, 'has remote address';
 ok $remote_port > 0, 'has remote port';
+
+# Timeout
+$tx = $ua->get('/timeout');
+ok $tx->keep_alive, 'will be kept alive';
+is $tx->res->code, 200, 'right status';
+is $tx->res->body, 15,  'inactivity timeout was used for the request';
+is(Mojo::IOLoop->stream($tx->res->headers->header('X-Connection-ID'))->timeout,
+  10, 'keep-alive timeout was assigned after the request');
 
 # Pipelined
 $daemon

--- a/t/mojo/hypnotoad.t
+++ b/t/mojo/hypnotoad.t
@@ -24,6 +24,7 @@ use Mojo::UserAgent;
     heartbeat_interval => 7,
     heartbeat_timeout  => 9,
     inactivity_timeout => 5,
+    keep_alive_timeout => 3,
     listen             => ['http://*:8081'],
     pid_file           => '/foo/bar.pid',
     proxy              => 1,
@@ -42,6 +43,7 @@ use Mojo::UserAgent;
   is $hypnotoad->prefork->heartbeat_interval, 7,  'right value';
   is $hypnotoad->prefork->heartbeat_timeout,  9,  'right value';
   is $hypnotoad->prefork->inactivity_timeout, 5,  'right value';
+  is $hypnotoad->prefork->keep_alive_timeout, 3,  'right value';
   is_deeply $hypnotoad->prefork->listen, ['http://*:8081'], 'right value';
   is $hypnotoad->prefork->max_clients,  1,              'right value';
   is $hypnotoad->prefork->max_requests, 3,              'right value';

--- a/t/mojo/reactor_ev.t
+++ b/t/mojo/reactor_ev.t
@@ -8,6 +8,7 @@ plan skip_all => 'EV 4.0+ required for this test!'
   unless eval { require EV; EV->VERSION('4.0'); 1 };
 
 use IO::Socket::INET;
+use Mojo::Util qw(steady_time);
 
 # Instantiation
 use_ok 'Mojo::Reactor::EV';
@@ -192,6 +193,7 @@ $reactor2->timer(0.025 => sub { shift->stop });
 $reactor2->start;
 ok !$timer, 'timer was not triggered';
 ok $timer2, 'timer was triggered';
+$reactor->reset;
 
 # Restart timer
 my ($single, $pair, $one, $two, $last);
@@ -214,6 +216,28 @@ $reactor->start;
 is $pair, 2, 'timer pair was triggered';
 ok $single, 'single timer was triggered';
 ok $last,   'timers were triggered in the right order';
+
+# Reset timer
+my $before = steady_time;
+my ($after, $again);
+$one = $reactor->timer(300 => sub { $after = steady_time });
+$two = $reactor->recurring(
+  300 => sub {
+    my $reactor = shift;
+    $reactor->remove($two) if ++$again > 3;
+  }
+);
+$reactor->timer(
+  0.025 => sub {
+    my $reactor = shift;
+    $reactor->again($one, 0.025);
+    $reactor->again($two, 0.025);
+  }
+);
+$reactor->start;
+ok $after, 'timer was triggered';
+ok(($after - $before) < 200, 'less than 200 seconds');
+is $again, 4, 'recurring timer triggered four times';
 
 # Restart inactive timer
 $id = $reactor->timer(0 => sub { });

--- a/t/mojo/reactor_poll.t
+++ b/t/mojo/reactor_poll.t
@@ -5,6 +5,7 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Test::More;
 use IO::Socket::INET;
 use Mojo::Reactor::Poll;
+use Mojo::Util qw(steady_time);
 
 # Instantiation
 my $reactor = Mojo::Reactor::Poll->new;
@@ -188,6 +189,7 @@ $reactor2->timer(0.025 => sub { shift->stop });
 $reactor2->start;
 ok !$timer, 'timer was not triggered';
 ok $timer2, 'timer was triggered';
+$reactor->reset;
 
 # Restart timer
 my ($single, $pair, $one, $two, $last);
@@ -210,6 +212,28 @@ $reactor->start;
 is $pair, 2, 'timer pair was triggered';
 ok $single, 'single timer was triggered';
 ok $last,   'timers were triggered in the right order';
+
+# Reset timer
+my $before = steady_time;
+my ($after, $again);
+$one = $reactor->timer(300 => sub { $after = steady_time });
+$two = $reactor->recurring(
+  300 => sub {
+    my $reactor = shift;
+    $reactor->remove($two) if ++$again > 3;
+  }
+);
+$reactor->timer(
+  0.025 => sub {
+    my $reactor = shift;
+    $reactor->again($one, 0.025);
+    $reactor->again($two, 0.025);
+  }
+);
+$reactor->start;
+ok $after, 'timer was triggered';
+ok(($after - $before) < 200, 'less than 200 seconds');
+is $again, 4, 'recurring timer triggered four times';
 
 # Restart inactive timer
 $id = $reactor->timer(0 => sub { });


### PR DESCRIPTION
This patch is preparation for #1492. It adds a low level way to reset timers, which is much more efficient than completely replacing timers every time you want to change a setting like the `inactivity_timeout`.

Baseline, this is pretty much equal with and without patch (EV):
```
$ perl -Ilib -Mojo -E 'a(sub ($c) { $c->render(text => "Hello Mojo!") })->start' daemon -m production
Server available at http://127.0.0.1:3000

$ wrk -c 20 -d 10 http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     9.46ms  735.87us  18.77ms   92.09%
    Req/Sec     1.06k    44.73     1.15k    69.50%
  21183 requests in 10.03s, 3.11MB read
Requests/sec:   2111.02
Transfer/sec:    317.85KB
````

With patch applied (EV):
```
$ perl -Ilib -Mojo -E 'a(sub ($c) { $c->inactivity_timeout(30); $c->render(text => "Hello Mojo!") })->start' daemon -m production
Server available at http://127.0.0.1:3000

$ wrk -c 20 -d 10 http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     9.66ms    0.96ms  23.77ms   93.89%
    Req/Sec     1.04k    43.88     1.11k    64.50%
  20761 requests in 10.05s, 3.05MB read
Requests/sec:   2066.38
Transfer/sec:    311.13KB
```

Without patch applied (EV):
```
$ perl -Mojo -E 'a(sub ($c) { $c->inactivity_timeout(30); $c->render(text => "Hello Mojo!") })->start' daemon -m production
Server available at http://127.0.0.1:3000

$ wrk -c 20 -d 10 http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    10.16ms    0.91ms  20.89ms   93.22%
    Req/Sec     0.99k    41.46     1.10k    73.00%
  19736 requests in 10.04s, 2.90MB read
Requests/sec:   1965.20
Transfer/sec:    295.88KB
```

With patch applied (Poll):
```
$ MOJO_REACTOR=Mojo::Reactor::Poll perl -Ilib -Mojo -E 'a(sub ($c) { $c->inactivity_timeout(30); $c->render(text => "Hello Mojo!") })->start' daemon -m production
Server available at http://127.0.0.1:3000

$ wrk -c 20 -d 10 http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     9.92ms    0.92ms  25.57ms   93.01%
    Req/Sec     1.01k    47.22     1.11k    74.50%
  20207 requests in 10.04s, 2.97MB read
Requests/sec:   2012.91
Transfer/sec:    303.09KB
```

Without patch applied (Poll):
```
$ MOJO_REACTOR=Mojo::Reactor::Poll perl -Mojo -E 'a(sub ($c) { $c->inactivity_timeout(30); $c->render(text => "Hello Mojo!") })->start' daemon -m production
Server available at http://127.0.0.1:3000

$ wrk -c 20 -d 10 http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    10.15ms    0.87ms  20.10ms   92.19%
    Req/Sec     0.99k    38.45     1.10k    78.00%
  19723 requests in 10.03s, 2.90MB read
Requests/sec:   1967.33
Transfer/sec:    296.20KB
```