### PR TITLE
Allow curfile to work in Perl Config files

### DIFF
--- a/lib/Mojolicious/Plugin/Config.pm
+++ b/lib/Mojolicious/Plugin/Config.pm
@@ -10,14 +10,24 @@ sub parse {
   my ($self, $content, $file, $conf, $app) = @_;
 
   # add the "#line" directive *only* if it's safe to do so
-  my $line_directive = $file=~/[\r\n]/ ? '' # can't break "#line" across lines
-    : ( $file=~/\s/ ? ( $file=~/"/ ? ''     # can't escape double-quotes
-      : qq{\n#line 1 "$file"\n} ) : qq{\n#line 1 $file\n} );
+  my $line_directive = $file =~ /[\r\n]/
+    ? ''    # can't break "#line" across lines
+    : (
+    $file =~ /\s/
+    ? (
+      $file =~ /"/
+      ? ''    # can't escape double-quotes
+      : qq{\n#line 1 "$file"\n}
+      )
+    : qq{\n#line 1 $file\n}
+    );
 
   # Run Perl code in sandbox
-  my $config = eval 'package Mojolicious::Plugin::Config::Sandbox; no warnings;'
+  my $config
+    = eval 'package Mojolicious::Plugin::Config::Sandbox; no warnings;'
     . "sub app; local *app = sub { \$app }; use Mojo::Base -strict;"
-    . $line_directive . $content;
+    . $line_directive
+    . $content;
   die qq{Can't load configuration from file "$file": $@} if $@;
   die qq{Configuration file "$file" did not return a hash reference.\n}
     unless ref $config eq 'HASH';

--- a/lib/Mojolicious/Plugin/Config.pm
+++ b/lib/Mojolicious/Plugin/Config.pm
@@ -9,11 +9,15 @@ sub load { $_[0]->parse(decode('UTF-8', path($_[1])->slurp), @_[1, 2, 3]) }
 sub parse {
   my ($self, $content, $file, $conf, $app) = @_;
 
+  # add the "#line" directive *only* if it's safe to do so
+  my $line_directive = $file=~/[\r\n]/ ? '' # can't break "#line" across lines
+    : ( $file=~/\s/ ? ( $file=~/"/ ? ''     # can't escape double-quotes
+      : qq{\n#line 1 "$file"\n} ) : qq{\n#line 1 $file\n} );
+
   # Run Perl code in sandbox
-  ( my $file_oneline = $file ) =~ s/\n/\\n/g; # work around breaking "#line"
   my $config = eval 'package Mojolicious::Plugin::Config::Sandbox; no warnings;'
     . "sub app; local *app = sub { \$app }; use Mojo::Base -strict;"
-    . "\n#line 1 $file_oneline\n$content";
+    . $line_directive . $content;
   die qq{Can't load configuration from file "$file": $@} if $@;
   die qq{Configuration file "$file" did not return a hash reference.\n}
     unless ref $config eq 'HASH';

--- a/lib/Mojolicious/Plugin/Config.pm
+++ b/lib/Mojolicious/Plugin/Config.pm
@@ -11,7 +11,7 @@ sub parse {
 
   # Run Perl code in sandbox
   my $config = eval 'package Mojolicious::Plugin::Config::Sandbox; no warnings;'
-    . "sub app; local *app = sub { \$app }; use Mojo::Base -strict; $content";
+    . "sub app; local *app = sub { \$app }; use Mojo::Base -strict;\n#line 1 $file\n$content";
   die qq{Can't load configuration from file "$file": $@} if $@;
   die qq{Configuration file "$file" did not return a hash reference.\n}
     unless ref $config eq 'HASH';

--- a/lib/Mojolicious/Plugin/Config.pm
+++ b/lib/Mojolicious/Plugin/Config.pm
@@ -10,8 +10,10 @@ sub parse {
   my ($self, $content, $file, $conf, $app) = @_;
 
   # Run Perl code in sandbox
+  ( my $file_oneline = $file ) =~ s/\n/\\n/g; # work around breaking "#line"
   my $config = eval 'package Mojolicious::Plugin::Config::Sandbox; no warnings;'
-    . "sub app; local *app = sub { \$app }; use Mojo::Base -strict;\n#line 1 $file\n$content";
+    . "sub app; local *app = sub { \$app }; use Mojo::Base -strict;"
+    . "\n#line 1 $file_oneline\n$content";
   die qq{Can't load configuration from file "$file": $@} if $@;
   die qq{Configuration file "$file" did not return a hash reference.\n}
     unless ref $config eq 'HASH';

--- a/t/mojolicious/perl_config_lite_app.conf
+++ b/t/mojolicious/perl_config_lite_app.conf
@@ -1,8 +1,8 @@
 use Mojo::File 'curfile';
 {
-	# Just a comment
-	foo => "bar",
-	utf => "утф",
-	file => curfile->to_string,
-	line => __LINE__, # 7
+  # Just a comment
+  foo => "bar",
+  utf => "утф",
+  file => curfile->to_abs->to_string,
+  line => __LINE__, # 7
 }

--- a/t/mojolicious/perl_config_lite_app.conf
+++ b/t/mojolicious/perl_config_lite_app.conf
@@ -1,0 +1,8 @@
+use Mojo::File 'curfile';
+{
+	# Just a comment
+	foo => "bar",
+	utf => "утф",
+	file => curfile->to_string,
+	line => __LINE__, # 7
+}

--- a/t/mojolicious/perl_config_lite_app.conf
+++ b/t/mojolicious/perl_config_lite_app.conf
@@ -1,8 +1,8 @@
 use Mojo::File 'curfile';
 {
   # Just a comment
-  foo => "bar",
-  utf => "утф",
+  foo  => "bar",
+  utf  => "утф",
   file => curfile->to_abs->to_string,
-  line => __LINE__, # 7
+  line => __LINE__,                     # 7
 }

--- a/t/mojolicious/perl_config_lite_app.t
+++ b/t/mojolicious/perl_config_lite_app.t
@@ -5,11 +5,13 @@ use Mojo::File qw(curfile);
 use Mojolicious::Lite;
 
 plugin 'Config';
-is_deeply app->config, {
-    foo => "bar",
-    utf => "утф",
-    file => curfile->sibling('perl_config_lite_app.conf')->to_abs->to_string,
-    line => 7,
-  }, 'right value';
+is_deeply app->config,
+  {
+  foo  => "bar",
+  utf  => "утф",
+  file => curfile->sibling('perl_config_lite_app.conf')->to_abs->to_string,
+  line => 7,
+  },
+  'right value';
 
 done_testing();

--- a/t/mojolicious/perl_config_lite_app.t
+++ b/t/mojolicious/perl_config_lite_app.t
@@ -23,7 +23,7 @@ my $tempdir = tempdir CLEANUP => 1;
 }
 SKIP: {
   skip 'these filenames are all invalid in Windows anyway', 5
-    if $^O eq 'MSWin32';
+    if $^O eq 'MSWin32' || $^O eq 'cygwin';
   {
     my $cf = $tempdir->child(qq{foo\rquz\tbaz.conf});
     $conffile->copy_to($cf);

--- a/t/mojolicious/perl_config_lite_app.t
+++ b/t/mojolicious/perl_config_lite_app.t
@@ -22,14 +22,16 @@ my $tempdir = tempdir CLEANUP => 1;
     'space in path works';
 }
 {
-  my $cf = $tempdir->child(qq{foo\rquz\tbaz.conf});
+  my $cf = $tempdir->child(
+    $^O eq 'MSWin32' ? qq{foo\tbar.conf} : qq{foo\rquz\tbaz.conf});
   $conffile->copy_to($cf);
   my $config = plugin Config => {file => $cf};
   is_deeply $config,
     {foo => "bar", utf => "утф", file => $cf->to_string, line => 7},
     'other whitespace in path works';
 }
-{
+SKIP: {
+  skip 'quotes not allowed in filenames on win', 2 if $^O eq 'MSWin32';
   my $cf = $tempdir->child(qq{quz"baz.conf});
   $conffile->copy_to($cf);
   my $config = plugin Config => {file => $cf};

--- a/t/mojolicious/perl_config_lite_app.t
+++ b/t/mojolicious/perl_config_lite_app.t
@@ -1,10 +1,4 @@
 use Mojo::Base -strict;
-
-BEGIN {
-  $ENV{MOJO_MODE}    = 'development';
-  $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
-}
-
 use Test::Mojo;
 use Test::More;
 use Mojo::File qw(curfile);
@@ -12,10 +6,10 @@ use Mojolicious::Lite;
 
 plugin 'Config';
 is_deeply app->config, {
-		foo => "bar",
-		utf => "утф",
-		file => curfile->sibling('perl_config_lite_app.conf')->to_string,
-		line => 7,
-	}, 'right value';
+    foo => "bar",
+    utf => "утф",
+    file => curfile->sibling('perl_config_lite_app.conf')->to_abs->to_string,
+    line => 7,
+  }, 'right value';
 
 done_testing();

--- a/t/mojolicious/perl_config_lite_app.t
+++ b/t/mojolicious/perl_config_lite_app.t
@@ -1,0 +1,21 @@
+use Mojo::Base -strict;
+
+BEGIN {
+  $ENV{MOJO_MODE}    = 'development';
+  $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
+}
+
+use Test::Mojo;
+use Test::More;
+use Mojo::File qw(curfile);
+use Mojolicious::Lite;
+
+plugin 'Config';
+is_deeply app->config, {
+		foo => "bar",
+		utf => "утф",
+		file => curfile->sibling('perl_config_lite_app.conf')->to_string,
+		line => 7,
+	}, 'right value';
+
+done_testing();

--- a/t/mojolicious/perl_config_lite_app.t
+++ b/t/mojolicious/perl_config_lite_app.t
@@ -21,9 +21,9 @@ my $tempdir = tempdir CLEANUP => 1;
     {foo => "bar", utf => "утф", file => $cf->to_string, line => 7},
     'space in path works';
 }
-{
-  my $cf = $tempdir->child(
-    $^O eq 'MSWin32' ? qq{foo\tbar.conf} : qq{foo\rquz\tbaz.conf});
+SKIP: {
+  skip 'this test filename is invalid on win', 1 if $^O eq 'MSWin32';
+  my $cf = $tempdir->child(qq{foo\rquz\tbaz.conf});
   $conffile->copy_to($cf);
   my $config = plugin Config => {file => $cf};
   is_deeply $config,
@@ -31,7 +31,7 @@ my $tempdir = tempdir CLEANUP => 1;
     'other whitespace in path works';
 }
 SKIP: {
-  skip 'quotes not allowed in filenames on win', 2 if $^O eq 'MSWin32';
+  skip 'this test filename is invalid on win', 2 if $^O eq 'MSWin32';
   my $cf = $tempdir->child(qq{quz"baz.conf});
   $conffile->copy_to($cf);
   my $config = plugin Config => {file => $cf};

--- a/t/mojolicious/perl_config_lite_app.t
+++ b/t/mojolicious/perl_config_lite_app.t
@@ -22,34 +22,36 @@ my $tempdir = tempdir CLEANUP => 1;
     'space in path works';
 }
 SKIP: {
-  skip 'this test filename is invalid on win', 1 if $^O eq 'MSWin32';
-  my $cf = $tempdir->child(qq{foo\rquz\tbaz.conf});
-  $conffile->copy_to($cf);
-  my $config = plugin Config => {file => $cf};
-  is_deeply $config,
-    {foo => "bar", utf => "утф", file => $cf->to_string, line => 7},
-    'other whitespace in path works';
-}
-SKIP: {
-  skip 'this test filename is invalid on win', 2 if $^O eq 'MSWin32';
-  my $cf = $tempdir->child(qq{quz"baz.conf});
-  $conffile->copy_to($cf);
-  my $config = plugin Config => {file => $cf};
-  like $config->{file}, qr/\(eval /,
-    'filename doesn\'t work with quote in path';
-  is_deeply $config,
-    {foo => "bar", utf => "утф", file => $config->{file}, line => 7},
-    'line still works with quote in path';
-}
-{
-  my $cf = $tempdir->child(qq{hello\nworld.conf});
-  $conffile->copy_to($cf);
-  my $config = plugin Config => {file => $cf};
-  like $config->{file}, qr/\(eval /,
-    'filename doesn\'t work with newline in path';
-  is_deeply $config,
-    {foo => "bar", utf => "утф", file => $config->{file}, line => 7},
-    'line still works with newline in path';
+  skip 'these filenames are all invalid in Windows anyway', 5
+    if $^O eq 'MSWin32';
+  {
+    my $cf = $tempdir->child(qq{foo\rquz\tbaz.conf});
+    $conffile->copy_to($cf);
+    my $config = plugin Config => {file => $cf};
+    is_deeply $config,
+      {foo => "bar", utf => "утф", file => $cf->to_string, line => 7},
+      'other whitespace in path works';
+  }
+  {
+    my $cf = $tempdir->child(qq{quz"baz.conf});
+    $conffile->copy_to($cf);
+    my $config = plugin Config => {file => $cf};
+    like $config->{file}, qr/\(eval /,
+      'filename doesn\'t work with quote in path';
+    is_deeply $config,
+      {foo => "bar", utf => "утф", file => $config->{file}, line => 7},
+      'line still works with quote in path';
+  }
+  {
+    my $cf = $tempdir->child(qq{hello\nworld.conf});
+    $conffile->copy_to($cf);
+    my $config = plugin Config => {file => $cf};
+    like $config->{file}, qr/\(eval /,
+      'filename doesn\'t work with newline in path';
+    is_deeply $config,
+      {foo => "bar", utf => "утф", file => $config->{file}, line => 7},
+      'line still works with newline in path';
+  }
 }
 
 done_testing();

--- a/t/mojolicious/perl_config_lite_app.t
+++ b/t/mojolicious/perl_config_lite_app.t
@@ -1,17 +1,53 @@
 use Mojo::Base -strict;
 use Test::Mojo;
 use Test::More;
-use Mojo::File qw(curfile);
+use Mojo::File qw(curfile tempdir);
 use Mojolicious::Lite;
+
+my $conffile = curfile->sibling('perl_config_lite_app.conf')->to_abs;
 
 plugin 'Config';
 is_deeply app->config,
-  {
-  foo  => "bar",
-  utf  => "утф",
-  file => curfile->sibling('perl_config_lite_app.conf')->to_abs->to_string,
-  line => 7,
-  },
+  {foo => "bar", utf => "утф", file => $conffile->to_string, line => 7},
   'right value';
+
+my $tempdir = tempdir CLEANUP => 1;
+
+{
+  my $cf = $tempdir->child(qq{foo bar.conf});
+  $conffile->copy_to($cf);
+  my $config = plugin Config => {file => $cf};
+  is_deeply $config,
+    {foo => "bar", utf => "утф", file => $cf->to_string, line => 7},
+    'space in path works';
+}
+{
+  my $cf = $tempdir->child(qq{foo\rquz\tbaz.conf});
+  $conffile->copy_to($cf);
+  my $config = plugin Config => {file => $cf};
+  is_deeply $config,
+    {foo => "bar", utf => "утф", file => $cf->to_string, line => 7},
+    'other whitespace in path works';
+}
+{
+  my $cf = $tempdir->child(qq{quz"baz.conf});
+  $conffile->copy_to($cf);
+  my $config = plugin Config => {file => $cf};
+  like $config->{file}, qr/\(eval /,
+    'filename doesn\'t work with quote in path';
+  is_deeply $config,
+    {foo => "bar", utf => "утф", file => $config->{file}, line => 7},
+    'line still works with quote in path';
+}
+{
+  my $cf = $tempdir->child(qq{hello\nworld.conf});
+  $conffile->copy_to($cf);
+  my $config = plugin Config => {file => $cf};
+  like $config->{file}, qr/\(eval /,
+    'filename doesn\'t work with newline in path';
+  is_deeply $config,
+    {foo => "bar", utf => "утф", file => $config->{file}, line => 7},
+    'line still works with newline in path';
+}
 
 done_testing();


### PR DESCRIPTION
### Summary
Allows `__FILE__`, `__LINE__`, and `Mojo::File::curfile` to work correctly in Perl config files.

### Motivation
Allows one to create filenames relative to the current configuration file in the config. For example:

```
use Mojo::File 'curfile';
{
    migrations_file => curfile->sibling('foo.sql'),
}
```

