### PR TITLE
Exclude <script> and <style> from Mojo::DOM text extraction

### DIFF
--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -337,7 +337,10 @@ sub _text {
     }
 
     # Nested tag
-    elsif ($type eq 'tag' && $all) { unshift @$nodes, @{_nodes($node)} }
+    elsif ($type eq 'tag' && $all) {
+      unshift @$nodes, @{_nodes($node)}
+        unless $node->[1] eq 'script' || $node->[1] eq 'style';
+    }
   }
 
   return $text;
@@ -470,7 +473,8 @@ L<Mojo::DOM> implements the following methods.
 
   my $text = $dom->all_text;
 
-Extract text content from all descendant nodes of this element.
+Extract text content from all descendant nodes of this element, with the
+exception of C<script> and C<style> elements.
 
   # "foo\nbarbaz\n"
   $dom->parse("<div>foo\n<p>bar</p>baz\n</div>")->at('div')->all_text;

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -2790,6 +2790,27 @@ is $dom->at('title')->selector,
 is $dom->at($dom->at('title')->selector)->text, 'Test', 'right text';
 is $dom->at('html')->selector, 'html:nth-child(1)', 'right selector';
 
+# Exclude "<script>" and "<style>" from text extraction
+$dom = Mojo::DOM->new(<<EOF);
+<html>
+  <head>
+    <title>Hello</title>
+    <script>123</script>
+    <style>456</style>
+  </head>
+  <body>
+    <script>123</script>
+    <div>Mojo!</div>
+    <style>456</style>
+  </body>
+<html>
+EOF
+like $dom->at('html')->all_text,   qr/Hello.*Mojo!/s, 'title and div';
+unlike $dom->at('html')->all_text, qr/123/,           'no script';
+unlike $dom->at('html')->all_text, qr/456/,           'no style';
+like $dom->at('script')->text,     qr/123/,           'script text';
+like $dom->at('style')->text,      qr/456/,           'style text';
+
 # Reusing partial DOM trees
 $dom = $dom->parse('<div><b>Test</b></div>');
 is $dom->at('div')->prepend($dom->at('b'))->root,


### PR DESCRIPTION
This came up on IRC recently, and everyone seemed to agree that excluding `<script>` and `<style>` would be the correct behaviour for `Mojo::DOM::all_text`.