### PR TITLE
Pr fix promises

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -206,7 +206,7 @@ sub _finally {
 sub _settle {
   my ($self, $status) = (shift, shift);
   my $thenable = blessed $_[0] && $_[0]->can('then');
-  $self = $thenable ? $_[0]->clone : $self->new unless ref $self;
+  $self = $thenable ? return $_[0] : $self->new unless ref $self;
 
   $_[0]->then(sub { $self->resolve(@_); () }, sub { $self->reject(@_); () })
     and return $self


### PR DESCRIPTION
This 7-character patch:

- fixes the 'map warnings' issue in bug #1454
- makes the Mojo Promise class behave more like JS's
- passes `promise.t` without warnings

`transactor.t` still has promise warnings, but those were there before this patch