### PR TITLE
Pr fix promises 2

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -206,6 +206,7 @@ sub _finally {
 sub _settle {
   my ($self, $status) = (shift, shift);
   my $thenable = blessed $_[0] && $_[0]->can('then');
+  return $_[0] if !ref $self and $status eq 'resolve' and $thenable;
   $self = $thenable ? $_[0]->clone : $self->new unless ref $self;
 
   $_[0]->then(sub { $self->resolve(@_); () }, sub { $self->reject(@_); () })


### PR DESCRIPTION
Fixes the undesired 'map' warnings in `promise.t` (described in issue #1454)

And also makes Mojo::Promise class behave more like JS's Promise, in that:
```perl
Mojo::Promise->resolve($p) == $p # true, was false before the patch
```
...acts more like:
```javascript
Promise.resolve(p) === p // true even before the patch
```

(...where `p` and `$p` are promise objects.)