### PR TITLE
Restore promise map

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,5 @@
 
 8.43  2020-05-18
-  - Removed experimental map method from Mojo::Promise, since its test coverage
-    was lacking, getting in the way of new feature development.
   - Removed deprecated argument handling from Mojo::Promise::new.
   - Fixed a bug where the resolve class method in Mojo::Promise would
     unnecessarily create new promises.

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -52,6 +52,31 @@ sub finally {
   return $new;
 }
 
+sub map {
+  my ($class, $options) = (shift, ref $_[0] eq 'HASH' ? shift : {});
+  my ($cb,    @items)   = @_;
+
+  my @start = map { $_->$cb } splice @items, 0,
+    $options->{concurrency} // @items;
+  my $proto = $class->resolve($start[0]);
+
+  my (@trigger, @wait);
+  for my $item (@items) {
+    my $p = $proto->clone;
+    push @trigger, $p;
+    push @wait,    $p->then(sub { local $_ = $item; $_->$cb });
+  }
+
+  my @all = map {
+    $proto->clone->resolve($_)->then(
+      sub { shift(@trigger)->resolve if @trigger; @_ },
+      sub { @trigger = (); $proto->clone->reject($_[0]) },
+    )
+  } (@start, @wait);
+
+  return $class->all(@all);
+}
+
 sub new {
   my $self = shift->SUPER::new;
   shift->(sub { $self->resolve(@_) }, sub { $self->reject(@_) }) if @_;
@@ -395,6 +420,33 @@ reason.
   $promise->finally(sub {
     say "We are done!";
   });
+
+=head2 map
+
+  my $new = Mojo::Promise->map(sub {...}, @items);
+  my $new = Mojo::Promise->map({concurrency => 3}, sub {...}, @items);
+
+Apply a function that returns a L<Mojo::Promise> to each item in a list of
+items while optionally limiting concurrency. Returns a L<Mojo::Promise> that
+collects the results in the same manner as L</all>. If any item's promise is
+rejected, any remaining items which have not yet been mapped will not be. Note
+that this method is B<EXPERIMENTAL> and might change without warning!
+
+  # Perform 3 requests at a time concurrently
+  Mojo::Promise->map({concurrency => 3}, sub { $ua->get_p($_) }, @urls)
+    ->then(sub{ say $_->[0]->res->dom->at('title')->text for @_ });
+
+These options are currently available:
+
+=over 2
+
+=item concurrency
+
+  concurrency => 3
+
+The maximum number of items that are in progress at the same time.
+
+=back
 
 =head2 new
 

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -359,6 +359,60 @@ $promise = Mojo::Promise->reject('foo');
 isnt refaddr(Mojo::Promise->reject($promise)), refaddr($promise),
   'different object';
 
+# Map
+my @started;
+(@results, @errors) = ();
+$promise = Mojo::Promise->map(sub { push @started, $_; $_ }, 1 .. 5)
+  ->then(sub { @results = @_ }, sub { @errors = @_ });
+is_deeply \@started, [1, 2, 3, 4, 5], 'all started without concurrency';
+$promise->wait;
+is_deeply \@results, [[1], [2], [3], [4], [5]], 'correct result';
+is_deeply \@errors, [], 'promise not rejected';
+
+# Map (with concurrency limit)
+my $concurrent = 0;
+(@results, @errors) = ();
+Mojo::Promise->map(
+  {concurrency => 3},
+  sub {
+    my $n = $_;
+    fail 'Concurrency too high' if ++$concurrent > 3;
+    Mojo::Promise->resolve->then(sub {
+      fail 'Concurrency too high' if $concurrent-- > 3;
+      $n;
+    });
+  },
+  1 .. 5
+)->then(sub { @results = @_ }, sub { @errors = @_ })->wait;
+is_deeply \@results, [[1], [2], [3], [4], [5]], 'correct result';
+is_deeply \@errors, [], 'promise not rejected';
+
+# Map (with reject)
+(@started, @results, @errors) = ();
+Mojo::Promise->map(
+  {concurrency => 3},
+  sub {
+    my $n = $_;
+    push @started, $n;
+    Mojo::Promise->resolve->then(sub { Mojo::Promise->reject($n) });
+  },
+  1 .. 5
+)->then(sub { @results = @_ }, sub { @errors = @_ })->wait;
+is_deeply \@results, [], 'promise not resolved';
+is_deeply \@errors, [1], 'correct errors';
+is_deeply \@started, [1, 2, 3], 'only initial batch started';
+
+# Map (custom event loop)
+my $ok;
+$loop = Mojo::IOLoop->new;
+$promise
+  = Mojo::Promise->map(sub { Mojo::Promise->new->ioloop($loop)->resolve }, 1);
+is $promise->ioloop, $loop, 'same loop';
+isnt $promise->ioloop, Mojo::IOLoop->singleton, 'not the singleton';
+$promise->then(sub { $ok = 1; $loop->stop });
+$loop->start;
+ok $ok, 'loop completed';
+
 # Wait for stopped loop
 @results = ();
 $promise = Mojo::Promise->new;

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -382,9 +382,9 @@ Mojo::Promise->map(
       $n;
     });
   },
-  1 .. 5
+  1 .. 7
 )->then(sub { @results = @_ }, sub { @errors = @_ })->wait;
-is_deeply \@results, [[1], [2], [3], [4], [5]], 'correct result';
+is_deeply \@results, [[1], [2], [3], [4], [5], [6], [7]], 'correct result';
 is_deeply \@errors, [], 'promise not rejected';
 
 # Map (with reject)


### PR DESCRIPTION
### Summary
Restore Mojo::Promise::map and improve where there were concerns

### Motivation
Because it was mostly ok, just needed some tweaks, and it is very useful

I have improved the test case to fail when the $proto promise wasn't cloned, however, I have then removed the $proto promise all together as an attempt to prevent warnings as we attempt to warn on unhandled rejected promises.
