### PR TITLE
Reintroduce Mojo::Promise map method with cleaner code

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,5 @@
 
 8.43  2020-05-18
-  - Removed experimental map method from Mojo::Promise, since its test coverage
-    was lacking, getting in the way of new feature development.
   - Removed deprecated argument handling from Mojo::Promise::new.
   - Removed experimental status from all_settled method in Mojo::Promise.
   - Removed experimental status from content_type and file_type methods in

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -52,6 +52,34 @@ sub finally {
   return $new;
 }
 
+sub map {
+  my ($class, $options) = (shift, ref $_[0] eq 'HASH' ? shift : {});
+  my ($cb,    @items)   = @_;
+
+  return $class->all(map { $_->$cb } @items)
+    if !$options->{concurrency} || @items <= $options->{concurrency};
+
+  my @start = map { $_->$cb } splice @items, 0, $options->{concurrency};
+
+  my $loop = $start[0]->ioloop;
+
+  my @wait = map { $class->new->ioloop($loop) } 0 .. $#items;
+
+  my $start_next;
+  $start_next = sub {
+    return unless my $item = shift @items;
+    my $chain = shift @wait;
+    $_->$cb->then(
+      sub { $start_next->() if $start_next; $chain->resolve(@_); () },
+      sub { $chain->reject(@_); () })
+      for $item;
+  };
+
+  $_->then(sub { $start_next->() if $start_next; () }, sub { }) for @start;
+
+  return $class->all(@start, @wait)->finally(sub { undef $start_next });
+}
+
 sub new {
   my $self = shift->SUPER::new;
   shift->(sub { $self->resolve(@_) }, sub { $self->reject(@_) }) if @_;
@@ -394,6 +422,33 @@ reason.
   $promise->finally(sub {
     say "We are done!";
   });
+
+=head2 map
+
+  my $new = Mojo::Promise->map(sub {...}, @items);
+  my $new = Mojo::Promise->map({concurrency => 3}, sub {...}, @items);
+
+Apply a function that returns a L<Mojo::Promise> to each item in a list of
+items while optionally limiting concurrency. Returns a L<Mojo::Promise> that
+collects the results in the same manner as L</all>. If any item's promise is
+rejected, any remaining items which have not yet been mapped will not be. Note
+that this method is B<EXPERIMENTAL> and might change without warning!
+
+  # Perform 3 requests at a time concurrently
+  Mojo::Promise->map({concurrency => 3}, sub { $ua->get_p($_) }, @urls)
+    ->then(sub{ say $_->[0]->res->dom->at('title')->text for @_ });
+
+These options are currently available:
+
+=over 2
+
+=item concurrency
+
+  concurrency => 3
+
+The maximum number of items that are in progress at the same time.
+
+=back
 
 =head2 new
 

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -359,6 +359,61 @@ $promise = Mojo::Promise->reject('foo');
 isnt refaddr(Mojo::Promise->reject($promise)), refaddr($promise),
   'different object';
 
+# Map
+my @started;
+(@results, @errors) = ();
+$promise
+  = Mojo::Promise->map(sub { push @started, $_; Mojo::Promise->resolve($_) },
+  1 .. 5)->then(sub { @results = @_ }, sub { @errors = @_ });
+is_deeply \@started, [1, 2, 3, 4, 5], 'all started without concurrency';
+$promise->wait;
+is_deeply \@results, [[1], [2], [3], [4], [5]], 'correct result';
+is_deeply \@errors, [], 'promise not rejected';
+
+# Map (with concurrency limit)
+my $concurrent = 0;
+(@results, @errors) = ();
+Mojo::Promise->map(
+  {concurrency => 3},
+  sub {
+    my $n = $_;
+    fail 'Concurrency too high' if ++$concurrent > 3;
+    Mojo::Promise->resolve->then(sub {
+      fail 'Concurrency too high' if $concurrent-- > 3;
+      $n;
+    });
+  },
+  1 .. 7
+)->then(sub { @results = @_ }, sub { @errors = @_ })->wait;
+is_deeply \@results, [[1], [2], [3], [4], [5], [6], [7]], 'correct result';
+is_deeply \@errors, [], 'promise not rejected';
+
+# Map (with reject)
+(@started, @results, @errors) = ();
+Mojo::Promise->map(
+  {concurrency => 3},
+  sub {
+    my $n = $_;
+    push @started, $n;
+    Mojo::Promise->resolve->then(sub { Mojo::Promise->reject($n) });
+  },
+  1 .. 5
+)->then(sub { @results = @_ }, sub { @errors = @_ })->wait;
+is_deeply \@results, [], 'promise not resolved';
+is_deeply \@errors, [1], 'correct errors';
+is_deeply \@started, [1, 2, 3], 'only initial batch started';
+
+# Map (custom event loop)
+my $ok;
+$loop = Mojo::IOLoop->new;
+$promise
+  = Mojo::Promise->map(sub { Mojo::Promise->new->ioloop($loop)->resolve }, 1);
+is $promise->ioloop, $loop, 'same loop';
+isnt $promise->ioloop, Mojo::IOLoop->singleton, 'not the singleton';
+$promise->then(sub { $ok = 1; $loop->stop });
+$loop->start;
+ok $ok, 'loop completed';
+
 # Wait for stopped loop
 @results = ();
 $promise = Mojo::Promise->new;


### PR DESCRIPTION
This reverses its removal in c949f574bdc4a62071d2f044b6cec3229cccf41c.

Tests and docs are stolen from jberger's attempt, although I tweaked the tests to match the docs.

Code inverts the previous approach and chains starting additional promises directly off the initially queued ones - this requires making $start_next close over itself, which we then undef in a ->finally once it's no longer required.