### PR TITLE
Make unhandled rejected promises warn

### DIFF
--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -221,7 +221,7 @@ sub _proxy_start_p {
   weaken $source_tx;
   $source_tx->once(finish => sub { $promise->reject(_tx_error(@_)) });
 
-  $c->ua->start_p($source_tx);
+  $c->ua->start_p($source_tx)->catch(sub { });
 
   return $promise;
 }


### PR DESCRIPTION
This is an implementation for #1454. I think it covers all use cases, but handling multiple branches with promise chains and `$promise->wait` correctly makes my head hurt a bit.
```
$ perl -Ilib -Mojo -E 'Mojo::Promise->reject("something bad")'
Unhandled rejected promise: something bad at -e line 1.
```