### PR TITLE
Pre-upgrade "App::cpanminus" and "ExtUtils::MakeMaker"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,8 +25,8 @@ jobs:
         run: perl -V
       - name: Install Dependencies
         run: |
+          cpanm -n App::cpanminus ExtUtils::MakeMaker
           cpanm -n --installdeps .
-          cpanm -n Sub::Util IO::Socket::IP
           cpanm -n Cpanel::JSON::XS EV Role::Tiny
           cpanm -n Test::Pod Test::Pod::Coverage
       - name: Run Tests


### PR DESCRIPTION
### Summary

On Perl 5.18 and older, `cpanm --installdeps` was not picking up `Sub::Util` and `IO::Socket::IP` properly, and updating `ExtUtils::MakeMaker` fixes it.  I included an update of `App::cpanminus` just for good measure.

### Motivation

Fixes #1508 :smile: :birthday:

### References

See #1508 for more details, especially https://github.com/mojolicious/mojo/issues/1508#issuecomment-634247300. :+1: