### PR TITLE
Convert t/mojo/date.t to use subtests

### DIFF
--- a/t/mojo/date.t
+++ b/t/mojo/date.t
@@ -3,72 +3,82 @@ use Mojo::Base -strict;
 use Test::More;
 use Mojo::Date;
 
-# RFC 822/1123
-my $date = Mojo::Date->new('Sun, 06 Nov 1994 08:49:37 GMT');
-is $date->epoch, 784111777, 'right epoch value';
-$date = Mojo::Date->new('Fri, 13 May 2011 10:00:24 GMT');
-is $date->epoch, 1305280824, 'right epoch value';
+subtest "RFC 822/1123" => sub {
+  my $date = Mojo::Date->new('Sun, 06 Nov 1994 08:49:37 GMT');
+  is $date->epoch, 784111777, 'right epoch value';
+  $date = Mojo::Date->new('Fri, 13 May 2011 10:00:24 GMT');
+  is $date->epoch, 1305280824, 'right epoch value';
+};
 
-# RFC 850/1036
-is(Mojo::Date->new('Sunday, 06-Nov-94 08:49:37 GMT')->epoch, 784111777,  'right epoch value');
-is(Mojo::Date->new('Friday, 13-May-11 10:00:24 GMT')->epoch, 1305280824, 'right epoch value');
+subtest "RFC 850/1036" => sub {
+  is(Mojo::Date->new('Sunday, 06-Nov-94 08:49:37 GMT')->epoch, 784111777,  'right epoch value');
+  is(Mojo::Date->new('Friday, 13-May-11 10:00:24 GMT')->epoch, 1305280824, 'right epoch value');
+};
 
-# RFC 3339
-is(Mojo::Date->new('2014-08-20T20:45:00')->epoch,       1408567500,                'right epoch value');
-is(Mojo::Date->new(1408567500)->to_datetime,            '2014-08-20T20:45:00Z',    'right format');
-is(Mojo::Date->new('2014-08-20T20:45:00.01')->epoch,    1408567500.01,             'right epoch value');
-is(Mojo::Date->new('2014-08-20T20:45:00-00:46')->epoch, 1408570260,                'right epoch value');
-is(Mojo::Date->new(1408570260)->to_datetime,            '2014-08-20T21:31:00Z',    'right format');
-is(Mojo::Date->new('2014-08-20t20:45:00-01:46')->epoch, 1408573860,                'right epoch value');
-is(Mojo::Date->new('2014-08-20t20:45:00+01:46')->epoch, 1408561140,                'right epoch value');
-is(Mojo::Date->new(1408561140)->to_datetime,            '2014-08-20T18:59:00Z',    'right format');
-is(Mojo::Date->new('1994-11-06T08:49:37Z')->epoch,      784111777,                 'right epoch value');
-is(Mojo::Date->new('1994-11-06t08:49:37.33z')->epoch,   784111777.33,              'right epoch value');
-is(Mojo::Date->new(784111777.33)->to_datetime,          '1994-11-06T08:49:37.33Z', 'right format');
+subtest "RFC 3339" => sub {
+  is(Mojo::Date->new('2014-08-20T20:45:00')->epoch,       1408567500,                'right epoch value');
+  is(Mojo::Date->new(1408567500)->to_datetime,            '2014-08-20T20:45:00Z',    'right format');
+  is(Mojo::Date->new('2014-08-20T20:45:00.01')->epoch,    1408567500.01,             'right epoch value');
+  is(Mojo::Date->new('2014-08-20T20:45:00-00:46')->epoch, 1408570260,                'right epoch value');
+  is(Mojo::Date->new(1408570260)->to_datetime,            '2014-08-20T21:31:00Z',    'right format');
+  is(Mojo::Date->new('2014-08-20t20:45:00-01:46')->epoch, 1408573860,                'right epoch value');
+  is(Mojo::Date->new('2014-08-20t20:45:00+01:46')->epoch, 1408561140,                'right epoch value');
+  is(Mojo::Date->new(1408561140)->to_datetime,            '2014-08-20T18:59:00Z',    'right format');
+  is(Mojo::Date->new('1994-11-06T08:49:37Z')->epoch,      784111777,                 'right epoch value');
+  is(Mojo::Date->new('1994-11-06t08:49:37.33z')->epoch,   784111777.33,              'right epoch value');
+  is(Mojo::Date->new(784111777.33)->to_datetime,          '1994-11-06T08:49:37.33Z', 'right format');
+};
 
-# Special cases
-is(Mojo::Date->new('Sun ,  06-Nov-1994  08:49:37  UTC')->epoch, 784111777,  'right epoch value');
-is(Mojo::Date->new('Sunday,06  Nov  94  08:49:37  UTC')->epoch, 784111777,  'right epoch value');
-is(Mojo::Date->new('Sunday 06 Nov 94 08:49:37UTC')->epoch,      784111777,  'right epoch value');
-is(Mojo::Date->new('2014-08-20  20:45:00')->epoch,              1408567500, 'right epoch value');
+subtest "Special cases" => sub {
+  is(Mojo::Date->new('Sun ,  06-Nov-1994  08:49:37  UTC')->epoch, 784111777,  'right epoch value');
+  is(Mojo::Date->new('Sunday,06  Nov  94  08:49:37  UTC')->epoch, 784111777,  'right epoch value');
+  is(Mojo::Date->new('Sunday 06 Nov 94 08:49:37UTC')->epoch,      784111777,  'right epoch value');
+  is(Mojo::Date->new('2014-08-20  20:45:00')->epoch,              1408567500, 'right epoch value');
+};
 
-# ANSI C asctime()
-is(Mojo::Date->new('Sun Nov  6 08:49:37 1994')->epoch, 784111777,  'right epoch value');
-is(Mojo::Date->new('Fri May 13 10:00:24 2011')->epoch, 1305280824, 'right epoch value');
+subtest "ANSI C asctime()" => sub {
+  is(Mojo::Date->new('Sun Nov  6 08:49:37 1994')->epoch, 784111777,  'right epoch value');
+  is(Mojo::Date->new('Fri May 13 10:00:24 2011')->epoch, 1305280824, 'right epoch value');
+};
 
-# Invalid string
-is(Mojo::Date->new('')->epoch,                                       undef, 'no epoch value');
-is(Mojo::Date->new('123 abc')->epoch,                                undef, 'no epoch value');
-is(Mojo::Date->new('abc')->epoch,                                    undef, 'no epoch value');
-is(Mojo::Date->new('Xxx, 00 Xxx 0000 00:00:00 XXX')->epoch,          undef, 'no epoch value');
-is(Mojo::Date->new('Sun, 06 Nov 1994 08:49:37 GMT GARBAGE')->epoch,  undef, 'no epoch value');
-is(Mojo::Date->new('Sunday, 06-Nov-94 08:49:37 GMT GARBAGE')->epoch, undef, 'no epoch value');
-is(Mojo::Date->new('Sun Nov  6 08:49:37 1994 GARBAGE')->epoch,       undef, 'no epoch value');
-is(Mojo::Date->new('Fri, 75 May 2011 99:99:99 GMT')->epoch,          undef, 'no epoch value');
-is(Mojo::Date->new('0000-00-00T00:00:00+01:00')->epoch,              undef, 'no epoch value');
+subtest "Invalid string" => sub {
+  is(Mojo::Date->new('')->epoch,                                       undef, 'no epoch value');
+  is(Mojo::Date->new('123 abc')->epoch,                                undef, 'no epoch value');
+  is(Mojo::Date->new('abc')->epoch,                                    undef, 'no epoch value');
+  is(Mojo::Date->new('Xxx, 00 Xxx 0000 00:00:00 XXX')->epoch,          undef, 'no epoch value');
+  is(Mojo::Date->new('Sun, 06 Nov 1994 08:49:37 GMT GARBAGE')->epoch,  undef, 'no epoch value');
+  is(Mojo::Date->new('Sunday, 06-Nov-94 08:49:37 GMT GARBAGE')->epoch, undef, 'no epoch value');
+  is(Mojo::Date->new('Sun Nov  6 08:49:37 1994 GARBAGE')->epoch,       undef, 'no epoch value');
+  is(Mojo::Date->new('Fri, 75 May 2011 99:99:99 GMT')->epoch,          undef, 'no epoch value');
+  is(Mojo::Date->new('0000-00-00T00:00:00+01:00')->epoch,              undef, 'no epoch value');
+};
 
-# to_string
-$date = Mojo::Date->new(784111777);
-is "$date", 'Sun, 06 Nov 1994 08:49:37 GMT', 'right format';
-$date = Mojo::Date->new(1305280824);
-is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
-$date = Mojo::Date->new('1305280824.23');
-is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
+subtest "to_string" => sub {
+  my $date = Mojo::Date->new(784111777);
+  is "$date", 'Sun, 06 Nov 1994 08:49:37 GMT', 'right format';
+  $date = Mojo::Date->new(1305280824);
+  is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
+  $date = Mojo::Date->new('1305280824.23');
+  is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
+};
 
-# Current time roundtrips
-my $before = time;
-ok(Mojo::Date->new(Mojo::Date->new->to_string)->epoch >= $before,   'successful roundtrip');
-ok(Mojo::Date->new(Mojo::Date->new->to_datetime)->epoch >= $before, 'successful roundtrip');
+subtest "Current time roundtrips" => sub {
+  my $before = time;
+  ok(Mojo::Date->new(Mojo::Date->new->to_string)->epoch >= $before,   'successful roundtrip');
+  ok(Mojo::Date->new(Mojo::Date->new->to_datetime)->epoch >= $before, 'successful roundtrip');
+};
 
-# Zero time checks
-$date = Mojo::Date->new(0);
-is $date->epoch, 0, 'right epoch value';
-is "$date", 'Thu, 01 Jan 1970 00:00:00 GMT', 'right format';
-is(Mojo::Date->new('Thu, 01 Jan 1970 00:00:00 GMT')->epoch, 0, 'right epoch value');
+subtest "Zero time checks" => sub {
+  my $date = Mojo::Date->new(0);
+  is $date->epoch, 0, 'right epoch value';
+  is "$date", 'Thu, 01 Jan 1970 00:00:00 GMT', 'right format';
+  is(Mojo::Date->new('Thu, 01 Jan 1970 00:00:00 GMT')->epoch, 0, 'right epoch value');
+};
 
-# No epoch value
-$date = Mojo::Date->new;
-ok $date->parse('Mon, 01 Jan 1900 00:00:00'), 'right format';
-is $date->epoch, undef, 'no epoch value';
+subtest "No epoch value" => sub {
+  my $date = Mojo::Date->new;
+  ok $date->parse('Mon, 01 Jan 1900 00:00:00'), 'right format';
+  is $date->epoch, undef, 'no epoch value';
+};
 
 done_testing();


### PR DESCRIPTION
### Summary
Tests for `Mojo::Date` in `t/mojo/date.t` converted to subtests.

### Motivation
Another file converted.

### References
#1520.
