### PR TITLE
Allow end and begin to occur on the same template line

### DIFF
--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -201,7 +201,7 @@ sub _compile {
       $blocks[-1] .= 'return Mojo::ByteStream->new($_O) }';
 
       # No following code
-      $blocks[-1] .= ';' if ($next->[1] // '') =~ /^\s*$/;
+      $blocks[-1] .= ';' if $next->[0] ne 'cpst' && ($next->[1] // '') =~ /^\s*$/;
     }
 
     # Expression

--- a/t/mojo/template.t
+++ b/t/mojo/template.t
@@ -575,6 +575,19 @@ $output = $mt->render(<<'EOF');
 EOF
 is $output, " \n    2\n\n    3\n\n    4\n", 'block loop';
 
+subtest 'End and begin in the same perl line' => sub {
+  my $concat = 'no warnings "redefine"; sub concat { $_[0]->() . $_[1]->() }';
+  my $mt = Mojo::Template->new(prepend => $concat);
+  my $output = $mt->render(<<'  EOF');
+  %= concat begin
+    1
+  % end, begin
+    2
+  % end
+  EOF
+  is $output, "  \n    1\n    2\n", 'end, begin';
+};
+
 # Strict
 $output = Mojo::Template->new->render('% $foo = 1;');
 isa_ok $output, 'Mojo::Exception', 'right exception';


### PR DESCRIPTION
When `end` and `begin` occur on the same perl line or mix-line group, the presence of the `begin` token causes the `end` token to incorrectly be followed by a `;` which breaks expectations, is hard to work around, and is generally incorrect as it is still valid in theory.

