### PR TITLE
use the Strawberry Portables for testing

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,19 +9,33 @@ on:
 jobs:
   perl:
     runs-on: windows-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        # any Strawberry Portable Perl version can be selected here
+        perl-version:
+          - '5.30'
     steps:
+      - name: Setup perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+          distribution: strawberry
       - name: Set git to use LF
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@v2
-      - name: Set up Perl
-        run: |
-          choco install strawberryperl
-          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
       - name: perl -V
         run: perl -V
+      # Make sure we have a newer cpanm and ExtUtils::Manifest
+      # this is problematic on some older Perls on Windows
       - name: Install Dependencies
-        run: curl -L https://cpanmin.us | perl - --installdeps .
+        run: |
+          cpanm ExtUtils::Manifest App::cpanminus
+          cpanm --installdeps -n .
+      # the prove app has some issues on Windows. Testing with
+      # cpanm this way tends to solve some of the oddities of
+      # dmake vs gmake, etc.
       - name: Run Tests
-        run: prove -l t t/mojo t/mojolicious
+        run: cpanm --test-only -v .


### PR DESCRIPTION
### Summary
Since GitHub Actions/Workflows uses a container for Windows that already has a version of [Strawberry Perl](http://strawberryperl.com/releases.html) pre-installed, it will not allow you to install any other version. You cannot remove the version of Perl that's pre-installed, and removing/installing a new one via Chocolatey is also next to impossible. If you re-install the version from Chocolatey that's already on the container, it seems to allow this, but it's basically a `NOOP` for you as a test setup.

The container also has MinGW installed; this can be bad for us as well. Having MinGW installed separately prevents XS modules from building (whether they be a dependency or if your own module is an XS module). Granted, this only happens if MinGW appears in the `PATH` ahead of your Perl install, but when you remove one Perl and add another, you're going to hit this problem.

To get around this, the best course of action is to remove the currently installed version of Perl from the `PATH` environment variable, along with their currently installed version of `MinGW`. Once both are safely out of the `PATH`, you can install a _Portable<sup>[1]</sup>_ [Strawberry Perl](http://strawberryperl.com/releases.html), put that Perl's paths in your `PATH` and begin testing with a fresh install of [Strawberry Perl](http://strawberryperl.com/releases.html).

### Motivation
That all sounds like a big headache, but it's really not. There's an `Action` available to us for this very purpose: [actions-setup-perl](https://github.com/shogo82148/actions-setup-perl). With this action you can easily test using any version of Perl you like. So, if you're hearing someone report a bug on Perl v5.26 on Windows, you can now add that to your matrix and test easily without the need for any back-and-forth from the user:

```yaml
jobs:
  perl:
    runs-on: windows-latest
    strategy:
      fail-fast: true
      matrix:
        perl-version:
          - '5.30'
          - '5.26'
    steps:
      - name: Setup perl
        uses: shogo82148/actions-setup-perl@v1
        with:
          perl-version: ${{ matrix.perl-version }}
          distribution: strawberry
      - name: Set git to use LF
        run: |
          git config --global core.autocrlf false
          git config --global core.eol lf
      - uses: actions/checkout@v2
...
```

Not only that, you can choose to always test with the latest portable Perl available from the [Strawberry Perl](http://strawberryperl.com/releases.html) distribution.

### References
I asked if this was something that would be useful on IRC. I get that it might not be as useful for you as it is for me. If that's the case, I'm happy to close this out.

`[1]` Portable versions of [Strawberry Perl](http://strawberryperl.com/releases.html) are zipped up, already compiled versions of Perl that do not require you to run an installer on Windows. This means that no heightened privileges are required, etc. You just unzip the archive in the directory you want to run Perl from, then add the relevant paths to Perl in your `$env:PATH` variable. It takes away any annoyances of build irregularities, etc. I've found it to be the most sane way to test on Windows.