### PR TITLE
fix attr test for falsy values

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -334,7 +334,7 @@ sub websocket_ok {
 sub _attr {
   my ($self, $selector, $attr) = @_;
   return '' unless my $e = $self->tx->res->dom->at($selector);
-  return $e->attr($attr) || '';
+  return $e->attr($attr) // '';
 }
 
 sub _build_ok {

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -188,6 +188,7 @@ $t->get_ok($url => {'X-Test' => 'Hi there!'})->status_isnt(404)->status_is(200)-
 # Foo::joy (testing HTML attributes in template)
 $t->get_ok('/fun/joy')->status_is(200)->attr_is('p.joy', 'style', 'background-color: darkred;')
   ->attr_is('p.joy', 'style', 'background-color: darkred;', 'with description')
+  ->attr_is('p.joy', 'data-foo', '0')
   ->attr_isnt('p.joy', 'style', 'float: left;')->attr_isnt('p.joy', 'style', 'float: left;', 'with description')
   ->attr_like('p.joy', 'style', qr/color/)->attr_like('p.joy', 'style', qr/color/, 'with description')
   ->attr_unlike('p.joy', 'style', qr/^float/)->attr_unlike('p.joy', 'style', qr/^float/, 'with description');

--- a/t/mojolicious/lib/MojoliciousTest/Foo.pm
+++ b/t/mojolicious/lib/MojoliciousTest/Foo.pm
@@ -103,7 +103,7 @@ __DATA__
 <p>Have fun!</p>\
 
 @@ foo/joy.html.ep
-<p class="joy" style="background-color: darkred;">Joy for all!</p>\
+<p class="joy" style="background-color: darkred;" data-foo="0">Joy for all!</p>\
 
 @@ just/some/template.html.epl
 Development template with high precedence.


### PR DESCRIPTION
### Summary
Make `attr_is` test work with falsy values.