### PR TITLE
Allow render_later in before_dispatch

### DIFF
--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -123,7 +123,8 @@ sub dispatch {
 
   # Routes
   $plugins->emit_hook(before_routes => $c);
-  $c->helpers->reply->not_found unless $tx->res->code || $self->routes->dispatch($c) || $tx->res->code;
+  $c->helpers->reply->not_found
+    unless $tx->res->code || $self->routes->dispatch($c) || $tx->res->code || $c->stash->{'mojo.rendered'};
 }
 
 sub handler {


### PR DESCRIPTION
### Summary
Currently Controller->render_later has no effect if called from before_dispatch hook.
This blocks delayed rendering for tasks which don't have pre-defined routes, e.g. Mojolicious-Plugin-Directory

### Motivation
It looks that documentation doesn't forbid Controller->render_later in before_dispatch.
With proposed change delayed rendering from before_dispatch seems to work properly.

### References
