### PR TITLE
Correct method call in Mojo::Promise synopsis, closes #1535

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -258,7 +258,7 @@ Mojo::Promise - Promises/A+
   get_p('https://mojolicious.org')->then(sub {
     my $mojo = shift;
     say $mojo->res->code;
-    return get('https://metacpan.org');
+    return get_p('https://metacpan.org');
   })->then(sub {
     my $cpan = shift;
     say $cpan->res->code;


### PR DESCRIPTION
One of the method calls in Mojo::Promise's synopsis was missed when it was changed to more thoroughly demonstrate the use of promises. This PR just corrects it. The synopsis has been tested and works after this fix (seems like metacpan.org always wins though! :stuck_out_tongue:).

### References
Issue report by dmanto #1535