### PR TITLE
Make proxy.start_p work on initial empty body

### DIFF
--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -189,7 +189,8 @@ sub _proxy_start_p {
       my $write = $source_content->is_chunked ? 'write_chunk' : 'write';
       $source_content->unsubscribe('read')->on(
         read => sub {
-          $content->$write(pop) and $tx->resume;
+          my $data = pop;
+          $content->$write(length $data ? $data : undef) and $tx->resume;
 
           # Throttle transparently when backpressure rises
           return if $stream->can_write;

--- a/t/mojolicious/proxy_app.t
+++ b/t/mojolicious/proxy_app.t
@@ -57,6 +57,14 @@ $r->get(
     Mojo::IOLoop->stream($c->tx->connection)->close;
   }
 );
+$r->get(
+  '/res6' => sub {
+    my $c = shift;
+    $c->res->headers->content_length(4);
+    $c->write;
+    Mojo::IOLoop->timer(0.1 => sub { $c->write("Six!") });
+  }
+);
 
 get '/proxy1/*target' => sub {
   my $c      = shift;
@@ -100,6 +108,7 @@ $t->get_ok('/proxy1/res3')->status_is(200)->header_is('X-Mojo-App' => 'Three')->
   ->header_is('X-Mojo-More' => '')->header_is('X-Mojo-Body' => 0)->content_is('Three!');
 $t->get_ok('/proxy1/res4')->status_is(204)->header_is('X-Mojo-App' => 'Four')->content_is('');
 $t->get_ok('/proxy1/res5')->status_is(400)->content_like(qr/Error: /);
+$t->get_ok('/proxy1/res6')->status_is(200)->content_is('Six!');
 
 # Custom request
 $t->patch_ok('/proxy2/res3')->status_is(200)->header_is('X-Mojo-App' => 'Three')->header_is('X-Mojo-Method' => 'POST')


### PR DESCRIPTION
### Summary
`proxy.start_p` misbehaves when it receives the headers only, with a zero-length body. It naively calls `$content->write(pop)` with that zero-length body, and "writ[ing] an empty chunk of data at any time [ends] the stream".

### Motivation
I believe this is not the intended behaviour. This PR has a test that captures this behaviour, and a patch to eliminate it.

### References
`#mojo` discussion over the last couple of weeks with @Grinnz and @CandyAngel (thanks!).