### PR TITLE
Add environment var to suppress "Unhandled rejected promise"

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -39,7 +39,7 @@ sub AWAIT_ON_READY {
 sub DESTROY {
   my $self = shift;
   return                                                 if $self->{handled} || ($self->{status} // '') ne 'reject';
-  carp "Unhandled rejected promise: @{$self->{results}}" if $self->{results};
+  carp "Unhandled rejected promise: @{$self->{results}}" if $self->{results} &! $ENV{MOJO_NO_PROMISE_WARN};
 }
 
 sub all         { _all(2, @_) }

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -415,6 +415,11 @@ subtest 'Warnings' => sub {
   undef $promise;
   like $warn[0], qr/Unhandled rejected promise: four/, 'unhandled';
   is $warn[1],   undef,                                'no more warnings';
+
+  @warn = ();
+  $ENV{MOJO_NO_PROMISE_WARN} = 1;
+  Mojo::Promise->reject('one');
+  is $warn[0], undef, 'no warning when environment variable set';
 };
 
 subtest 'Warnings (multiple branches)' => sub {


### PR DESCRIPTION
This adds an environment variable, MOJO_NO_PROMISE_WARN, which
disables the emission of "Unhandled rejected promise" warnings.
This is to address an issue with openQA package builds in Fedora
(but may help in other similar situations): most openQA test
suites use Test::Warnings to fail on unexpected warnings, but
when run in Fedora's package build environment where networking
is intentionally nerfed, many dozens of these "Unhandled rejected
promise" warnings are generated by many pretty normal actions.
Test::Warnings does not have a convenient way to whitelist a
known error.

Signed-off-by: Adam Williamson <awilliam@redhat.com>