### PR TITLE
Add Mojo::Loader::is_package

### DIFF
--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -6,7 +6,7 @@ use Mojo::Exception;
 use Mojo::File qw(path);
 use Mojo::Util qw(b64_decode class_to_path);
 
-our @EXPORT_OK = qw(data_section file_is_binary find_modules find_packages load_class);
+our @EXPORT_OK = qw(data_section file_is_binary find_modules find_packages load_class is_package);
 
 my (%BIN, %CACHE);
 
@@ -32,11 +32,31 @@ sub find_packages {
   return sort map { /^(.+)::$/ ? "${ns}::$1" : () } keys %{"${ns}::"};
 }
 
+sub is_package {
+  my $package = shift;
+  if($package && $package =~
+    /
+      ^
+      [a-zA-Z_]         # Can't begin from digit
+      [a-zA-Z0-9_]*
+      (?:
+          (?: :: | ' )  # Package::name eq Package'name
+          [a-zA-Z0-9_]+
+      )*
+      \z
+    /x) {
+      return 1;
+  }
+  return 0;
+}
+
+
+
 sub load_class {
   my $class = shift;
 
   # Invalid class name
-  return 1 if ($class || '') !~ /^\w(?:[\w:']*\w)?$/;
+  return 1 unless is_package($class);
 
   # Load if not already loaded
   return undef if $class->can('new') || eval "require $class; 1";
@@ -149,6 +169,14 @@ Check if embedded file from the C<DATA> section of a class was Base64 encoded.
   my @pkgs = find_packages 'MyApp::Namespace';
 
 Search for packages in a namespace non-recursively.
+
+=head2 is_package
+
+  if( is_package('a1::aaa') ){
+    say "package name valid";
+  }
+
+Check package name.
 
 =head2 find_modules
 

--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -6,7 +6,7 @@ use Mojo::Exception;
 use Mojo::File qw(path);
 use Mojo::Util qw(b64_decode class_to_path);
 
-our @EXPORT_OK = qw(data_section file_is_binary find_modules find_packages load_class is_package);
+our @EXPORT_OK = qw(data_section file_is_binary find_modules find_packages is_package load_class);
 
 my (%BIN, %CACHE);
 

--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -172,11 +172,17 @@ Search for packages in a namespace non-recursively.
 
 =head2 is_package
 
-  if( is_package('a1::aaa') ){
-    say "package name valid";
-  }
+  my $bool = is_package 'Mojo::Base';
 
-Check package name.
+Check if value is a package name.
+
+  # False
+  is_package 'MyApp.pm';
+  is_package 'My/App.pm';
+
+  # True
+  is_package 'MyApp';
+  is_package 'My::App';
 
 =head2 find_modules
 

--- a/lib/Mojolicious/Command/Author/generate/app.pm
+++ b/lib/Mojolicious/Command/Author/generate/app.pm
@@ -2,12 +2,15 @@ package Mojolicious::Command::Author::generate::app;
 use Mojo::Base 'Mojolicious::Command';
 
 use Mojo::Util qw(class_to_file class_to_path decamelize);
+use Mojo::Loader qw(is_package);
 
 has description => 'Generate Mojolicious application directory structure';
 has usage       => sub { shift->extract_usage };
 
 sub run {
   my ($self, $class) = (shift, shift || 'MyApp');
+
+  is_package($class) or die "Bad app name[$class]\n";
 
   # Script
   my $name = class_to_file $class;

--- a/lib/Mojolicious/Command/Author/generate/app.pm
+++ b/lib/Mojolicious/Command/Author/generate/app.pm
@@ -10,7 +10,7 @@ has usage       => sub { shift->extract_usage };
 sub run {
   my ($self, $class) = (shift, shift || 'MyApp');
 
-  is_package($class) or die "Bad app name[$class]\n";
+  is_package($class) or die "Can't generate application: Bad name[$class]\n";
 
   # Script
   my $name = class_to_file $class;

--- a/t/mojo/loader.t
+++ b/t/mojo/loader.t
@@ -7,7 +7,7 @@ use Test::More;
 use Mojo::File qw(curfile);
 use lib curfile->sibling('lib')->to_string;
 
-use Mojo::Loader qw(data_section file_is_binary find_packages find_modules load_class is_package);
+use Mojo::Loader qw(data_section file_is_binary find_modules find_packages is_package load_class);
  
 package MyLoaderTest::Foo::Bar;
 

--- a/t/mojo/loader.t
+++ b/t/mojo/loader.t
@@ -7,8 +7,8 @@ use Test::More;
 use Mojo::File qw(curfile);
 use lib curfile->sibling('lib')->to_string;
 
-use Mojo::Loader qw(data_section file_is_binary find_packages find_modules load_class);
-
+use Mojo::Loader qw(data_section file_is_binary find_packages find_modules load_class is_package);
+ 
 package MyLoaderTest::Foo::Bar;
 
 package MyLoaderTest::Foo::Baz;
@@ -70,6 +70,31 @@ subtest 'Search packages' => sub {
   my @pkgs = find_packages 'MyLoaderTest::Foo';
   is_deeply \@pkgs, ['MyLoaderTest::Foo::Bar', 'MyLoaderTest::Foo::Baz'], 'found the right packages';
   is_deeply [find_packages 'MyLoaderTest::DoesNotExist'], [], 'no packages found';
+};
+
+# is_package
+# To check cases use
+# perl -e"package aaa::a; print __PACKAGE__"
+
+subtest 'is_package valid' => sub {
+  ok is_package('A'), 'valid package';
+  ok is_package('a::aaa'), 'valid package';
+  ok is_package('A::aaa'), 'valid package';
+  ok is_package('a1::aaa'), 'valid package';
+  ok is_package('a1::AaA::a'), 'valid package';
+  ok is_package("a1'AaA::a"), 'valid package';
+  ok is_package('_::aaa'), 'valid package';
+  ok is_package('_::111'), 'valid package';
+};
+
+subtest 'is_package invalid' => sub {
+  ok !is_package('A:::aaa'), 'invalid package';
+  ok !is_package('1::aaa'), 'invalid package';
+  ok !is_package('a:aaa'), 'invalid package';
+  ok !is_package('a::'), 'invalid package';
+  ok !is_package("a'"), 'invalid package';
+  ok !is_package('::a'), 'invalid package';
+  ok !is_package('aa-a'), 'valid package';
 };
 
 subtest 'Load' => sub {

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -280,6 +280,10 @@ ok -e $app->rel_file('my_app/templates/layouts/default.html.ep'), 'layout exists
 ok -e $app->rel_file('my_app/templates/example/welcome.html.ep'), 'template exists';
 chdir $cwd;
 
+# generate app with bad name
+eval{$commands->run('generate', 'app', 'bad:::package')};
+is $@, "Can't generate application: Bad name[bad:::package]\n", 'right output';
+
 # generate lite_app
 require Mojolicious::Command::Author::generate::lite_app;
 $app = Mojolicious::Command::Author::generate::lite_app->new;


### PR DESCRIPTION
### Summary
Some of the app names lead to the generation of broken code. So that this does not happen, it is worth checking the app name.

### Motivation
```
$ mojo generate app app-api
```

```
$ ./app-api/script/app-api
Can't find application class "app-api" in @INC.  (/home/gr...
```

```
$ perl -wc app-api/lib/app-api.pm 
Invalid version format (negative version number) at app-api/lib/app-api.pm line 1, near "package app"
syntax error at app-api/lib/app-api.pm line 1, near "package app-"
BEGIN not safe after errors--compilation aborted at app-api/lib/app-api.pm line 2.
```

In app-api.pm bad package name

```
$ head -1 app-api/lib/app-api.pm
package app-api;
```