### PR TITLE
Fix calling of finish in EventSource example

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -903,7 +903,7 @@ for transport.
     });
 
     # Unsubscribe from "message" event again once we are done
-    $c->on(finish => sub ($c, $code, $reason = undef) {
+    $c->on(finish => sub ($c) {
       $c->app->log->unsubscribe(message => $cb);
     });
   };


### PR DESCRIPTION
### Summary
Fix the example about EventSource in the Cookbook.

### Motivation
When using the example for EventSource in the Cookbook, closing one of the listeners triggers an error because the callback expects at least parameter `$code` but receives only the Controller instance.

### References
None

### Description
The original example in the Cookbook for EventSource has this:

    # Unsubscribe from "message" event again once we are done
    $c->on(finish => sub ($c, $code, $reason = undef) {
      $c->app->log->unsubscribe(message => $cb);
    });

This is probably a copy-and-paste from the WebSocket example, but the "finish" event that is emitted by Mojo::Transaction does not provide any parameter, which makes the above call fail with an error on the number of arguments.

