### PR TITLE
add status_(un)like to Test::Mojo

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -299,6 +299,18 @@ sub status_isnt {
   return $self->test('isnt', $self->tx->res->code, $status, $desc);
 }
 
+sub status_like {
+  my ($self, $status, $desc) = @_;
+  $desc = _desc($desc, $self->tx->res->code . " like $status");
+  return $self->test('like', $self->tx->res->code, $status, $desc);
+};
+
+sub status_unlike {
+  my ($self, $status, $desc) = @_;
+  $desc = _desc($desc, $self->tx->res->code . " unlike $status");
+  return $self->test('unlike', $self->tx->res->code, $status, $desc);
+};
+
 sub test {
   my ($self, $name, @args) = @_;
   local $Test::Builder::Level = $Test::Builder::Level + 3;
@@ -1070,6 +1082,20 @@ Check response status for exact match.
   $t = $t->status_isnt(200, 'different status');
 
 Opposite of L</"status_is">.
+
+=head2 status_like
+
+  $t = $t->status_like(qr/^4/);
+  $t = $t->status_like(qr/^4/, 'some kind of error');
+
+Check response status for regex match.
+
+=head2 status_unlike
+
+  $t = $t->status_unlike(qr/^3/);
+  $t = $t->status_unlike(qr/^3/, 'not any kind of redirect');
+
+Check response status for B<not> matching a regex.
 
 =head2 test
 

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -1095,7 +1095,7 @@ Check response status for regex match.
   $t = $t->status_unlike(qr/^3/);
   $t = $t->status_unlike(qr/^3/, 'not any kind of redirect');
 
-Check response status for B<not> matching a regex.
+Opposite of L</"status_like">.
 
 =head2 test
 

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -11,6 +11,8 @@ my $t = Test::Mojo->new;
 subtest 'Basics' => sub {
   isa_ok $t->app, 'Mojolicious', 'right class';
   $t->get_ok('/')->status_is(200)->content_is('Hello Test!');
+  $t->status_like(qr/^2/);
+  $t->status_unlike(qr/^4/);
   ok $t->success, 'success';
   $t->handler(sub {1})->status_is(404);
   ok $t->success, 'success';

--- a/t/test/mojo.t
+++ b/t/test/mojo.t
@@ -11,8 +11,6 @@ my $t = Test::Mojo->new;
 subtest 'Basics' => sub {
   isa_ok $t->app, 'Mojolicious', 'right class';
   $t->get_ok('/')->status_is(200)->content_is('Hello Test!');
-  $t->status_like(qr/^2/);
-  $t->status_unlike(qr/^4/);
   ok $t->success, 'success';
   $t->handler(sub {1})->status_is(404);
   ok $t->success, 'success';
@@ -76,6 +74,20 @@ subtest 'status_is' => sub {
   is_deeply \@args, ['is', 200, 200, '200 OK'], 'right result';
   $t->status_is(404, 'some description');
   is_deeply \@args, ['is', 200, 404, 'some description'], 'right result';
+};
+
+subtest 'status_like' => sub {
+  $t->status_like(qr/^2/);
+  is_deeply \@args, ['like', 200, qr/^2/, '200 like '.qr/^2/], 'right result';
+  $t->status_like(qr/^2/, 'some description');
+  is_deeply \@args, ['like', 200, qr/^2/, 'some description'], 'right result';
+};
+
+subtest 'status_unlike' => sub {
+  $t->status_unlike(qr/^2/);
+  is_deeply \@args, ['unlike', 200, qr/^2/, '200 unlike '.qr/^2/], 'right result';
+  $t->status_unlike(qr/^2/, 'some description');
+  is_deeply \@args, ['unlike', 200, qr/^2/, 'some description'], 'right result';
 };
 
 subtest 'content_is' => sub {


### PR DESCRIPTION
### Summary
Adds two functions to Test::Mojo, `status_like` and `status_unlike`.

### Motivation
While working on a hook that looks for one particular class of error, I can easily test that the hook fires and spits out the appropriate HTTP status code by crafting some dodgy input and checking `status_is(456)`. But I also want to test that it *doesn't* fire when the input is OK (as far as that hook is concerned), and instead control passes on to the next hook or to the controller, which will whine about its input in some different way but I don't care which species of whining I happen to get as long as it's a different error. So I want `status_isnt(456)` but to still check that the status is some species of HTTP error code.

Hence `status_like(qr/^4/)`. I also implemented its inverse `status_unlike` even though I have no immediate need for it.