### PR TITLE
Unsubscribe close events for streams when resetting ioloop

### DIFF
--- a/lib/Mojo/IOLoop.pm
+++ b/lib/Mojo/IOLoop.pm
@@ -95,6 +95,7 @@ sub remove {
 
 sub reset {
   my $self = _instance(shift)->emit('reset');
+  $self->stream($_)->unsubscribe('close') for (keys %{$self->{in}}, keys %{$self->{out}});
   delete @$self{qw(accepting acceptors events in out stop)};
   $self->reactor->reset;
   $self->stop;


### PR DESCRIPTION
### Summary
No longer trigger close event for streams when resetting the ioloop.

### Motivation
This fixes the bug where child processes have such cleanup events triggered.

### References
- #1563
