### PR TITLE
subroutine main::app intentionally redefined for "eval" command

### DIFF
--- a/lib/Mojolicious/Command/eval.pm
+++ b/lib/Mojolicious/Command/eval.pm
@@ -15,7 +15,7 @@ sub run {
 
   # Run code against application
   my $app    = $self->app;
-  my $result = eval "package main; sub app; local *app = sub { \$app }; $code";
+  my $result = eval "package main; no warnings 'redefine'; sub app; local *app = sub { \$app }; $code";
   die $@ if $@;
 
   # Handle promises


### PR DESCRIPTION
This is a fixed version of PR#1576 with consistent syntax to allow a clean merge.

### Summary
suppresses a superfluous warning when using the "eval" command with a Mojolicious::Lite app

### Motivation
This came up when preparing an internal workshop about Mojolicious.

When I use even a minimal Mojolicious::Lite app as follows (say `myapp-lite.pl`):
```perl
#!perl
use Mojolicious::Lite;
app->start;
```
running `./myapp-lite.pl eval` will issue a warning: `Subroutine main::app redefined at (eval 109) line 1.`

With the equivalent full app (say `myapp-full.pl`):
```perl
#!perl
use Mojo::Base qw(-strict);
package MyApp { use Mojo::Base 'Mojolicious'; }
use Mojolicious::Commands;
Mojolicious::Commands->start_app('MyApp');
```
running `./myapp-full.pl eval` will issue no such warning.

A more realistic example like `./myapp-lite.ps eval 'say app->moniker'` (or the equivalent `myapp-full.pl eval 'say app->moniker'` will work as intended, albeit with the same distracting warning.

The patch proposes to suppress the warning specifically for the `eval` command as the redefinition is intentional.
