### PR TITLE
Mojo::Util#secure_compare fix leak of string length #1599

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -276,8 +276,8 @@ sub scope_guard { Mojo::Util::_Guard->new(cb => shift) }
 
 sub secure_compare {
   my ($one, $two) = @_;
-  return undef if length $one != length $two;
-  my $r = 0;
+  my $r = length $one != length $two;
+  $two = $one if $r;
   $r |= ord(substr $one, $_) ^ ord(substr $two, $_) for 0 .. length($one) - 1;
   return $r == 0;
 }
@@ -792,7 +792,8 @@ Create anonymous scope guard object that will execute the passed callback when t
 
   my $bool = secure_compare $str1, $str2;
 
-Constant time comparison algorithm to prevent timing attacks.
+Constant time comparison algorithm to prevent timing attacks. The secret string should be the second argument, to
+avoid leaking information about the length of the string.
 
 =head2 sha1_bytes
 


### PR DESCRIPTION
By immediately returning when the two strings are not the
same length, the function allows an attacker to guess the
length of the secret string using timing attacks.

This change uses a fix by @jberger, based on [1].

This also updates the documentation to emphasize that the
secret string should be the second argument (although it's
not critical).

[1] https://github.com/vadimdemedes/secure-compare/blob/master/index.js

### Summary

This fixes a potential leak of the length of the secret string using timing attacks.

### Motivation

The secure_compare function is not as secure as claimed.

### References

See discussion #1599.