### PR TITLE
'Sandbox' -> 'SandBox'

### DIFF
--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -407,7 +407,7 @@ L<Mojo::Exception> objects that stringify to error messages with context.
     5: %= $i * 2
     6: </body>
   Traceback (most recent call first):
-    File "template", line 4, in "Mojo::Template::Sandbox"
+    File "template", line 4, in "Mojo::Template::SandBox"
     File "path/to/Mojo/Template.pm", line 123, in "Mojo::Template"
     File "path/to/myapp.pl", line 123, in "main"
 


### PR DESCRIPTION
### Summary

Just a simple capitalization issue. 

### Motivation

When I try the example, the error message has "SandBox" instead of "Sandbox".

### References
