### PR TITLE
Provide (empty) Mojo::Promise::AWAIT_CHAIN_CANCEL method

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -10,6 +10,8 @@ use constant DEBUG => $ENV{MOJO_PROMISE_DEBUG} || 0;
 
 has ioloop => sub { Mojo::IOLoop->singleton }, weak => 1;
 
+sub AWAIT_CHAIN_CANCEL { }
+
 sub AWAIT_CLONE { _await('clone', @_) }
 
 sub AWAIT_DONE { shift->resolve(@_) }

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -7,8 +7,8 @@ plan skip_all => 'Test::Pod::Coverage 1.04+ required for this test!'  unless eva
 
 # async/await hooks
 my @await = (
-  qw(AWAIT_CLONE AWAIT_DONE AWAIT_FAIL AWAIT_GET AWAIT_IS_CANCELLED AWAIT_IS_READY AWAIT_NEW_DONE AWAIT_NEW_FAIL),
-  qw(AWAIT_ON_CANCEL AWAIT_ON_READY)
+  qw(AWAIT_CHAIN_CANCEL AWAIT_CLONE AWAIT_DONE AWAIT_FAIL AWAIT_GET AWAIT_IS_CANCELLED AWAIT_IS_READY AWAIT_NEW_DONE),
+  qw(AWAIT_NEW_FAIL AWAIT_ON_CANCEL AWAIT_ON_READY)
 );
 
 all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', @await, 'success']});


### PR DESCRIPTION
### Summary
Adds new named method for latest `Future::AsyncAwait::Awaitable` role API specification.

### Motivation
Future::AsyncAwait will expect this new name in a later version.

### References
https://metacpan.org/pod/Future::AsyncAwait::Awaitable#AWAIT_ON_CANCEL