### PR TITLE
Display help for dash commands as per hint

### DIFF
--- a/lib/Mojolicious/Commands.pm
+++ b/lib/Mojolicious/Commands.pm
@@ -35,11 +35,11 @@ sub run {
 
   # Run command
   if ($name && $name =~ /^\w[\w-]+$/ && ($name ne 'help' || $args[0])) {
-    $name =~ s/-/_/g;
 
     # Help
     $name = shift @args if my $help = $name eq 'help';
     local $ENV{MOJO_HELP} = $help = $ENV{MOJO_HELP} || $help;
+    $name =~ s/-/_/g;
 
     # Remove options shared by all commands before loading the command
     _args(\@args);

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -141,6 +141,13 @@ $buffer = '';
 {
   open my $handle, '>', \$buffer;
   local *STDOUT = $handle;
+  $commands->run('generate', 'help', 'lite-app');
+}
+like $buffer, qr/Usage: APPLICATION generate lite-app \[OPTIONS\] \[NAME\]/, 'right output';
+$buffer = '';
+{
+  open my $handle, '>', \$buffer;
+  local *STDOUT = $handle;
   $commands->run('generate', 'app', '-h');
 }
 like $buffer, qr/Usage: APPLICATION generate app \[OPTIONS\] \[NAME\]/, 'right output';


### PR DESCRIPTION
### Summary
Resolves the bug where help is not shown for commands with a dash.

### Motivation
Consistency

### References
#1610
