### PR TITLE
Fix Windows GitHub Action (GITHUB_PATH env vs add-path command)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Perl
         run: |
           choco install strawberryperl
-          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
+          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: perl -V
         run: perl -V
       - name: Install Dependencies


### PR DESCRIPTION
Refs:

- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path.

This is as mentioned on IRC:

> \<@kraih\> our windows setup for github actions is broken and needs to be updated https://github.com/mojolicious/mojo/pull/1611/checks?check_run_id=1411922741

:heart:

(As always, happy to update, rebase, amend, adjust, discuss, close, etc)