### PR TITLE
Fix typo in docs example code

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -263,8 +263,8 @@ Mojo::Promise - Promises/A+
     my $promise = Mojo::Promise->new;
     $ua->get(@_ => sub ($ua, $tx) {
       my $err = $tx->error;
-      if   (!$err || $err->{code}) { $promise->resolve($tx) }
-      else                         { $promise->reject($err->{message}) }
+      if   (!$err || !$err->{code}) { $promise->resolve($tx) }
+      else                          { $promise->reject($err->{message}) }
     });
     return $promise;
   }


### PR DESCRIPTION
Unsure if it's the right way to fix, but it looks wrong when it says "if not error or error *has* a code", because I think, say, a 404 would have a 404 code and a message and needs to be rejected.