### PR TITLE
Use split /PATTERN/ syntax consistently

### DIFF
--- a/lib/Mojo/Exception.pm
+++ b/lib/Mojo/Exception.pm
@@ -65,7 +65,7 @@ sub inspect {
   }
 
   # Search for context in sources
-  $self->_context($files[-1][1], [map { [split "\n"] } @sources]) if @sources;
+  $self->_context($files[-1][1], [map { [split /\n/] } @sources]) if @sources;
 
   return $self;
 }

--- a/lib/Mojo/Home.pm
+++ b/lib/Mojo/Home.pm
@@ -13,7 +13,7 @@ sub detect {
   # Location of the application class (Windows mixes backslash and slash)
   elsif ($class && (my $path = $INC{my $file = class_to_path $class})) {
     $home = Mojo::File->new($path)->to_array;
-    splice @$home, (my @dummy = split('/', $file)) * -1;
+    splice @$home, (my @dummy = split(/\//, $file)) * -1;
     @$home && $home->[-1] eq $_ && pop @$home for qw(lib blib);
   }
 
@@ -21,7 +21,7 @@ sub detect {
   return $self;
 }
 
-sub rel_file { shift->child(split('/', shift)) }
+sub rel_file { shift->child(split(/\//, shift)) }
 
 1;
 

--- a/lib/Mojo/JSON.pm
+++ b/lib/Mojo/JSON.pm
@@ -268,7 +268,7 @@ sub _throw {
   my $context = 'Malformed JSON: ' . shift;
   if (m/\G\z/gc) { $context .= ' before end of data' }
   else {
-    my @lines = split "\n", substr($_, 0, pos);
+    my @lines = split /\n/, substr($_, 0, pos);
     $context .= ' at line ' . @lines . ', offset ' . length(pop @lines || '');
   }
 

--- a/lib/Mojo/JSON/Pointer.pm
+++ b/lib/Mojo/JSON/Pointer.pm
@@ -13,7 +13,7 @@ sub _pointer {
 
   my $data = $self->data;
   return length $pointer ? undef : $get ? $data : 1 unless $pointer =~ s!^/!!;
-  for my $p (length $pointer ? (split '/', $pointer, -1) : ($pointer)) {
+  for my $p (length $pointer ? (split /\//, $pointer, -1) : ($pointer)) {
     $p =~ s!~1!/!g;
     $p =~ s/~0/~/g;
 

--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -17,7 +17,7 @@ sub file_is_binary { keys %{_all($_[0])} ? !!$BIN{$_[0]}{$_[1]} : undef }
 sub find_modules {
   my ($ns, $options) = (shift, shift // {});
 
-  my @ns  = split '::', $ns;
+  my @ns  = split /::/, $ns;
   my @inc = grep { -d $$_ } map { path($_, @ns) } @INC;
 
   my %modules;

--- a/lib/Mojo/Parameters.pm
+++ b/lib/Mojo/Parameters.pm
@@ -78,7 +78,7 @@ sub pairs {
     return $pairs unless length $str;
 
     my $charset = $self->charset;
-    for my $pair (split '&', $str) {
+    for my $pair (split /&/, $str) {
       next unless $pair =~ /^([^=]+)(?:=(.*))?$/;
       my ($name, $value) = ($1, $2 // '');
 

--- a/lib/Mojo/Path.pm
+++ b/lib/Mojo/Path.pm
@@ -107,7 +107,7 @@ sub _parse {
     $path                   = decode($charset, $path) // $path if $charset;
     $self->{leading_slash}  = $path =~ s!^/!!;
     $self->{trailing_slash} = $path =~ s!/$!!;
-    $self->{parts}          = [split '/', $path, -1];
+    $self->{parts}          = [split /\//, $path, -1];
   }
 
   return $self->{$name} unless @_;

--- a/lib/Mojo/Server/Daemon.pm
+++ b/lib/Mojo/Server/Daemon.pm
@@ -16,7 +16,7 @@ has [qw(backlog max_clients silent)];
 has inactivity_timeout => sub { $ENV{MOJO_INACTIVITY_TIMEOUT} // 30 };
 has ioloop             => sub { Mojo::IOLoop->singleton };
 has keep_alive_timeout => sub { $ENV{MOJO_KEEP_ALIVE_TIMEOUT} // 5 };
-has listen             => sub { [split ',', $ENV{MOJO_LISTEN} || 'http://*:3000'] };
+has listen             => sub { [split /,/, $ENV{MOJO_LISTEN} || 'http://*:3000'] };
 has max_requests       => 100;
 
 sub DESTROY {

--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -59,7 +59,7 @@ sub parse {
   # Split lines
   my $op = 'text';
   my ($trimming, $capture);
-  for my $line (split "\n", $template) {
+  for my $line (split /\n/, $template) {
 
     # Turn Perl line into mixed line
     if ($op eq 'text' && $line =~ $line_re) {
@@ -188,7 +188,7 @@ sub _compile {
 
     # Text (quote and fix line ending)
     if ($op eq 'text') {
-      $value = join "\n", map { quotemeta $_ } split("\n", $value, -1);
+      $value = join "\n", map { quotemeta $_ } split(/\n/, $value, -1);
       $value      .= '\n'                          if $newline;
       $blocks[-1] .= "\$_O .= \"" . $value . "\";" if length $value;
     }

--- a/lib/Mojo/Transaction/WebSocket.pm
+++ b/lib/Mojo/Transaction/WebSocket.pm
@@ -151,7 +151,7 @@ sub with_compression {
 sub with_protocols {
   my $self = shift;
 
-  my %protos = map { trim($_) => 1 } split ',', $self->req->headers->sec_websocket_protocol // '';
+  my %protos = map { trim($_) => 1 } split /,/, $self->req->headers->sec_websocket_protocol // '';
   return undef unless defined(my $proto = first { $protos{$_} } @_);
 
   $self->res->headers->sec_websocket_protocol($proto);

--- a/lib/Mojo/UserAgent.pm
+++ b/lib/Mojo/UserAgent.pm
@@ -109,7 +109,7 @@ sub _connect {
     @options{qw(socks_address socks_port)} = @options{qw(address port)};
     ($proto, @options{qw(address port)}) = $t->endpoint($tx);
     my $userinfo = $tx->req->via_proxy(0)->proxy->userinfo;
-    @options{qw(socks_user socks_pass)} = split ':', $userinfo if $userinfo;
+    @options{qw(socks_user socks_pass)} = split /:/, $userinfo if $userinfo;
   }
 
   # TLS

--- a/lib/Mojo/UserAgent/Proxy.pm
+++ b/lib/Mojo/UserAgent/Proxy.pm
@@ -9,7 +9,7 @@ sub detect {
   my $self = shift;
   $self->http($ENV{HTTP_PROXY}   || $ENV{http_proxy});
   $self->https($ENV{HTTPS_PROXY} || $ENV{https_proxy});
-  return $self->not([split ',', $ENV{NO_PROXY} || $ENV{no_proxy} || '']);
+  return $self->not([split /,/, $ENV{NO_PROXY} || $ENV{no_proxy} || '']);
 }
 
 sub is_needed {

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -44,7 +44,7 @@ my %ENTITIES;
   open my $file, '<', $path or croak "Unable to open html entities file ($path): $!";
   my $lines = do { local $/; <$file> };
 
-  for my $line (split "\n", $lines) {
+  for my $line (split /\n/, $lines) {
     next unless $line =~ /^(\S+)\s+U\+(\S+)(?:\s+U\+(\S+))?/;
     $ENTITIES{$1} = defined $3 ? (chr(hex $2) . chr(hex $3)) : chr(hex $2);
   }
@@ -91,8 +91,8 @@ sub camelize {
 
   # CamelCase words
   return join '::', map {
-    join('', map { ucfirst lc } split '_')
-  } split '-', $str;
+    join('', map { ucfirst lc } split /_/)
+  } split /-/, $str;
 }
 
 sub class_to_file {
@@ -111,7 +111,7 @@ sub decamelize {
   # snake_case words
   return join '-', map {
     join('_', map {lc} grep {length} split /([A-Z]{1}[^A-Z]*)/)
-  } split '::', $str;
+  } split /::/, $str;
 }
 
 sub decode {
@@ -193,7 +193,7 @@ sub punycode_decode {
   my ($n, $i, $bias, @output) = (PC_INITIAL_N, 0, PC_INITIAL_BIAS);
 
   # Consume all code points before the last delimiter
-  push @output, split('', $1) if $input =~ s/(.*)\x2d//s;
+  push @output, split(//, $1) if $input =~ s/(.*)\x2d//s;
 
   while (length $input) {
     my ($oldi, $w) = ($i, 1);
@@ -226,7 +226,7 @@ sub punycode_encode {
   my ($n, $delta, $bias) = (PC_INITIAL_N, 0, PC_INITIAL_BIAS);
 
   # Extract basic code points
-  my @input = map {ord} split '', $output;
+  my @input = map {ord} split //, $output;
   $output =~ s/[^\x00-\x7f]+//gs;
   my $h = my $basic = length $output;
   $output .= "\x2d" if $basic > 0;
@@ -334,7 +334,7 @@ sub trim {
 
 sub unindent {
   my $str = shift;
-  my $min = min map { m/^([ \t]*)/; length $1 || () } split "\n", $str;
+  my $min = min map { m/^([ \t]*)/; length $1 || () } split /\n/, $str;
   $str =~ s/^[ \t]{0,$min}//gm if $min;
   return $str;
 }

--- a/lib/Mojolicious/Command.pm
+++ b/lib/Mojolicious/Command.pm
@@ -34,7 +34,7 @@ sub extract_usage { Mojo::Util::extract_usage((caller)[1]) }
 
 sub help { print shift->usage }
 
-sub rel_file { path->child(split('/', pop)) }
+sub rel_file { path->child(split(/\//, pop)) }
 
 sub render_data {
   my ($self, $name) = (shift, shift);

--- a/lib/Mojolicious/Command/Author/generate/plugin.pm
+++ b/lib/Mojolicious/Command/Author/generate/plugin.pm
@@ -14,7 +14,7 @@ sub run {
   # Class
   my $name  = $args[0] // 'MyPlugin';
   my $class = $full ? $name : "Mojolicious::Plugin::$name";
-  my $dir   = join '-', split('::', $class);
+  my $dir   = join '-', split(/::/, $class);
   my $app   = class_to_path $class;
   $self->render_to_rel_file('class', "$dir/lib/$app", {class => $class, name => $name});
 

--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -141,7 +141,7 @@ sub template_for {
   # Normal default template
   my $stash = $c->stash;
   my ($controller, $action) = @$stash{qw(controller action)};
-  return join '/', split('-', decamelize $controller), $action if $controller && $action;
+  return join '/', split(/-/, decamelize $controller), $action if $controller && $action;
 
   # Try the route name if we don't have controller and action
   return undef unless my $route = $c->match->endpoint;
@@ -178,7 +178,7 @@ sub template_name {
 sub template_path {
   my ($self, $options) = @_;
   return undef unless my $name = $self->template_name($options);
-  my @parts = split '/', $name;
+  my @parts = split /\//, $name;
   -r and return $_ for map { path($_, @parts)->to_string } @{$self->paths}, $TEMPLATES;
   return undef;
 }

--- a/lib/Mojolicious/Routes/Pattern.pm
+++ b/lib/Mojolicious/Routes/Pattern.pm
@@ -165,7 +165,7 @@ sub _tokenize {
   my $wildcard    = $self->wildcard_start;
 
   my (@tree, $spec, $more);
-  for my $char (split '', $pattern) {
+  for my $char (split //, $pattern) {
 
     # Quoted
     if    ($char eq $quote_start) { push @tree, ['placeholder', ''] if ++$spec }

--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -41,7 +41,7 @@ sub file {
   my ($self, $rel) = @_;
 
   # Search all paths
-  my @parts = split '/', $rel;
+  my @parts = split /\//, $rel;
   for my $path (@{$self->paths}) {
     next unless my $asset = _get_file(path($path, @parts)->to_string);
     return $asset;
@@ -70,7 +70,7 @@ sub is_fresh {
 
   # If-None-Match
   $etag //= $res_headers->etag // '';
-  return undef if $match && !grep { $_ eq $etag || "W/$_" eq $etag } map { trim($_) } split ',', $match;
+  return undef if $match && !grep { $_ eq $etag || "W/$_" eq $etag } map { trim($_) } split /,/, $match;
 
   # If-Modified-Since
   return !!$match unless ($last //= $res_headers->last_modified) && $since;

--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -50,7 +50,7 @@ sub detect {
 
   # Extract and prioritize MIME types
   my %types;
-  /^\s*([^,; ]+)(?:\s*\;\s*q\s*=\s*(\d+(?:\.\d+)?))?\s*$/i and $types{lc $1} = $2 // 1 for split ',', $accept // '';
+  /^\s*([^,; ]+)(?:\s*\;\s*q\s*=\s*(\d+(?:\.\d+)?))?\s*$/i and $types{lc $1} = $2 // 1 for split /,/, $accept // '';
   my @detected = sort { $types{$b} <=> $types{$a} } sort keys %types;
 
   # Detect extensions from MIME types

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -239,22 +239,22 @@ subtest 'list/list_tree' => sub {
   is_deeply path('does_not_exist')->list->to_array, [], 'no files';
   is_deeply curfile->list->to_array, [], 'no files';
   my $lib   = curfile->sibling('lib', 'Mojo');
-  my @files = map { path($lib)->child(split '/') }
+  my @files = map { path($lib)->child(split /\//) }
     ('DeprecationTest.pm', 'LoaderException.pm', 'LoaderException2.pm', 'TestConnectProxy.pm');
   is_deeply path($lib)->list->map('to_string')->to_array, \@files, 'right files';
   unshift @files, $lib->child('.hidden.txt')->to_string;
   is_deeply path($lib)->list({hidden => 1})->map('to_string')->to_array, \@files, 'right files';
-  @files = map { path($lib)->child(split '/') } (
+  @files = map { path($lib)->child(split /\//) } (
     'BaseTest',   'DeprecationTest.pm',  'LoaderException.pm', 'LoaderException2.pm',
     'LoaderTest', 'LoaderTestException', 'Server',             'TestConnectProxy.pm'
   );
   is_deeply path($lib)->list({dir => 1})->map('to_string')->to_array, \@files, 'right files';
-  my @hidden = map { path($lib)->child(split '/') } '.hidden.txt', '.test';
+  my @hidden = map { path($lib)->child(split /\//) } '.hidden.txt', '.test';
   is_deeply path($lib)->list({dir => 1, hidden => 1})->map('to_string')->to_array, [@hidden, @files], 'right files';
 
   is_deeply path('does_not_exist')->list_tree->to_array, [], 'no files';
   is_deeply curfile->list_tree->to_array, [], 'no files';
-  @files = map { path($lib)->child(split '/') } (
+  @files = map { path($lib)->child(split /\//) } (
     'BaseTest/Base1.pm',        'BaseTest/Base2.pm',
     'BaseTest/Base3.pm',        'DeprecationTest.pm',
     'LoaderException.pm',       'LoaderException2.pm',
@@ -265,9 +265,9 @@ subtest 'list/list_tree' => sub {
     'TestConnectProxy.pm'
   );
   is_deeply path($lib)->list_tree->map('to_string')->to_array, \@files, 'right files';
-  @hidden = map { path($lib)->child(split '/') } '.hidden.txt', '.test/hidden.txt';
+  @hidden = map { path($lib)->child(split /\//) } '.hidden.txt', '.test/hidden.txt';
   is_deeply path($lib)->list_tree({hidden => 1})->map('to_string')->to_array, [@hidden, @files], 'right files';
-  my @all = map { path($lib)->child(split '/') } (
+  my @all = map { path($lib)->child(split /\//) } (
     '.hidden.txt',          '.test',
     '.test/hidden.txt',     'BaseTest',
     'BaseTest/Base1.pm',    'BaseTest/Base2.pm',
@@ -283,21 +283,21 @@ subtest 'list/list_tree' => sub {
     'TestConnectProxy.pm'
   );
   is_deeply path($lib)->list_tree({dir => 1, hidden => 1})->map('to_string')->to_array, [@all], 'right files';
-  my @one = map { path($lib)->child(split '/') }
+  my @one = map { path($lib)->child(split /\//) }
     ('DeprecationTest.pm', 'LoaderException.pm', 'LoaderException2.pm', 'TestConnectProxy.pm');
   is_deeply path($lib)->list_tree({max_depth => 1})->map('to_string')->to_array, [@one], 'right files';
-  my @one_dir = map { path($lib)->child(split '/') } (
+  my @one_dir = map { path($lib)->child(split /\//) } (
     'BaseTest',   'DeprecationTest.pm',  'LoaderException.pm', 'LoaderException2.pm',
     'LoaderTest', 'LoaderTestException', 'Server',             'TestConnectProxy.pm'
   );
   is_deeply path($lib)->list_tree({dir => 1, max_depth => 1})->map('to_string')->to_array, [@one_dir], 'right files';
-  my @two = map { path($lib)->child(split '/') } (
+  my @two = map { path($lib)->child(split /\//) } (
     'BaseTest/Base1.pm',  'BaseTest/Base2.pm',   'BaseTest/Base3.pm',        'DeprecationTest.pm',
     'LoaderException.pm', 'LoaderException2.pm', 'LoaderTest/A.pm',          'LoaderTest/B.pm',
     'LoaderTest/C.pm',    'LoaderTest/D.txt',    'LoaderTestException/A.pm', 'TestConnectProxy.pm'
   );
   is_deeply path($lib)->list_tree({max_depth => 2})->map('to_string')->to_array, [@two], 'right files';
-  my @three = map { path($lib)->child(split '/') } (
+  my @three = map { path($lib)->child(split /\//) } (
     '.hidden.txt',        '.test',               '.test/hidden.txt',     'BaseTest',
     'BaseTest/Base1.pm',  'BaseTest/Base2.pm',   'BaseTest/Base3.pm',    'DeprecationTest.pm',
     'LoaderException.pm', 'LoaderException2.pm', 'LoaderTest',           'LoaderTest/A.pm',


### PR DESCRIPTION
### Summary
Use `split /PATTERN/` rather than `split 'STRING'` where appropriate.

### Motivation
As described in its [documentation](https://perldoc.perl.org/functions/split), the first argument to split is a pattern, not a string. Even if a string is passed, it is used as a pattern. Thus using the `/PATTERN/` syntax makes it clear to the reader that it is a regex and not a string.

Note that `split ' '` (single space string) is an exception where a string must be passed to activate awk compatibility, so we leave this case alone. Also, Mojo::ByteStream's split method cannot take a bare `/PATTERN/` because in that case it would be interpreted as an immediate regex match against `$_`.

### References
https://perldoc.perl.org/functions/split
