### PR TITLE
Treat type_start in Mojolicious::Routes::Pattern as a character instead of a regex

### DIFF
--- a/lib/Mojolicious/Routes/Pattern.pm
+++ b/lib/Mojolicious/Routes/Pattern.pm
@@ -71,7 +71,7 @@ sub render {
 
     # Placeholder
     else {
-      my $name    = (split $start, $value)[0] // '';
+      my $name    = (split /\Q$start/, $value)[0] // '';
       my $default = $self->defaults->{$name};
       $part = $values->{$name} // $default // '';
       if    (!defined $default || ($default ne $part)) { $optional = 0 }

--- a/t/mojolicious/pattern.t
+++ b/t/mojolicious/pattern.t
@@ -250,4 +250,23 @@ is_deeply $result, {'bar' => 23}, 'right structure';
 is $pattern->render($result, 1), '/foo/23/baz', 'right result';
 ok !$pattern->match('/foo/bar/baz', 1), 'no result';
 
+subtest 'Alternate placeholder characters' => sub {
+  my $pattern = Mojolicious::Routes::Pattern->new->placeholder_start('|')->parse('/|test');
+  my $result  = $pattern->match('/foo');
+  is_deeply $result, {test => 'foo'}, 'right structure';
+  is $pattern->render($result, 1), '/foo', 'right result';
+  $pattern = Mojolicious::Routes::Pattern->new->relaxed_start('|')->parse('/|test');
+  $result  = $pattern->match('/foo');
+  is_deeply $result, {test => 'foo'}, 'right structure';
+  is $pattern->render($result, 1), '/foo', 'right result';
+  $pattern = Mojolicious::Routes::Pattern->new->wildcard_start('|')->parse('/|test');
+  $result  = $pattern->match('/foo');
+  is_deeply $result, {test => 'foo'}, 'right structure';
+  is $pattern->render($result, 1), '/foo', 'right result';
+  $pattern = Mojolicious::Routes::Pattern->new->types({num => qr/\d+/})->type_start('|')->parse('/<test|num>');
+  $result  = $pattern->match('/42');
+  is_deeply $result, {test => '42'}, 'right structure';
+  is $pattern->render($result, 1), '/42', 'right result';
+};
+
 done_testing();


### PR DESCRIPTION
### Summary
The type_start character passed to split is currently being treated as a regex but it should be treated as a string to split on.

### Motivation
The type_start attribute is meant to be a single character that delimits a placeholder name from its type. It was being
passed directly to split and thus used as a regex, which means any regex metacharacters would break the parsing.
Interpolate it with \Q to apply quotemeta to the character for use in split, and add tests for custom placeholder
characters.

### References

