### PR TITLE
Document and test that Mojo::ByteStream split method uses core split function semantics

### DIFF
--- a/lib/Mojo/ByteStream.pm
+++ b/lib/Mojo/ByteStream.pm
@@ -49,6 +49,9 @@ sub size { length ${$_[0]} }
 
 sub split {
   my ($self, $pat, $lim) = (shift, shift, shift // 0);
+
+  # awk compatible special case on 5.16
+  return Mojo::Collection->new(map { $self->new($_) } split ' ',  $$self, $lim) if !ref $pat and $pat eq ' ';
   return Mojo::Collection->new(map { $self->new($_) } split $pat, $$self, $lim);
 }
 
@@ -281,13 +284,19 @@ Generate URL slug for bytestream with L<Mojo::Util/"slugify">.
   my $collection = $stream->split(',');
   my $collection = $stream->split(',', -1);
 
-Turn bytestream into L<Mojo::Collection> object containing L<Mojo::ByteStream> objects.
+Turn bytestream into L<Mojo::Collection> object containing L<Mojo::ByteStream> objects with L<perlfunc/"split">.
 
   # "One,Two,Three"
   b("one,two,three")->split(',')->map('camelize')->join(',');
 
   # "One,Two,Three,,,"
   b("one,two,three,,,")->split(',', -1)->map('camelize')->join(',');
+
+  # "One,Two,Three"
+  b("one,,,two,,three")->split(',+')->map('camelize')->join(',');
+
+  # "One Two Three"
+  b("one   two\nthree")->split(' ')->map('camelize')->join(' ');
 
 =head2 tap
 

--- a/t/mojo/bytestream.t
+++ b/t/mojo/bytestream.t
@@ -115,10 +115,12 @@ subtest 'split' => sub {
   is_deeply $stream->split(qr/,/)->to_array, [1, 2, 3, 4, 5], 'right elements';
   is_deeply b('1,2,3,4,5,,,')->split(',')->to_array, [1, 2, 3, 4, 5], 'right elements';
   is_deeply b('1,2,3,4,5,,,')->split(',', -1)->to_array, [1, 2, 3, 4, 5, '', '', ''], 'right elements';
-  is_deeply b('54321')->split('')->to_array, [5, 4, 3, 2, 1], 'right elements';
-  is_deeply b('')->split('')->to_array,      [], 'no elements';
-  is_deeply b('')->split(',')->to_array,     [], 'no elements';
-  is_deeply b('')->split(qr/,/)->to_array,   [], 'no elements';
+  is_deeply b('54321')->split('')->to_array,       [5, 4, 3, 2, 1], 'right elements';
+  is_deeply b("1  2\n3")->split(' ')->to_array,    [1, 2, 3], 'right elements';
+  is_deeply b('1,,2,,3')->split(qr/,+/)->to_array, [1, 2, 3], 'right elements';
+  is_deeply b('')->split('')->to_array,            [], 'no elements';
+  is_deeply b('')->split(',')->to_array,           [], 'no elements';
+  is_deeply b('')->split(qr/,/)->to_array,         [], 'no elements';
   $stream = b('1/2/3');
   is $stream->split('/')->map(sub { $_->quote })->join(', '), '"1", "2", "3"', 'right result';
   is $stream->split('/')->map(sub { shift->quote })->join(', '), '"1", "2", "3"', 'right result';


### PR DESCRIPTION
### Summary
The first argument to Mojo::ByteStream's split method has some special treatment as it's passed directly to the split function. Add some documentation and examples to clarify this treatment - it's the pattern argument and is treated as a regex, except in the awk compatibility special case of a single space character, and the special case of an empty pattern which splits on each character.

It also may be worthwhile to suggest and document passing split patterns to this function as `qr//` regex refs rather than strings, thoughts? (this is already tested)

### Motivation
Clarify how this argument is interpreted.

### References
https://perldoc.perl.org/functions/split
