### PR TITLE
Randomize request id morbo

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -6,13 +6,14 @@ use Mojo::Cookie::Request;
 use Mojo::Util qw(b64_encode b64_decode sha1_sum);
 use Mojo::URL;
 
-my ($SEED, $COUNTER) = ($$ . time . rand, int rand 0xffffff);
-
 has env    => sub { {} };
 has method => 'GET';
 has [qw(proxy reverse_proxy)];
 has request_id => sub {
-  my $b64 = substr(sha1_base64($SEED . ($COUNTER = ($COUNTER + 1) % 0xffffff)), 0, 8);
+  state $seed    = $$ . time . rand;
+  state $counter = int rand 0xffffff;
+
+  my $b64 = substr(sha1_base64($seed . ($counter = ($counter + 1) % 0xffffff)), 0, 8);
   $b64 =~ tr!+/!-_!;
   return $b64;
 };


### PR DESCRIPTION
### Summary
Running under Morbo, any time it detects a file has changed and reloads itself, it resets `$c->req->request_id` back to its *initial* value, rather than continuing to generate new ones — i.e., it ***reuses*** old Request IDs, which makes it hard to `grep` through logs.  :-\

### Motivation
I tried to limit the blast radius of my changes to where they're actually used — just the `Mojo::Message::Request` package.

I had originally thought of promoting the SEED/COUNTER to `Mojo::EventEmitter`, and then maybe adding some kind of `app->srand()` method to re-seed the RNG, which would get called by `Mojolicious->new()` right before running `startup()`, but I figured keeping it localized, like before, was more prudent...

(PS: I'm also guessing the fact that it uses/increments lexically scoped `my` variables was an optimization to only call `rand()` once [okay, twice] up-front, rather than on every request — even though it still calls `sha1_base64` every time, which is ~25–30x slower on my machine...?  But maybe that's not necessarily true if you've replaced the RNG with something more cryptographically secure?  «shrug»)

### References
If you'd prefer that I create an issue, and then reference *that*, by all means, lemme know...