### PR TITLE
Fixed a bug in the synopsis section of the documentation

### DIFF
--- a/lib/Mojolicious/Lite.pm
+++ b/lib/Mojolicious/Lite.pm
@@ -66,8 +66,8 @@ Mojolicious::Lite - Micro real-time web framework
   # Automatically enables "strict", "warnings", "utf8" and Perl 5.16 features
   use Mojolicious::Lite;
 
-  # Route with placeholder
-  get '/:foo' => sub ($c) {
+  get '/:foo' => sub {
+    my $c = shift;
     my $foo = $c->param('foo');
     $c->render(text => "Hello from $foo.");
   };
@@ -85,6 +85,7 @@ signatures|perlsub/"Signatures">.
 
   use Mojolicious::Lite -signatures;
 
+  # Route with placeholder
   get '/:foo' => sub ($c) {
     my $foo = $c->param('foo');
     $c->render(text => "Hello from $foo.");


### PR DESCRIPTION
### Summary
Updated the very first example in the synopsis section of the Mojolicious::Lite perldoc.

### Motivation
It can be discouraging for newcomers to Mojolicious who are eager to try it out only to discover that their Hello World script throws an error **immediately**.

### References
Since the `-signatures` flag is not present in the first example, anyone who tries to copy/paste and run that code snippet will encounter an error.
