### PR TITLE
Add workflow that triggers the website to rebuild

### DIFF
--- a/.github/workflows/rebuild-website.yml
+++ b/.github/workflows/rebuild-website.yml
@@ -1,0 +1,18 @@
+name: Rebuild Website
+on:
+  push:
+    branches:
+      - master
+jobs:
+  rebuild_website:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger website workflow
+        run: |
+          curl \
+            -X POST \
+            -u "${{ secrets.WORKFLOW_DISPATCH_USERINFO }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" \
+            --data '{"ref": "master"}' \
+            https://api.github.com/repos/mojolicious/mojolicious.org/actions/workflows/docker-publish.yml/dispatches


### PR DESCRIPTION
Now that as of https://github.com/mojolicious/mojolicious.org/pull/23 the website can be automatically built and deployed, this PR adds the ability to trigger the website rebuild when pushes are made to the master branch of mojolicious itself.