### PR TITLE
allow top-level help command to output usage and list available commands

### DIFF
--- a/lib/Mojolicious/Commands.pm
+++ b/lib/Mojolicious/Commands.pm
@@ -57,7 +57,7 @@ sub run {
     return $command->run(@args);
   }
 
-  elsif ($name) { die qq{Invalid command "$name".\n} }
+  elsif ($name && $name ne 'help') { die qq{Invalid command "$name".\n} }
 
   # Hide list for tests
   return 1 if $ENV{HARNESS_ACTIVE};

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -154,6 +154,14 @@ $buffer = '';
   $commands->run('generate', 'lite-app', '--help');
 }
 like $buffer, qr/Usage: APPLICATION generate lite-app \[OPTIONS\] \[NAME\]/, 'right output';
+$buffer = '';
+{
+  open my $handle, '>', \$buffer;
+  local *STDOUT = $handle;
+  local $ENV{HARNESS_ACTIVE} = 0;
+  $commands->run('help');
+}
+like $buffer, qr/Usage: APPLICATION COMMAND \[OPTIONS\]/, 'right output';
 
 # get
 require Mojolicious::Command::get;


### PR DESCRIPTION
### Summary

Top level `mojo help` subcommand is currenlty returning `Invalid command 'help'` instead of usage and available subcommands.

### Motivation

Bring back usage and command list functionality.

### References

This closes #1629
