### PR TITLE
Trusted proxy handling to existing reverse proxy functionality

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -16,8 +16,9 @@ has request_id => sub {
   $b64 =~ tr!+/!-_!;
   return $b64;
 };
-has url       => sub { Mojo::URL->new };
-has via_proxy => 1;
+has trusted_proxies => sub { [] };
+has url             => sub { Mojo::URL->new };
+has via_proxy       => 1;
 
 sub clone {
   my $self = shift;
@@ -300,6 +301,13 @@ Proxy URL for request.
   $req     = $req->reverse_proxy($bool);
 
 Request has been performed through a reverse proxy.
+
+=head2 trusted_proxies
+
+  my $proxies = $req->trusted_proxies;
+  $req        = $req->trusted_proxies(['10.0/8', '127.0.0.1', '172.16.0/12', '192.168.0/16', 'fc00::/7']);
+
+Trusted reverse proxies, addresses or networks in CIDR form.
 
 =head2 request_id
 

--- a/lib/Mojo/Server/Hypnotoad.pm
+++ b/lib/Mojo/Server/Hypnotoad.pm
@@ -21,9 +21,10 @@ sub configure {
   $self->upgrade_timeout($c->{upgrade_timeout}) if $c->{upgrade_timeout};
 
   # Pre-fork settings
-  $prefork->reverse_proxy($c->{proxy})   if defined $c->{proxy};
-  $prefork->max_clients($c->{clients})   if $c->{clients};
-  $prefork->max_requests($c->{requests}) if $c->{requests};
+  $prefork->reverse_proxy($c->{proxy})             if defined $c->{proxy};
+  $prefork->trusted_proxies($c->{trusted_proxies}) if defined $c->{trusted_proxies};
+  $prefork->max_clients($c->{clients})             if $c->{clients};
+  $prefork->max_requests($c->{requests})           if $c->{requests};
   defined $c->{$_} and $prefork->$_($c->{$_})
     for qw(accepts backlog graceful_timeout heartbeat_interval heartbeat_timeout inactivity_timeout keep_alive_timeout),
     qw(listen pid_file spare workers);
@@ -330,6 +331,12 @@ Number of keep-alive requests per connection, defaults to the value of L<Mojo::S
 Temporarily spawn up to this number of additional workers if there is a need, defaults to the value of
 L<Mojo::Server::Prefork/"spare">. This allows for new workers to be started while old ones are still shutting down
 gracefully, drastically reducing the performance cost of worker restarts.
+
+=head2 trusted_proxies
+
+  trusted_proxies => ['10.0/8', '127.0.0.1', '172.16.0/12', '192.168.0/16', 'fc00::/7']
+
+Trusted reverse proxies, addresses or networks in CIDR form.
 
 =head2 upgrade_timeout
 

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -106,7 +106,10 @@ instead of something meaningful for the client, like this:
 
 To solve these problems, you can configure your reverse proxy to send the missing data (see L</Nginx> and
 L</"Apache/mod_proxy">) and tell your application about it by setting the environment variable C<MOJO_REVERSE_PROXY>.
-For finer control, L</Rewriting> includes examples of how the changes could be implemented manually.
+In more complex situations, usually involving multiple proxies or proxies that live outside your network, it can be
+necessary to tell the application from which ip addresses to expect proxy requests by setting C<MOJO_TRUSTED_PROXIES>
+to a list of comma separated addresses or CIDR networks. For even finer control, L</Rewriting> includes examples of how
+the changes could be implemented manually.
 
 =head1 DEPLOYMENT
 

--- a/t/mojo/hypnotoad.t
+++ b/t/mojo/hypnotoad.t
@@ -30,6 +30,7 @@ use Mojo::UserAgent;
     proxy              => 1,
     requests           => 3,
     spare              => 4,
+    trusted_proxies    => ['127.0/8'],
     upgrade_timeout    => 45,
     workers            => 7
   };
@@ -37,20 +38,21 @@ use Mojo::UserAgent;
   $hypnotoad->configure('test');
   is_deeply $hypnotoad->prefork->listen, ['http://*:8080'], 'right value';
   $hypnotoad->configure('myserver');
-  is $hypnotoad->prefork->accepts,            13, 'right value';
-  is $hypnotoad->prefork->backlog,            43, 'right value';
-  is $hypnotoad->prefork->graceful_timeout,   23, 'right value';
-  is $hypnotoad->prefork->heartbeat_interval, 7,  'right value';
-  is $hypnotoad->prefork->heartbeat_timeout,  9,  'right value';
-  is $hypnotoad->prefork->inactivity_timeout, 5,  'right value';
-  is $hypnotoad->prefork->keep_alive_timeout, 3,  'right value';
-  is_deeply $hypnotoad->prefork->listen,      ['http://*:8081'], 'right value';
-  is $hypnotoad->prefork->max_clients,        1,              'right value';
-  is $hypnotoad->prefork->max_requests,       3,              'right value';
-  is $hypnotoad->prefork->pid_file,           '/foo/bar.pid', 'right value';
-  ok $hypnotoad->prefork->reverse_proxy,      'reverse proxy enabled';
-  is $hypnotoad->prefork->spare,              4, 'right value';
-  is $hypnotoad->prefork->workers,            7, 'right value';
+  is $hypnotoad->prefork->accepts,                13, 'right value';
+  is $hypnotoad->prefork->backlog,                43, 'right value';
+  is $hypnotoad->prefork->graceful_timeout,       23, 'right value';
+  is $hypnotoad->prefork->heartbeat_interval,     7,  'right value';
+  is $hypnotoad->prefork->heartbeat_timeout,      9,  'right value';
+  is $hypnotoad->prefork->inactivity_timeout,     5,  'right value';
+  is $hypnotoad->prefork->keep_alive_timeout,     3,  'right value';
+  is_deeply $hypnotoad->prefork->listen,          ['http://*:8081'], 'right value';
+  is $hypnotoad->prefork->max_clients,            1,              'right value';
+  is $hypnotoad->prefork->max_requests,           3,              'right value';
+  is $hypnotoad->prefork->pid_file,               '/foo/bar.pid', 'right value';
+  ok $hypnotoad->prefork->reverse_proxy,          'reverse proxy enabled';
+  is $hypnotoad->prefork->spare,                  4, 'right value';
+  is_deeply $hypnotoad->prefork->trusted_proxies, ['127.0/8'], 'right value';
+  is $hypnotoad->prefork->workers,                7, 'right value';
   is $hypnotoad->upgrade_timeout, 45, 'right value';
 }
 

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -244,19 +244,48 @@ $buffer = '';
 }
 like $buffer, qr/Unknown option: unknown/, 'right output';
 
-# daemon
-require Mojolicious::Command::daemon;
-my $daemon = Mojolicious::Command::daemon->new;
-ok $daemon->description, 'has a description';
-like $daemon->usage, qr/daemon/, 'has usage information';
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDERR = $handle;
-  eval { $daemon->run('--unknown') };
-  like $@, qr/Usage: APPLICATION daemon/, 'unknown option';
-}
-like $buffer, qr/Unknown option: unknown/, 'right output';
+subtest 'daemon' => sub {
+  require Mojolicious::Command::daemon;
+
+  subtest 'Description' => sub {
+    my $command = Mojolicious::Command::daemon->new;
+    ok $command->description, 'has a description';
+    like $command->usage, qr/daemon/, 'has usage information';
+  };
+
+  subtest 'Unknown option' => sub {
+    my $command = Mojolicious::Command::daemon->new;
+    $buffer = '';
+    {
+      open my $handle, '>', \$buffer;
+      local *STDERR = $handle;
+      eval { $command->run('--unknown') };
+      like $@, qr/Usage: APPLICATION daemon/, 'unknown option';
+    }
+    like $buffer, qr/Unknown option: unknown/, 'right output';
+  };
+
+  subtest 'Proxy boolean' => sub {
+    my $command = Mojolicious::Command::daemon->new;
+    my $daemon = $command->build_server('-p');
+    ok $daemon->reverse_proxy, 'right value';
+    is_deeply $daemon->trusted_proxies, [], 'right value';
+  };
+
+  subtest 'Trusted proxies' => sub {
+    my $command = Mojolicious::Command::daemon->new;
+    my $daemon = $command->build_server('-p', '127.0/8', '-p', '10.0/8');
+    ok $daemon->reverse_proxy, 'right value';
+    is_deeply $daemon->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+  };
+
+  subtest 'Proxy boolean and trusted' => sub {
+    my $command = Mojolicious::Command::daemon->new;
+    my $daemon = $command->build_server('-p', '-p', '127.0/8', '-p', '10.0/8');
+    ok $daemon->reverse_proxy, 'right value';
+    is_deeply $daemon->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+  };
+};
 
 # eval
 require Mojolicious::Command::eval;
@@ -426,19 +455,48 @@ my $inflate = Mojolicious::Command::Author::inflate->new;
 ok $inflate->description, 'has a description';
 like $inflate->usage, qr/inflate/, 'has usage information';
 
-# prefork
-require Mojolicious::Command::prefork;
-my $prefork = Mojolicious::Command::prefork->new;
-ok $prefork->description, 'has a description';
-like $prefork->usage, qr/prefork/, 'has usage information';
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDERR = $handle;
-  eval { $prefork->run('--unknown') };
-  like $@, qr/Usage: APPLICATION prefork/, 'unknown option';
-}
-like $buffer, qr/Unknown option: unknown/, 'right output';
+subtest 'prefork' => sub {
+  require Mojolicious::Command::prefork;
+
+  subtest 'Description' => sub {
+    my $command = Mojolicious::Command::prefork->new;
+    ok $command->description, 'has a description';
+    like $command->usage, qr/prefork/, 'has usage information';
+  };
+
+  subtest 'Unknown option' => sub {
+    my $command = Mojolicious::Command::prefork->new;
+    $buffer = '';
+    {
+      open my $handle, '>', \$buffer;
+      local *STDERR = $handle;
+      eval { $command->run('--unknown') };
+      like $@, qr/Usage: APPLICATION prefork/, 'unknown option';
+    }
+    like $buffer, qr/Unknown option: unknown/, 'right output';
+  };
+
+  subtest 'Proxy boolean' => sub {
+    my $command = Mojolicious::Command::prefork->new;
+    my $prefork = $command->build_server('-p');
+    ok $prefork->reverse_proxy, 'right value';
+    is_deeply $prefork->trusted_proxies, [], 'right value';
+  };
+
+  subtest 'Trusted proxies' => sub {
+    my $command = Mojolicious::Command::prefork->new;
+    my $prefork = $command->build_server('-p', '127.0/8', '-p', '10.0/8');
+    ok $prefork->reverse_proxy, 'right value';
+    is_deeply $prefork->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+  };
+
+  subtest 'Proxy boolean and trusted' => sub {
+    my $command = Mojolicious::Command::prefork->new;
+    my $prefork = $command->build_server('-p', '-p', '127.0/8', '-p', '10.0/8');
+    ok $prefork->reverse_proxy, 'right value';
+    is_deeply $prefork->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+  };
+};
 
 # psgi
 require Mojolicious::Command::psgi;


### PR DESCRIPTION
Both when using self-hosted kubernetes with ingresses and using external cloud proxy services, it is useful to have the ability mark certain proxies as trusted, ignoring their entries in the X-Forwarded-For header and getting the true client's ip address. While there are plugins on CPAN that can do this, those are hard to add to existing pre-built applications which would have to load them, and their mechanism to do so (hooks and rewriting) is heavier that what can be done in core (during message parsing).

This PR adds this ability to core, keeping the implementation as simple as possible and using only core libraries.