### PR TITLE
Use a constant for empty arrayref defaults

### DIFF
--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -12,6 +12,7 @@ use overload
 use Mojo::Collection;
 use Mojo::DOM::CSS;
 use Mojo::DOM::HTML;
+use Mojo::Util;
 use Scalar::Util qw(blessed weaken);
 use Storable qw(dclone);
 
@@ -229,7 +230,7 @@ sub _ancestors {
 sub _build { shift->new->tree(shift)->xml(shift) }
 
 sub _collect {
-  my ($self, $nodes) = (shift, shift // []);
+  my ($self, $nodes) = (shift, shift // Mojo::Util::_EMPTY_ARRAY);
   my $xml = $self->xml;
   return Mojo::Collection->new(map { $self->_build($_, $xml) } @$nodes);
 }

--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -4,6 +4,7 @@ use Mojo::Base -base;
 use Carp qw(carp);
 use Mojo::Exception;
 use Mojo::IOLoop;
+use Mojo::Util;
 use Scalar::Util qw(blessed);
 
 use constant DEBUG => $ENV{MOJO_PROMISE_DEBUG} || 0;
@@ -19,7 +20,7 @@ sub AWAIT_FAIL { shift->reject(@_) }
 
 sub AWAIT_GET {
   my $self    = shift;
-  my @results = @{$self->{results} // []};
+  my @results = @{$self->{results} // Mojo::Util::_EMPTY_ARRAY};
   die $results[0] unless $self->{status} eq 'resolve';
   return wantarray ? @results : $results[0];
 }

--- a/lib/Mojo/UserAgent/Proxy.pm
+++ b/lib/Mojo/UserAgent/Proxy.pm
@@ -2,6 +2,7 @@ package Mojo::UserAgent::Proxy;
 use Mojo::Base -base;
 
 use Mojo::URL;
+use Mojo::Util;
 
 has [qw(http https not)];
 
@@ -13,7 +14,7 @@ sub detect {
 }
 
 sub is_needed {
-  !grep { $_[1] =~ /\Q$_\E$/ } @{$_[0]->not // []};
+  !grep { $_[1] =~ /\Q$_\E$/ } @{$_[0]->not // Mojo::Util::_EMPTY_ARRAY};
 }
 
 sub prepare {

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -23,6 +23,12 @@ use Unicode::Normalize ();
 # Check for monotonic clock support
 use constant MONOTONIC => eval { !!Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC()) };
 
+# Speed up @{ $foo // [] } and similar by avoiding having to construct a new empty arrayref each time
+use constant _EMPTY_ARRAY => [];
+
+# Make sure nobody accidentally modifies the referenced array
+BEGIN { Internals::SvREADONLY(@{+_EMPTY_ARRAY}, 1) }
+
 # Punycode bootstring parameters
 use constant {
   PC_BASE         => 36,

--- a/lib/Mojolicious/Command/routes.pm
+++ b/lib/Mojolicious/Command/routes.pm
@@ -27,7 +27,7 @@ sub _walk {
 
   # Flags
   my @flags;
-  push @flags, @{$route->requires // []} ? 'C' : '.';
+  push @flags, @{$route->requires // Mojo::Util::_EMPTY_ARRAY} ? 'C' : '.';
   push @flags, (my $partial = $route->partial) ? 'P' : '.';
   push @flags, $route->inline       ? 'U' : '.';
   push @flags, $route->is_websocket ? 'W' : '.';

--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -168,7 +168,7 @@ sub template_name {
   my $handler = $options->{handler};
   if (defined(my $variant = $options->{variant})) {
     $variant = "$template+$variant";
-    my $handlers = $self->{templates}{$variant} // [];
+    my $handlers = $self->{templates}{$variant} // Mojo::Util::_EMPTY_ARRAY;
     $template = $variant if @$handlers && !defined $handler || grep { $_ eq $handler } @$handlers;
   }
 

--- a/lib/Mojolicious/Routes/Route.pm
+++ b/lib/Mojolicious/Routes/Route.pm
@@ -130,7 +130,7 @@ sub suggested_method {
 
   my %via;
   for my $route (@{$self->_chain}) {
-    next unless my @via = @{$route->methods // []};
+    next unless my @via = @{$route->methods // Mojo::Util::_EMPTY_ARRAY};
     %via = map { $_ => 1 } keys %via ? grep { $via{$_} } @via : @via;
   }
 

--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -2,6 +2,7 @@ package Mojolicious::Types;
 use Mojo::Base -base;
 
 use Mojo::File qw(path);
+use Mojo::Util;
 
 has mapping => sub {
   {
@@ -62,7 +63,7 @@ sub detect {
     push @{$reverse{$_}}, $ext for map { s/\;.*$//; lc $_ } @types;
   }
 
-  return [map { @{$reverse{$_} // []} } @detected];
+  return [map { @{$reverse{$_} // Mojo::Util::_EMPTY_ARRAY} } @detected];
 }
 
 sub file_type { $_[0]->type(path($_[1])->extname) }

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -352,13 +352,13 @@ sub _handler {
 
 sub _json {
   my ($self, $method, $p) = @_;
-  return Mojo::JSON::Pointer->new(j(@{$self->message // []}[1]))->$method($p);
+  return Mojo::JSON::Pointer->new(j(@{$self->message // Mojo::Util::_EMPTY_ARRAY}[1]))->$method($p);
 }
 
 sub _message {
   my ($self, $name, $value, $desc) = @_;
   local $Test::Builder::Level = $Test::Builder::Level + 1;
-  my ($type, $msg) = @{$self->message // []};
+  my ($type, $msg) = @{$self->message // Mojo::Util::_EMPTY_ARRAY};
 
   # Type check
   if (ref $value eq 'HASH') {


### PR DESCRIPTION
### Summary

This micro-optimises cases where the arraref is immediately
dereferenced and not passed to things that might subsequently modify it.

### Motivation

This replaces the anonlist+pushmark of [] with a const RV in the
optree, which is nearly three times as fast, according to this
microbenchmark:

    $ perl -MBenchmark::Dumb=cmpthese -e '
      use constant empty => []; my $foo;
      cmpthese(0.001, {
        const => sub { @{ $foo // empty } },
        array => sub { @{ $foo // [] } },
      })'
                         Rate       array  const
    array 1.2869e+07+-22000/s          -- -75.1%
    const 5.166e+07+-220000/s 301.4+-1.8%     --
