### PR TITLE
Delay app log stringification

### DIFF
--- a/lib/Mojo/Log.pm
+++ b/lib/Mojo/Log.pm
@@ -69,13 +69,9 @@ sub _log {
   my @msgs = ref $_[0] eq 'CODE' ? $_[0]() : @_;
   if ($self->{context}) {
     if (@msgs == 1 && blessed($msgs[0]) && $msgs[0]->isa('Mojo::Exception')) {
-      $msgs[0] = Mojo::Exception
-        ->new("$self->{context} ".$msgs[0]->message)
-        ->frames($msgs[0]->frames)
-        ->line($msgs[0]->line)
-        ->lines_after($msgs[0]->lines_after)
-        ->lines_before($msgs[0]->lines_before)
-        ->verbose($msgs[0]->verbose);
+      $msgs[0]
+        = Mojo::Exception->new("$self->{context} " . $msgs[0]->message)->frames($msgs[0]->frames)->line($msgs[0]->line)
+        ->lines_after($msgs[0]->lines_after)->lines_before($msgs[0]->lines_before)->verbose($msgs[0]->verbose);
     }
     else {
       $msgs[0] = "$self->{context} $msgs[0]";

--- a/t/mojolicious/log_delayed_stringification.t
+++ b/t/mojolicious/log_delayed_stringification.t
@@ -5,10 +5,11 @@ use Test::Mojo;
 use Test::More;
 
 {
-    package Mojolicious::Test::Log; # an app that dies
-    use Mojolicious::Lite;
 
-    get '/error' => sub { die "Log Me" };
+  package Mojolicious::Test::Log;    # an app that dies
+  use Mojolicious::Lite;
+
+  get '/error' => sub { die "Log Me" };
 }
 
 local $ENV{MOJO_LOG_LEVEL} = 'info';
@@ -16,18 +17,20 @@ my $t   = Test::Mojo->new('Mojolicious::Test::Log');
 my $app = $t->app;
 
 my $logged_an_error = 0;
+
 # simpler case of real-world use in Mojolicious::Plugin::Log::Any
-$app->log->unsubscribe('message')->on(message => sub {
+$app->log->unsubscribe('message')->on(
+  message => sub {
     my ($log, $level, @lines) = @_;
     if ($level eq 'error') {
-        $logged_an_error = 1;
-        isa_ok($lines[0], 'Mojo::Exception') or diag explain $lines[0];
+      $logged_an_error = 1;
+      isa_ok($lines[0], 'Mojo::Exception') or diag explain $lines[0];
     }
-});
+  }
+);
 
 # this succeeds, but the isa_ok above fails
-$t->get_ok('/error')
-  ->status_is(500 => 'threw exception');
+$t->get_ok('/error')->status_is(500 => 'threw exception');
 
 # sanity check
 ok $logged_an_error, "ran error testing above";

--- a/t/mojolicious/log_delayed_stringification.t
+++ b/t/mojolicious/log_delayed_stringification.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+
+use Test::Mojo;
+use Test::More;
+
+{
+    package Mojolicious::Test::Log; # an app that dies
+    use Mojolicious::Lite;
+
+    get '/error' => sub { die "Log Me" };
+}
+
+my $t   = Test::Mojo->new('Mojolicious::Test::Log');
+my $app = $t->app;
+
+my $logged_an_error = 0;
+# simpler case of real-world use in Mojolicious::Plugin::Log::Any
+$app->log->unsubscribe('message')->on(message => sub {
+    my ($log, $level, @lines) = @_;
+    if ($level eq 'error') {
+        $logged_an_error = 1;
+        isa_ok($lines[0], 'Mojo::Exception') or diag explain $lines[0];
+    }
+});
+
+local $ENV{MOJO_LOG_LEVEL} = 'info';
+# this succeeds, but the isa_ok above fails
+$t->get_ok('/error')
+  ->status_is(500 => 'threw exception');
+
+# sanity check
+ok $logged_an_error, "ran error testing above";
+
+done_testing();

--- a/t/mojolicious/log_delayed_stringification.t
+++ b/t/mojolicious/log_delayed_stringification.t
@@ -11,6 +11,7 @@ use Test::More;
     get '/error' => sub { die "Log Me" };
 }
 
+local $ENV{MOJO_LOG_LEVEL} = 'info';
 my $t   = Test::Mojo->new('Mojolicious::Test::Log');
 my $app = $t->app;
 
@@ -24,7 +25,6 @@ $app->log->unsubscribe('message')->on(message => sub {
     }
 });
 
-local $ENV{MOJO_LOG_LEVEL} = 'info';
 # this succeeds, but the isa_ok above fails
 $t->get_ok('/error')
   ->status_is(500 => 'threw exception');


### PR DESCRIPTION
### Summary
This tweaks `Mojo::Log` to delay `Mojo::Exception` stringification until *after* it emits the message.

### Motivation
The primary motivation is to give non-default loggers (like [Mojolicious::Plugin::Log::Any](https://metacpan.org/pod/Mojolicious%3A%3APlugin%3A%3ALog%3A%3AAny)) direct access to the `Mojo::Exception` being logged (which allows logging of a stack trace via eg. [Log::Any::Adapter::Sentry::Raven](https://metacpan.org/pod/Log%3A%3AAny%3A%3AAdapter%3A%3ASentry%3A%3ARaven)).

A secondary motivation is to provide consistency in what non-default loggers receive, regardless of whether the sending logger has a context or not.

### References
This was originally reported in #1499.
There has been some discussion about this on IRC. One concern raised was that of performance. To that end, https://gist.github.com/jrubinator/387dcac4635942641bc85b82e91f41e4 details what I saw regarding performance. Quoting,

> I saw little, if any, performance regression.
> ...
> 
> This table contains the net requests/second (across all threads)
> The first one is from the one-minute run.
> The second is from the five-minute run.
> ...
>
> TL;DR
> Setup | Regular-Call | Mojo-Exception | Custom-Exception
> ------------ | -------------|------------ | -------------
> Old Code+Development   |  809.63 / 803.89 |    187.36/246.77  | 776.23/764.71
> Old Code+Production   |  1098.18/1102.15 |    442.26/420.58  | 935.83/916.78
> New Code+Development |     805.10/ 803.28 |    181.07/247.63  | 761.39/759.00
> New Code+Production    | 1105.91/1108.10    | 429.07/415.89  | 909.28/910.12