### PR TITLE
Prevent unintended subprocess side effects by freezing the current state

### DIFF
--- a/lib/Mojo/IOLoop/Subprocess.pm
+++ b/lib/Mojo/IOLoop/Subprocess.pm
@@ -49,7 +49,7 @@ sub _start {
   return $self->$parent("Can't fork: $!") unless defined(my $pid = $self->{pid} = fork);
   unless ($pid) {
     eval {
-      $self->ioloop->reset;
+      $self->ioloop->reset({freeze => 1});
       my $results = eval { [$self->$child] } // [];
       print {$self->{writer}} '0-', $self->serialize->([$@, @$results]);
       $self->emit('cleanup');


### PR DESCRIPTION
This is a possible solution for #1563. It sidesteps the original problem by keeping all the original state active, but hidden away. The event loop is reset with a fresh reactor instance. In the case of `Mojo::Reactor::EV` this means that all subprocesses will end up with `Mojo::Reactor::Poll`. Which is probably an advantage.
