### PR TITLE
Accept MOJO_TRUSTED_PROXIES when -p is not given

### DIFF
--- a/lib/Mojolicious/Command/daemon.pm
+++ b/lib/Mojolicious/Command/daemon.pm
@@ -23,7 +23,8 @@ sub build_server {
 
   $daemon->listen(\@listen) if @listen;
   $daemon->reverse_proxy(1) if @proxy;
-  $daemon->trusted_proxies([grep {length} @proxy]);
+  my @trusted = grep {length} @proxy;
+  $daemon->trusted_proxies(\@trusted) if @trusted;
   return $daemon;
 }
 

--- a/lib/Mojolicious/Command/prefork.pm
+++ b/lib/Mojolicious/Command/prefork.pm
@@ -30,7 +30,8 @@ sub build_server {
 
   $prefork->listen(\@listen) if @listen;
   $prefork->reverse_proxy(1) if @proxy;
-  $prefork->trusted_proxies([grep {length} @proxy]);
+  my @trusted = grep {length} @proxy;
+  $prefork->trusted_proxies(\@trusted) if @trusted;
   return $prefork;
 }
 

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -279,6 +279,14 @@ subtest 'daemon' => sub {
     is_deeply $daemon->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
   };
 
+  subtest 'Trusted proxies from environment' => sub {
+    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8,10.0/8';
+    my $command = Mojolicious::Command::daemon->new;
+    my $daemon  = $command->build_server;
+    ok $daemon->reverse_proxy, 'right value';
+    is_deeply $daemon->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+  };
+
   subtest 'Proxy boolean and trusted' => sub {
     my $command = Mojolicious::Command::daemon->new;
     my $daemon  = $command->build_server('-p', '-p', '127.0/8', '-p', '10.0/8');
@@ -486,6 +494,14 @@ subtest 'prefork' => sub {
   subtest 'Trusted proxies' => sub {
     my $command = Mojolicious::Command::prefork->new;
     my $prefork = $command->build_server('-p', '127.0/8', '-p', '10.0/8');
+    ok $prefork->reverse_proxy, 'right value';
+    is_deeply $prefork->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+  };
+
+  subtest 'Trusted proxies from environment' => sub {
+    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8,10.0/8';
+    my $command = Mojolicious::Command::prefork->new;
+    my $prefork = $command->build_server;
     ok $prefork->reverse_proxy, 'right value';
     is_deeply $prefork->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
   };


### PR DESCRIPTION
The golfing of the daemon and prefork commands was too aggressive and it meant that command line invocations essentially could not use the environment variables.
