### PR TITLE
Add subtests in tls.t and enable TEST_TLS on Linux.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,10 +29,39 @@ jobs:
       - name: Install dependencies
         run: |
           cpanm -n --installdeps .
-          cpanm -n Cpanel::JSON::XS EV Role::Tiny
+          cpanm -n Cpanel::JSON::XS EV Role::Tiny IO::Socket::SSL
           cpanm -n Test::Pod Test::Pod::Coverage
+      - name: Generate temporary SSL certificates
+        run: |
+          openssl genrsa -out $CERT_DIR/ca.key $BITS
+          openssl req -new -key $CERT_DIR/ca.key -out $CERT_DIR/ca.csr -subj "/C=US/CN=ca"
+          openssl req -x509 -days $DAYS -key $CERT_DIR/ca.key -in $CERT_DIR/ca.csr -out $CERT_DIR/ca.crt
+
+          openssl genrsa -out $CERT_DIR/server.key $BITS
+          openssl req -new -key $CERT_DIR/server.key -out $CERT_DIR/server.csr -subj "/C=US/CN=127.0.0.1"
+          openssl x509 -req -days $DAYS -in $CERT_DIR/server.csr -out $CERT_DIR/server.crt -CA $CERT_DIR/ca.crt \
+            -CAkey $CERT_DIR/ca.key -CAcreateserial
+
+          openssl genrsa -out $CERT_DIR/client.key $BITS
+          openssl req -new -key $CERT_DIR/client.key -out $CERT_DIR/client.csr -subj "/C=US/CN=127.0.0.1"
+          openssl x509 -req -days $DAYS -in $CERT_DIR/client.csr -out $CERT_DIR/client.crt -CA $CERT_DIR/ca.crt \
+            -CAkey $CERT_DIR/ca.key -CAcreateserial
+
+          openssl genrsa -out $CERT_DIR/bad.key $BITS
+          openssl req -new -key $CERT_DIR/bad.key -out $CERT_DIR/bad.csr -subj "/C=US/CN=bad"
+          openssl req -x509 -days $DAYS -key $CERT_DIR/bad.key -in $CERT_DIR/bad.csr -out $CERT_DIR/bad.crt
+
+          openssl x509 -noout -serial -dates -subject -issuer -in $CERT_DIR/ca.crt
+          openssl x509 -noout -serial -dates -subject -issuer -in $CERT_DIR/server.crt
+          openssl x509 -noout -serial -dates -subject -issuer -in $CERT_DIR/client.crt
+          openssl x509 -noout -serial -dates -subject -issuer -in $CERT_DIR/bad.crt
+        env:
+          CERT_DIR: t/mojo/certs
+          BITS: 2048
+          DAYS: 1
       - name: Run tests
         run: prove -l t t/mojo t/mojolicious
         env:
           TEST_POD: 1
           TEST_EV: 1
+          TEST_TLS: 1

--- a/t/mojo/ioloop_tls.t
+++ b/t/mojo/ioloop_tls.t
@@ -8,22 +8,22 @@ use Mojo::IOLoop::TLS;
 plan skip_all => 'set TEST_TLS to enable this test (developer only!)' unless $ENV{TEST_TLS} || $ENV{TEST_ALL};
 plan skip_all => 'IO::Socket::SSL 2.009+ required for this test!'     unless Mojo::IOLoop::TLS->can_tls;
 
-# To regenerate all required certificates run these commands (12.12.2014)
-# openssl genrsa -out ca.key 1024
+# To regenerate all required certificates run these commands (16.09.2020)
+# openssl genrsa -out ca.key 2048
 # openssl req -new -key ca.key -out ca.csr -subj "/C=US/CN=ca"
 # openssl req -x509 -days 7300 -key ca.key -in ca.csr -out ca.crt
 #
-# openssl genrsa -out server.key 1024
+# openssl genrsa -out server.key 2048
 # openssl req -new -key server.key -out server.csr -subj "/C=US/CN=127.0.0.1"
 # openssl x509 -req -days 7300 -in server.csr -out server.crt -CA ca.crt \
 #   -CAkey ca.key -CAcreateserial
 #
-# openssl genrsa -out client.key 1024
+# openssl genrsa -out client.key 2048
 # openssl req -new -key client.key -out client.csr -subj "/C=US/CN=127.0.0.1"
 # openssl x509 -req -days 7300 -in client.csr -out client.crt -CA ca.crt \
 #   -CAkey ca.key -CAcreateserial
 #
-# openssl genrsa -out bad.key 1024
+# openssl genrsa -out bad.key 2048
 # openssl req -new -key bad.key -out bad.csr -subj "/C=US/CN=bad"
 # openssl req -x509 -days 7300 -key bad.key -in bad.csr -out bad.crt
 use Mojo::IOLoop;

--- a/t/mojo/user_agent_tls.t
+++ b/t/mojo/user_agent_tls.t
@@ -77,7 +77,7 @@ $listen
   . '&ca=t/mojo/certs/ca.crt'
   . '&ciphers=AES256-SHA:ALL'
   . '&verify=0x00'
-  . '&version=TLSv1';
+  . '&version=TLSv1_2';
 $port = $daemon->listen([$listen])->start->ports->[0];
 
 # Invalid certificate
@@ -90,6 +90,6 @@ $ua->cert('t/mojo/certs/bad.crt')->key('t/mojo/certs/bad.key');
 $tx = $ua->get("https://127.0.0.1:$port");
 ok !$tx->error, 'no error';
 is $ua->ioloop->stream($tx->connection)->handle->get_cipher,     'AES256-SHA', 'AES256-SHA has been negotiatied';
-is $ua->ioloop->stream($tx->connection)->handle->get_sslversion, 'TLSv1',      'TLSv1 has been negotiatied';
+is $ua->ioloop->stream($tx->connection)->handle->get_sslversion, 'TLSv1_2',    'TLSv1_2 has been negotiatied';
 
 done_testing();


### PR DESCRIPTION
### Summary
Continuous integration testing TLS is not currently done. The built-in certificates use only 1024 bits and result in `ee key too small` error. These are regenerated before the tests step here and TLS testing is enabled, but new certs could equally be committed and the extra step removed. The latter should probably be done by a trusted party so I've chosen the former for this PR.

### Motivation
Increasing coverage of CI by testing TLS and continuing move to subtests (`tls.t`)

### References
#1520
