### PR TITLE
Fixes CGI port

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -153,6 +153,9 @@ sub _parse_env {
   my $headers = $self->headers;
   my $url     = $self->url;
   my $base    = $url->base;
+
+  my $port = $env->{SERVER_PORT};
+
   for my $name (keys %$env) {
     my $value = $env->{$name};
     next unless $name =~ s/^HTTP_//i;
@@ -160,8 +163,13 @@ sub _parse_env {
     $headers->header($name => $value);
 
     # Host/Port
-    $value =~ s/:(\d+)$// ? $base->host($value)->port($1) : $base->host($value) if $name eq 'HOST';
+    if ($name eq 'HOST') {
+      $value =~ s/:(\d+)$//;
+      $base->host($value);
+      $port //= $1;
+    }
   }
+  $base->port($port) if $port;
 
   # Content-Type is a special case on some servers
   $headers->content_type($env->{CONTENT_TYPE}) if $env->{CONTENT_TYPE};

--- a/t/mojo/request_cgi.t
+++ b/t/mojo/request_cgi.t
@@ -291,6 +291,38 @@ subtest 'Parse Apache 2.2.14 CGI environment variables and body (root)' => sub {
   is $req->url->to_abs->to_string, 'http://127.0.0.1:13028/upload/', 'right absolute URL';
 };
 
+subtest 'SERVER_PORT (spec) superior to HTTP_HOST (not-spec)' => sub {
+  my $req = Mojo::Message::Request->new;
+  $req->parse({
+    SCRIPT_NAME       => '/upload',
+    SERVER_NAME       => '127.0.0.1',
+    SERVER_ADMIN      => '[no address given]',
+    PATH_INFO         => '/upload',
+    HTTP_CONNECTION   => 'Keep-Alive',
+    REQUEST_METHOD    => 'POST',
+    CONTENT_LENGTH    => '11',
+    SCRIPT_FILENAME   => '/tmp/SnLu1cQ3t2/test.fcgi',
+    SERVER_SOFTWARE   => 'Apache/2.2.14 (Unix) mod_fastcgi/2.4.2',
+    QUERY_STRING      => '',
+    REMOTE_PORT       => '58232',
+    HTTP_USER_AGENT   => 'Mojolicious (Perl)',
+    SERVER_PORT       => '13042',                                              # NOTE: When this line is present
+    SERVER_SIGNATURE  => '',
+    REMOTE_ADDR       => '127.0.0.1',
+    CONTENT_TYPE      => 'application/x-www-form-urlencoded; charset=UTF-8',
+    SERVER_PROTOCOL   => 'HTTP/1.1',
+    REQUEST_URI       => '/upload',
+    GATEWAY_INTERFACE => 'CGI/1.1',
+    SERVER_ADDR       => '127.0.0.1',
+    DOCUMENT_ROOT     => '/tmp/SnLu1cQ3t2',
+    PATH_TRANSLATED   => '/tmp/test.fcgi/upload',
+    HTTP_HOST         => '127.0.0.1:13028'                                     # NOTE: Ignore this PORT.
+  });
+  $req->parse('hello=world');
+  is $req->url->base->port,        13042,                            'right base port';       # from SERVER_PORT
+  is $req->url->to_abs->to_string, 'http://127.0.0.1:13042/upload/', 'right absolute URL';    # from SERVER_PORT
+};
+
 subtest 'Parse Apache 2.2.11 CGI environment variables and body (HTTPS=ON)' => sub {
   my $req = Mojo::Message::Request->new;
   $req->parse({


### PR DESCRIPTION
Source the port in CGI from `SERVER_PORT`, as per spec rather than just expecting to find it in the non-started `HTTP_HOST`. Detailed in #1466

### Summary
Previously we ignored `SERVER_PORT`. Now we source it as the primary information and only if it doesn't exist do we fall back to `HTTP_HOST` (which is non-standard). Not in all of the tests prior to this patch `SERVER_PORT` was provided and should have been used per the CGI spec, that it wasn't was a bug. However, the `SERVER_PORT` in all of the tests was also the same as `HTTP_HOST`, so the bug never caught by the tests. Moreover, the bug only occurs when either (a) only `SERVER_PORT` is provided, or (b) the `SERVER_PORT` is different from the `HTTP_HOST`.

### Motivation
This is simply a broken version of CGI as-is. Though it probably only effects you if you run CGI on a non-standard port outside of Apache (which also provides the non-standard `HTTP_HOST` that we accommodate). At cPanel we have our own web server, `cpservd` which does not set `HTTP_HOST`. It does set `SERVER_PORT`. Without this patch url generation in Mojo is broken.

### References
#1466 (issue referencing)
#1467 (last pull request)