### PR TITLE
Disallow short-form ipv4 networks

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -305,7 +305,7 @@ Request has been performed through a reverse proxy.
 =head2 trusted_proxies
 
   my $proxies = $req->trusted_proxies;
-  $req        = $req->trusted_proxies(['10.0/8', '127.0.0.1', '172.16.0/12', '192.168.0/16', 'fc00::/7']);
+  $req        = $req->trusted_proxies(['10.0.0.0/8', '127.0.0.1', '172.16.0.0.0/12', '192.168.0.0/16', 'fc00::/7']);
 
 Trusted reverse proxies, addresses or networks in CIDR form.
 

--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -138,7 +138,7 @@ or true if L</trusted_proxies> is not empty.
 =head2 trusted_proxies
 
   my $proxies = $server->trusted_proxies;
-  $server     = $server->trusted_proxies(['10.0/8', '127.0.0.1', '172.16.0/12', '192.168.0/16', 'fc00::/7']);
+  $server     = $server->trusted_proxies(['10.0.0.0/8', '127.0.0.1', '172.16.0.0/12', '192.168.0.0/16', 'fc00::/7']);
 
 This server expects requests from trusted reverse proxies, defaults to the value of the C<MOJO_TRUSTED_PROXIES>
 environment variable split on commas with optional whitespace. These proxies should be addresses or networks in CIDR

--- a/lib/Mojo/Server/Hypnotoad.pm
+++ b/lib/Mojo/Server/Hypnotoad.pm
@@ -334,7 +334,7 @@ gracefully, drastically reducing the performance cost of worker restarts.
 
 =head2 trusted_proxies
 
-  trusted_proxies => ['10.0/8', '127.0.0.1', '172.16.0/12', '192.168.0/16', 'fc00::/7']
+  trusted_proxies => ['10.0.0.0/8', '127.0.0.1', '172.16.0.0/12', '192.168.0.0/16', 'fc00::/7']
 
 Trusted reverse proxies, addresses or networks in CIDR form.
 

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -15,7 +15,7 @@ use IO::Uncompress::Gunzip;
 use List::Util qw(min);
 use MIME::Base64 qw(decode_base64 encode_base64);
 use Pod::Usage qw(pod2usage);
-use Socket qw(inet_aton inet_pton AF_INET6);
+use Socket qw(inet_pton AF_INET6 AF_INET);
 use Sub::Util qw(set_subname);
 use Symbol qw(delete_package);
 use Time::HiRes        ();
@@ -194,8 +194,8 @@ sub network_contains {
   return undef if $v6 xor $addr =~ /:/;
 
   # Convert addresses to binary
-  return undef unless $net  = $v6 ? inet_pton(AF_INET6, $net)  : inet_aton($net);
-  return undef unless $addr = $v6 ? inet_pton(AF_INET6, $addr) : inet_aton($addr);
+  return undef unless $net  = inet_pton($v6 ? AF_INET6 : AF_INET, $net);
+  return undef unless $addr = inet_pton($v6 ? AF_INET6 : AF_INET, $addr);
   my $length = $v6 ? 128 : 32;
 
   # Apply mask if given

--- a/lib/Mojolicious/Command/daemon.pm
+++ b/lib/Mojolicious/Command/daemon.pm
@@ -47,7 +47,7 @@ Mojolicious::Command::daemon - Daemon command
     ./myapp.pl daemon -l http://127.0.0.1:8080 -l https://[::]:8081
     ./myapp.pl daemon -l 'https://*:443?cert=./server.crt&key=./server.key'
     ./myapp.pl daemon -l http+unix://%2Ftmp%2Fmyapp.sock
-    ./myapp.pl daemon -l http://127.0.0.1:8080 -p 127.0/8 -p fc00::/7
+    ./myapp.pl daemon -l http://127.0.0.1:8080 -p 127.0.0.0/8 -p fc00::/7
 
   Options:
     -b, --backlog <size>                 Listen backlog size, defaults to

--- a/lib/Mojolicious/Command/prefork.pm
+++ b/lib/Mojolicious/Command/prefork.pm
@@ -54,7 +54,7 @@ Mojolicious::Command::prefork - Pre-fork command
     ./myapp.pl prefork -l http://127.0.0.1:8080 -l https://[::]:8081
     ./myapp.pl prefork -l 'https://*:443?cert=./server.crt&key=./server.key'
     ./myapp.pl prefork -l http+unix://%2Ftmp%2Fmyapp.sock -w 12
-    ./myapp.pl prefork -l http://127.0.0.1:8080 -p 127.0/8 -p fc00::/7
+    ./myapp.pl prefork -l http://127.0.0.1:8080 -p 127.0.0.0/8 -p fc00::/7
 
   Options:
     -a, --accepts <number>               Number of connections for workers to

--- a/t/mojo/cgi.t
+++ b/t/mojo/cgi.t
@@ -193,7 +193,7 @@ subtest 'Trusted proxies' => sub {
     HTTP_X_FORWARDED_FOR   => '10.10.10.10, 192.0.2.2, 192.0.2.1',
     HTTP_X_FORWARDED_PROTO => 'https'
   );
-  local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8, 192.0/8';
+  local $ENV{MOJO_TRUSTED_PROXIES} = '127.0.0.0/8, 192.0.0.0/8';
   is(Mojolicious::Command::cgi->new(app => app)->run, 200, 'right status');
 
   my $res = Mojo::Message::Response->new->parse("HTTP/1.1 200 OK\x0d\x0a$msg");
@@ -217,7 +217,7 @@ subtest 'Trusted proxies (no REMOTE_ADDR)' => sub {
     HTTP_X_FORWARDED_FOR   => '10.10.10.10, 192.0.2.2, 192.0.2.1',
     HTTP_X_FORWARDED_PROTO => 'https'
   );
-  local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8, 192.0/8';
+  local $ENV{MOJO_TRUSTED_PROXIES} = '127.0.0.0/8, 192.0.0.0/8';
   is(Mojolicious::Command::cgi->new(app => app)->run, 200, 'right status');
 
   my $res = Mojo::Message::Response->new->parse("HTTP/1.1 200 OK\x0d\x0a$msg");

--- a/t/mojo/hypnotoad.t
+++ b/t/mojo/hypnotoad.t
@@ -30,7 +30,7 @@ use Mojo::UserAgent;
     proxy              => 1,
     requests           => 3,
     spare              => 4,
-    trusted_proxies    => ['127.0/8'],
+    trusted_proxies    => ['127.0.0.0/8'],
     upgrade_timeout    => 45,
     workers            => 7
   };
@@ -51,7 +51,7 @@ use Mojo::UserAgent;
   is $hypnotoad->prefork->pid_file,               '/foo/bar.pid', 'right value';
   ok $hypnotoad->prefork->reverse_proxy,          'reverse proxy enabled';
   is $hypnotoad->prefork->spare,                  4, 'right value';
-  is_deeply $hypnotoad->prefork->trusted_proxies, ['127.0/8'], 'right value';
+  is_deeply $hypnotoad->prefork->trusted_proxies, ['127.0.0.0/8'], 'right value';
   is $hypnotoad->prefork->workers,                7, 'right value';
   is $hypnotoad->upgrade_timeout, 45, 'right value';
 }

--- a/t/mojo/psgi.t
+++ b/t/mojo/psgi.t
@@ -262,7 +262,7 @@ subtest 'Trusted proxies' => sub {
   };
   my ($app, $res);
   {
-    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8, 192.0/8';
+    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0.0.0/8, 192.0.0.0/8';
     $app = Mojolicious::Command::psgi->new(app => app)->run;
     $res = $app->($env);
   }
@@ -298,7 +298,7 @@ subtest 'Trusted proxies (no REMOTE_ADDR)' => sub {
   };
   my ($app, $res);
   {
-    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8, 192.0/8';
+    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0.0.0/8, 192.0.0.0/8';
     $app = Mojolicious::Command::psgi->new(app => app)->run;
     $res = $app->($env);
   }

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -480,7 +480,7 @@ subtest 'monkey_patch (with name)' => sub {
 };
 
 subtest 'network_contains' => sub {
-  ok !network_contains('10.0/8',         ''),            'empty address';
+  ok !network_contains('10.0.0.0/8',     ''),            'empty address';
   ok !network_contains('',               '10.10.10.10'), 'empty network';
   ok !network_contains('foo',            '10.10.10.10'), 'invalid v4 network';
   ok !network_contains('10.10.10.10',    'foo'),         'invalid v4 address';
@@ -492,8 +492,8 @@ subtest 'network_contains' => sub {
   ok network_contains('192.168.0.1/33', '192.168.0.1'), 'oversize v4 mask';
   ok network_contains('::/130',         '::'),          'oversize v6 mask';
 
-  ok network_contains('0/0',                '0'),               'v4 network contains addresss';
-  ok network_contains('0/0',                '255.255.255.255'), 'v4 network contains addresss';
+  ok network_contains('0.0.0.0/0',          '0.0.0.0'),         'v4 network contains addresss';
+  ok network_contains('0.0.0.0/0',          '255.255.255.255'), 'v4 network contains addresss';
   ok network_contains('192.168.0.0/24',     '192.168.0.1'),     'v4 network contains addresss';
   ok network_contains('10.10.10.8/30',      '10.10.10.11'),     'v4 network contains addresss';
   ok network_contains('10.10.10.8/30',      '10.10.10.8'),      'v4 network contains addresss';
@@ -503,7 +503,7 @@ subtest 'network_contains' => sub {
   ok network_contains('10.10.10.8/29',      '10.10.10.10'),     'v4 network contains addresss';
   ok network_contains('127.0.0.1',          '127.0.0.1'),       'v4 network contains addresss';
 
-  ok !network_contains('0/32',           '1'),              'v4 network does not contain address';
+  ok !network_contains('0.0.0.0/32',     '0.0.0.1'),        'v4 network does not contain address';
   ok !network_contains('192.168.1.0/24', '192.168.0.1'),    'v4 network does not contain address';
   ok !network_contains('10.10.0.8/29',   '10.10.10.8'),     'v4 network does not contain address';
   ok !network_contains('10.10.10.8/29',  '10.10.10.7'),     'v4 network does not contain address';

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -274,24 +274,24 @@ subtest 'daemon' => sub {
 
   subtest 'Trusted proxies' => sub {
     my $command = Mojolicious::Command::daemon->new;
-    my $daemon  = $command->build_server('-p', '127.0/8', '-p', '10.0/8');
+    my $daemon  = $command->build_server('-p', '127.0.0.0/8', '-p', '10.0.0.0/8');
     ok $daemon->reverse_proxy, 'right value';
-    is_deeply $daemon->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+    is_deeply $daemon->trusted_proxies, ['127.0.0.0/8', '10.0.0.0/8'], 'right value';
   };
 
   subtest 'Trusted proxies from environment' => sub {
-    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8,10.0/8';
+    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0.0.0/8,10.0.0.0/8';
     my $command = Mojolicious::Command::daemon->new;
     my $daemon  = $command->build_server;
     ok $daemon->reverse_proxy, 'right value';
-    is_deeply $daemon->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+    is_deeply $daemon->trusted_proxies, ['127.0.0.0/8', '10.0.0.0/8'], 'right value';
   };
 
   subtest 'Proxy boolean and trusted' => sub {
     my $command = Mojolicious::Command::daemon->new;
-    my $daemon  = $command->build_server('-p', '-p', '127.0/8', '-p', '10.0/8');
+    my $daemon  = $command->build_server('-p', '-p', '127.0.0.0/8', '-p', '10.0.0.0/8');
     ok $daemon->reverse_proxy, 'right value';
-    is_deeply $daemon->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+    is_deeply $daemon->trusted_proxies, ['127.0.0.0/8', '10.0.0.0/8'], 'right value';
   };
 };
 
@@ -493,24 +493,24 @@ subtest 'prefork' => sub {
 
   subtest 'Trusted proxies' => sub {
     my $command = Mojolicious::Command::prefork->new;
-    my $prefork = $command->build_server('-p', '127.0/8', '-p', '10.0/8');
+    my $prefork = $command->build_server('-p', '127.0.0.0/8', '-p', '10.0.0.0/8');
     ok $prefork->reverse_proxy, 'right value';
-    is_deeply $prefork->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+    is_deeply $prefork->trusted_proxies, ['127.0.0.0/8', '10.0.0.0/8'], 'right value';
   };
 
   subtest 'Trusted proxies from environment' => sub {
-    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8,10.0/8';
+    local $ENV{MOJO_TRUSTED_PROXIES} = '127.0.0.0/8,10.0.0.0/8';
     my $command = Mojolicious::Command::prefork->new;
     my $prefork = $command->build_server;
     ok $prefork->reverse_proxy, 'right value';
-    is_deeply $prefork->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+    is_deeply $prefork->trusted_proxies, ['127.0.0.0/8', '10.0.0.0/8'], 'right value';
   };
 
   subtest 'Proxy boolean and trusted' => sub {
     my $command = Mojolicious::Command::prefork->new;
-    my $prefork = $command->build_server('-p', '-p', '127.0/8', '-p', '10.0/8');
+    my $prefork = $command->build_server('-p', '-p', '127.0.0.0/8', '-p', '10.0.0.0/8');
     ok $prefork->reverse_proxy, 'right value';
-    is_deeply $prefork->trusted_proxies, ['127.0/8', '10.0/8'], 'right value';
+    is_deeply $prefork->trusted_proxies, ['127.0.0.0/8', '10.0.0.0/8'], 'right value';
   };
 };
 

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -685,7 +685,7 @@ subtest 'Reverse proxy with "X-Forwarded-For" and trusted proxies (untrusted ori
 };
 
 subtest 'Reverse proxy with "X-Forwarded-For" and trusted proxy networks' => sub {
-  local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8, 192.0.2.1/32';
+  local $ENV{MOJO_TRUSTED_PROXIES} = '127.0.0.0/8, 192.0.2.1/32';
   my $t = Test::Mojo->new;
   $t->get_ok('/0' => {'X-Forwarded-For' => '192.0.2.2, 192.0.2.1'})->status_is(200)
     ->header_unlike('X-Original' => qr/192\.0\.2\.(?:2|1)/)
@@ -693,7 +693,7 @@ subtest 'Reverse proxy with "X-Forwarded-For" and trusted proxy networks' => sub
 };
 
 subtest 'Reverse proxy with "X-Forwarded-For" and trusted proxies (all addresses trusted)' => sub {
-  local $ENV{MOJO_TRUSTED_PROXIES} = '0/0';
+  local $ENV{MOJO_TRUSTED_PROXIES} = '0.0.0.0/0';
   my $t = Test::Mojo->new;
   $t->get_ok('/0' => {'X-Forwarded-For' => '192.0.2.2, 192.0.2.1'})->status_is(200)
     ->header_unlike('X-Original' => qr/192\.0\.2\.(?:2|1)/)
@@ -701,7 +701,7 @@ subtest 'Reverse proxy with "X-Forwarded-For" and trusted proxies (all addresses
 };
 
 subtest 'Reverse proxy with "X-Forwarded-For" and trusted proxies (unexpected leading address)' => sub {
-  local $ENV{MOJO_TRUSTED_PROXIES} = '127.0/8, 192.0.2.1';
+  local $ENV{MOJO_TRUSTED_PROXIES} = '127.0.0.0/8, 192.0.2.1';
   my $t = Test::Mojo->new;
   $t->get_ok('/0' => {'X-Forwarded-For' => '7.7.7.7, 192.0.2.2, 192.0.2.1'})->status_is(200)
     ->header_unlike('X-Original' => qr/192\.0\.2\.(?:2|1)/)


### PR DESCRIPTION
As seen in https://github.com/mojolicious/mojo/runs/1912645557
apparently a change to Socket on windows meant that these addresses were
no longer parsing correctly. While they're convenient they're not
required. This change no longer allows them on any platform.