### PR TITLE
Issue 1708 return reject from finally

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -56,7 +56,20 @@ sub catch { shift->then(undef, shift) }
 
 sub clone { $_[0]->new->ioloop($_[0]->ioloop) }
 
-sub finally { shift->_finally(1, @_) }
+sub finally {
+  my $class = ref $_[0];
+  my $cb    = $_[1];
+
+  my $big_cb = sub {
+    my @vals = @_;
+
+    $class->resolve($cb->())->then(sub {@vals});
+  };
+
+  $_[0]->catch($big_cb);
+
+  return $_[0]->then($big_cb);
+}
 
 sub map {
   my ($class, $options, $cb, @items) = (shift, ref $_[0] eq 'HASH' ? shift : {}, @_);


### PR DESCRIPTION
### Summary
Fix a nonstandard behaviour of Mojo::Promise::finally()

### Motivation
The library advertises compatibility with ES6 promises; this fixes one area of incompatibility.

NOTE: This is a breaking change; there was previously a test (now commented out) that verified ES6-incompatible behaviour regarding finally().