### PR TITLE
Support MOJO_LOG_LEVEL in Mojo::Log

### DIFF
--- a/lib/Mojo/Log.pm
+++ b/lib/Mojo/Log.pm
@@ -19,7 +19,7 @@ has handle => sub {
   return Mojo::File->new($path)->open('>>');
 };
 has history          => sub { [] };
-has level            => 'debug';
+has level            => sub { $ENV{MOJO_LOG_LEVEL} || 'debug' };
 has max_history_size => 10;
 has 'path';
 has short => sub { $ENV{MOJO_LOG_SHORT} };
@@ -182,8 +182,8 @@ The last few logged messages.
   my $level = $log->level;
   $log      = $log->level('debug');
 
-Active log level, defaults to C<debug>. Available log levels are C<debug>, C<info>, C<warn>, C<error> and C<fatal>, in
-that order.
+Active log level, defaults to the value of the C<MOJO_LOG_LEVEL>  environment variable or C<debug>. Available log
+levels are C<debug>, C<info>, C<warn>, C<error> and C<fatal>, in that order.
 
 =head2 max_history_size
 

--- a/t/mojo/log.t
+++ b/t/mojo/log.t
@@ -210,4 +210,15 @@ subtest 'Context' => sub {
   like $buffer,   qr/\[.*\] \[fatal\] \[123\] Mojolicious rocks\n/, 'right fatal message';
 };
 
+subtest 'MOJO_LOG_LEVEL' => sub {
+  local $ENV{MOJO_LOG_LEVEL} = 'warn';
+
+  my $log = Mojo::Log->new;
+  is $log->level, 'warn', 'right level';
+  ok !$log->is_level('debug'), '"debug" log level is inactive';
+  ok !$log->is_level('info'),  '"info" log level is inactive';
+  ok $log->is_level('warn'),  '"warn" log level is inactive';
+  ok $log->is_level('error'), '"error" log level is inactive';
+};
+
 done_testing();

--- a/t/mojolicious/log_lite_app.t
+++ b/t/mojolicious/log_lite_app.t
@@ -7,6 +7,9 @@ use Mojolicious::Lite;
 use Mojo::Log;
 use Test::Mojo;
 
+# Test::Mojo sets MOJO_LOG_LEVEL to fatal
+local $ENV{MOJO_LOG_LEVEL} = 'debug';
+
 hook before_dispatch => sub {
   my $c = shift;
   $c->req->request_id('17a60115');

--- a/t/mojolicious/log_lite_app.t
+++ b/t/mojolicious/log_lite_app.t
@@ -7,9 +7,6 @@ use Mojolicious::Lite;
 use Mojo::Log;
 use Test::Mojo;
 
-# Test::Mojo sets MOJO_LOG_LEVEL to fatal
-local $ENV{MOJO_LOG_LEVEL} = 'debug';
-
 hook before_dispatch => sub {
   my $c = shift;
   $c->req->request_id('17a60115');
@@ -29,7 +26,7 @@ my $t = Test::Mojo->new;
 # Simple log messages with and without context
 my $buffer = '';
 open my $handle, '>', \$buffer;
-$t->app->log(Mojo::Log->new(handle => $handle));
+$t->app->log(Mojo::Log->new(handle => $handle, level => 'debug'));
 $t->get_ok('/simple')->status_is(200)->content_is('Simple!');
 like $buffer, qr/First.*Second.*Third.*No context!.*Fourth.*Fifth/s,    'right order';
 like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[17a60115\] First!/,         'message with request id';


### PR DESCRIPTION
### Summary

This pull request introduces support for the `MOJO_LOG_LEVEL` environment variable in `Mojo::Log`.

### Motivation

The variable is currently only supported in the context of `Mojolicious` or `Mojolicious::Lite`. However, `Mojo::Log` can also be used independently and therefore support for `MOJO_LOG_LEVEL` was previously missing.

### References