### PR TITLE
doc: Cleanup ipv4 address expansion from short form.

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -305,7 +305,7 @@ Request has been performed through a reverse proxy.
 =head2 trusted_proxies
 
   my $proxies = $req->trusted_proxies;
-  $req        = $req->trusted_proxies(['10.0.0.0/8', '127.0.0.1', '172.16.0.0.0/12', '192.168.0.0/16', 'fc00::/7']);
+  $req        = $req->trusted_proxies(['10.0.0.0/8', '127.0.0.1', '172.16.0.0/12', '192.168.0.0/16', 'fc00::/7']);
 
 Trusted reverse proxies, addresses or networks in CIDR form.
 


### PR DESCRIPTION
### Summary

This change is a minor tweak to the documentation for `Mojo::Message::Request` to fix a recent documentation error introduced as part of IPv4 short-form address removal in commit e3af2e7b4b.

This fix added too many octets when inflating an address to normal form, resulting in the invalid address of 172.16.0.0.0/12.

I fix the fix by removing the extra octet to leave 172.16.0.0/12.

### Motivation

The issue is minor, but documentation errors may tend to introduce concern on the part of the reader, and this seems to be reflected in other Mojo core team commits to make occasional documentation cleanups after new features or important changes until the docs are clear and easy to understand and apply.

To look for other potential documentation flaws I ran a scan of the entire Mojolicious repository looking for other
"five octet" IPv4 addresses and there was nothing except a deliberate DNS
hostname meant 1.1.1.1.1.1 in the testsuite, presumably to validate that
it is not accidentally treated as an IP address.

### References

I did not see any open issues or pull requests for this, nor have I opened a forum discussion. If the change is unwanted I won't bug anyone about it but since I noticed it while reviewing recent changes I figured I'd contribute the fix instead of opening an issue.