### PR TITLE
Add a 'worker_starting' event.

### DIFF
--- a/lib/Mojo/Server/CGI.pm
+++ b/lib/Mojo/Server/CGI.pm
@@ -3,6 +3,14 @@ use Mojo::Base 'Mojo::Server';
 
 has 'nph';
 
+sub new {
+  my $class = shift;
+  my $self  = $class->SUPER::new(@_);
+  my $app   = $self->app;
+  $app->app_starting if ref $app;
+  return $self;
+}
+
 sub run {
   my $self = shift;
 
@@ -117,6 +125,14 @@ Activate non-parsed header mode.
 =head1 METHODS
 
 L<Mojo::Server::CGI> inherits all methods from L<Mojo::Server> and implements the following new ones.
+
+=head2 new
+
+  my $app    = Mojolicious->new;
+  my $server = Mojo::Server::CGI->new(app => $app);
+  my $server = Mojo::Server::CGI->new(app => $app, nph => 1);
+
+Creates a C<Mojo::Server::CGI> object.
 
 =head2 run
 

--- a/lib/Mojo/Server/Daemon.pm
+++ b/lib/Mojo/Server/Daemon.pm
@@ -35,6 +35,7 @@ sub run {
   my $loop = $self->ioloop;
   my $int  = $loop->recurring(1 => sub { });
   local $SIG{INT} = local $SIG{TERM} = sub { $loop->stop };
+  $self->app->app_starting;
   $self->start->ioloop->start;
   $loop->remove($int);
 }
@@ -53,6 +54,7 @@ sub start {
   # Start listening
   elsif (!@{$self->acceptors}) {
     $self->app->server($self);
+    $self->app->app_starting;
     $self->_listen($_) for @{$self->listen};
   }
 

--- a/lib/Mojo/Server/PSGI.pm
+++ b/lib/Mojo/Server/PSGI.pm
@@ -35,6 +35,7 @@ sub to_psgi_app {
 
   # Preload application and wrap it
   $self->app->server($self);
+  $self->app->app_starting;
   return sub { $self->run(@_) }
 }
 

--- a/lib/Mojo/Server/Prefork.pm
+++ b/lib/Mojo/Server/Prefork.pm
@@ -149,6 +149,7 @@ sub _spawn {
   srand;
 
   $self->app->log->info("Worker $$ started");
+  $self->app->app_starting;
   $loop->start;
   exit 0;
 }

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -175,6 +175,8 @@ sub plugin {
 
 sub server { $_[0]->plugins->emit_hook(before_server_start => @_[1, 0]) }
 
+sub app_starting { $_[0]->plugins->emit_hook(before_app_start => $_[0]) }
+
 sub start {
   my $self = shift;
   $_->warmup for $self->static, $self->renderer;
@@ -259,6 +261,17 @@ built-in ones (except for L<Mojo::Server::CGI>).
 
 Useful for reconfiguring application servers dynamically or collecting server diagnostics information. (Passed the
 server and application objects)
+
+=head2 before_app_start
+
+Emitted right before the application starts.  It works with all the built-in web
+servers.  In the case of L<Mojo::Server::Prefork>, it will run in each spawned
+worker, not in the master server.
+
+  $app->hook(before_app_start => sub ($app) {...});
+
+This can be used to initialize the global state that the application will be
+perusing during its processing. (Passed the application object)
 
 =head2 after_build_tx
 
@@ -723,6 +736,12 @@ subclass.
   $app->warmup;
 
 Preload classes from L</"preload_namespaces"> for future use.
+
+=head2 app_starting
+
+  $app->app_starting;
+
+Emits the L</"before_app_start"> hook.
 
 =head1 HELPERS
 

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -175,7 +175,15 @@ sub plugin {
 
 sub server { $_[0]->plugins->emit_hook(before_server_start => @_[1, 0]) }
 
-sub app_starting { $_[0]->plugins->emit_hook(before_app_start => $_[0]) }
+sub app_starting {
+  my $self = shift;
+
+  # Ensure we run 'before_app_start' only once per process
+  $self->{_started} = {} unless defined $self->{_started};
+  return if exists $self->{_started}->{$$};
+  $self->{_started}->{$$} = undef;
+  $self->plugins->emit_hook(before_app_start => $self);
+}
 
 sub start {
   my $self = shift;

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -272,14 +272,13 @@ server and application objects)
 
 =head2 before_app_start
 
-Emitted right before the application starts.  It works with all the built-in web
-servers.  In the case of L<Mojo::Server::Prefork>, it will run in each spawned
-worker, not in the master server.
+Emitted right before the application starts.  It works with all the built-in web servers.  In the case of
+L<Mojo::Server::Prefork>, it will run in each spawned worker, not in the master server.
 
   $app->hook(before_app_start => sub ($app) {...});
 
-This can be used to initialize the global state that the application will be
-perusing during its processing. (Passed the application object)
+This can be used to initialize the global state that the application will be perusing during its processing. (Passed
+the application object)
 
 =head2 after_build_tx
 

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -179,7 +179,7 @@ sub app_starting {
   my $self = shift;
 
   # Ensure we run 'before_app_start' only once per process
-  $self->{_started} = {} unless defined $self->{_started};
+  $self->{_started} //= {};
   return if exists $self->{_started}->{$$};
   $self->{_started}->{$$} = undef;
   $self->plugins->emit_hook(before_app_start => $self);

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -178,12 +178,10 @@ worker is allowed to handle (often as low as C<1>).
   $ ./script/my_app prefork -m production -w 10 -c 1
   Web application available at http://127.0.0.1:3000
 
-During startup your application is preloaded in the manager process
-but it will not start any processing there.
+During startup your application is preloaded in the manager process but it will not start any processing there.
 
-You can use the hook L<Mojolicious/"before_worker_start"> to run code in each
-child process (the worker processes that are being forked) before it is about
-to start processing incoming requests:
+You can use the hook L<Mojolicious/"before_worker_start"> to run code in each child process (the worker processes
+that are being forked) before it is about to start processing incoming requests:
 
   use Mojolicious::Lite;
 
@@ -195,7 +193,7 @@ to start processing incoming requests:
 
   app->start;
 
-That can be handy to setup global state once.
+That can be handy to setup global state, once.
 
 And to manage the pre-forking web server with systemd, you can use a unit configuration file like this.
 

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -178,18 +178,24 @@ worker is allowed to handle (often as low as C<1>).
   $ ./script/my_app prefork -m production -w 10 -c 1
   Web application available at http://127.0.0.1:3000
 
-During startup your application is preloaded in the manager process, which does not run an event loop, so you can use
-L<Mojo::IOLoop/"next_tick"> to run code whenever a new worker process has been forked and its event loop gets started.
+During startup your application is preloaded in the manager process
+but it will not start any processing there.
+
+You can use the hook L<Mojolicious/"before_worker_start"> to run code in each
+child process (the worker processes that are being forked) before it is about
+to start processing incoming requests:
 
   use Mojolicious::Lite;
 
-  Mojo::IOLoop->next_tick(sub ($ioloop) {
-    app->log->info("Worker $$ star...ALL GLORY TO THE HYPNOTOAD!");
+  app->hook(before_worker_start => sub ($app) {
+    $app->log->info("Worker $$ star...ALL GLORY TO THE HYPNOTOAD!");
   });
 
   get '/' => {text => 'Hello Wor...ALL GLORY TO THE HYPNOTOAD!'};
 
   app->start;
+
+That can be handy to setup global state once.
 
 And to manage the pre-forking web server with systemd, you can use a unit configuration file like this.
 

--- a/t/mojo/cgi.t
+++ b/t/mojo/cgi.t
@@ -9,7 +9,13 @@ use Mojolicious::Lite;
 # Silence
 app->log->level('fatal');
 
-get '/' => {text => 'Your Mojo is working!'};
+my $working = "NOT working";
+app->hook(before_app_start => sub { $working = "working" });
+
+get '/' => sub {
+  my $c = shift;
+  $c->render(text => "Your Mojo is $working!");
+};
 
 post '/chunked' => sub {
   my $c = shift;

--- a/t/mojo/daemon.t
+++ b/t/mojo/daemon.t
@@ -112,8 +112,8 @@ my $ua  = Mojo::UserAgent->new(ioloop => Mojo::IOLoop->singleton);
 my $whatever = 'Failed!';
 $app->hook(
   before_app_start => sub {
-    my ($app) = shift;
-    my $ok = ref $app && $app->isa('Mojolicious');
+    my $app = shift;
+    my $ok  = ref $app && $app->isa('Mojolicious');
     $whatever = $ok ? 'Whatever!' : 'Wrong type';
   }
 );

--- a/t/mojo/daemon.t
+++ b/t/mojo/daemon.t
@@ -109,6 +109,15 @@ subtest 'Transaction' => sub {
 my $app = Mojolicious->new;
 my $ua  = Mojo::UserAgent->new(ioloop => Mojo::IOLoop->singleton);
 
+my $whatever = 'Failed!';
+$app->hook(
+  before_app_start => sub {
+    my ($app) = shift;
+    my $ok = ref $app && $app->isa('Mojolicious');
+    $whatever = $ok ? 'Whatever!' : 'Wrong type';
+  }
+);
+
 subtest 'Moniker' => sub {
   is $ua->server->app($app)->app->moniker, 'mojolicious', 'right moniker';
 };
@@ -161,7 +170,12 @@ $app->routes->any(
   }
 );
 
-$app->routes->any('/*whatever' => {text => 'Whatever!'});
+$app->routes->any(
+  '/*whatever' => sub {
+    my ($c) = shift;
+    $c->render(text => $whatever);
+  }
+);
 
 subtest 'Normal request' => sub {
   my $tx = $ua->get('/normal/');

--- a/t/mojo/morbo.t
+++ b/t/mojo/morbo.t
@@ -71,7 +71,6 @@ app->log->level('fatal');
 Mojo::IOLoop->next_tick(sub { path('$started')->touch });
 
 get '/hello' => {text => 'Hello World!'};
-get '/start' => {text => 'Started Morbo!'};
 
 app->start;
 EOF
@@ -91,12 +90,6 @@ EOF
   ok $tx->is_finished, 'transaction is finished';
   is $tx->res->code, 200,            'right status';
   is $tx->res->body, 'Hello World!', 'right content';
-
-  # Hook has been properly called
-  $tx = $ua->get("http://127.0.0.1:$port/started");
-  ok $tx->is_finished, 'transaction is finished';
-  is $tx->res->code, 200,              'right status';
-  is $tx->res->body, 'Started Morbo!', 'right content';
 };
 
 subtest 'Update script without changing mtime' => sub {
@@ -115,11 +108,7 @@ Mojo::IOLoop->next_tick(sub { path('$started')->touch });
 my \$message = 'Failed!';
 hook before_server_start => sub { \$message = 'Hello!' };
 
-my \$started = 'Failed!';
-hook before_app_start => sub { \$started = 'YES!' };
-
 get '/hello' => sub { shift->render(text => \$message) };
-get '/start' => sub { shift->render(text => \$started) };
 
 app->start;
 EOF
@@ -140,12 +129,6 @@ EOF
   ok $tx->is_finished, 'transaction is finished';
   is $tx->res->code, 200,      'right status';
   is $tx->res->body, 'Hello!', 'right content';
-
-  # This new one is there
-  $tx = $ua->get("http://127.0.0.1:$port/start");
-  ok $tx->is_finished, 'transaction is finished';
-  is $tx->res->code, 200,    'right status';
-  is $tx->res->body, 'YES!', 'right content';
 };
 
 subtest 'New file(s)' => sub {

--- a/t/mojo/prefork.t
+++ b/t/mojo/prefork.t
@@ -50,7 +50,7 @@ my $counter = Mojolicious->new;
 my ($counter_events, $counter_spawned, $counter_server);
 $counter->hook(
   before_app_start => sub {
-    my ($app) = @_;
+    my $app = shift;
     $counter_events  = {};
     $counter_spawned = {};
     $counter_server  = {};
@@ -146,7 +146,7 @@ $prefork->app->hook(
 );
 $prefork->app->hook(
   before_app_start => sub {
-    my ($app) = @_;
+    my $app = shift;
     Mojo::UserAgent->new->post("$durl}triggered/$$");
   }
 );
@@ -211,7 +211,7 @@ $prefork->app->hook(
 );
 $prefork->app->hook(
   before_app_start => sub {
-    my ($app) = @_;
+    my $app = shift;
     Mojo::UserAgent->new->post("$durl/triggered/$$");
   }
 );
@@ -239,7 +239,7 @@ is $spawned_count, 5, 'right amount of spawned servers';
 is $server_count,  1, 'right amount of master servers';
 
 sub all_values_one {
-  my ($href) = @_;
+  my $href = shift;
   foreach my $val (values %$href) {
     return 0 unless 1 == $val;
   }

--- a/t/mojo/prefork.t
+++ b/t/mojo/prefork.t
@@ -50,7 +50,7 @@ my $counter = Mojolicious->new;
 my ($counter_events, $counter_spawned, $counter_server);
 $counter->hook(
   before_app_start => sub {
-    my ($app) = shift;
+    my ($app) = @_;
     $counter_events  = {};
     $counter_spawned = {};
     $counter_server  = {};

--- a/t/mojo/psgi.t
+++ b/t/mojo/psgi.t
@@ -49,7 +49,7 @@ subtest 'Binding' => sub {
   );
   app->hook(
     before_app_start => sub {
-      my ($app) = @_;
+      my $app = shift;
       push @started, $app->mode;
     }
   );

--- a/t/mojo/psgi.t
+++ b/t/mojo/psgi.t
@@ -40,11 +40,17 @@ subtest 'Reverse proxy' => sub {
 };
 
 subtest 'Binding' => sub {
-  my @server;
+  my (@server, @started);
   app->hook(
     before_server_start => sub {
       my ($server, $app) = @_;
       push @server, ref $server, $app->mode;
+    }
+  );
+  app->hook(
+    before_app_start => sub {
+      my ($app) = @_;
+      push @started, $app->mode;
     }
   );
   my $app     = Mojo::Server::PSGI->new(app => app)->to_psgi_app;
@@ -81,6 +87,7 @@ subtest 'Binding' => sub {
   is delete $ENV{MOJO_HELLO}, 'world', 'finish event has been emitted';
   is_deeply decode_json($params), {bar => 'baz', hello => 'world', lalala => 23}, 'right structure';
   is_deeply \@server, ['Mojo::Server::PSGI', 'development'], 'hook has been emitted once';
+  is_deeply \@started, ['development'], 'hook has been emitted once';
 };
 
 subtest 'Command' => sub {


### PR DESCRIPTION
This event (`before_app_start`) is always called before the application starts, regardless
of whether it is invoked via `morbo`, is started in daemon mode from the
command line or via `hypnotoad` in pre-forking mode.

It avoids having to say:

    Mojo::IOLoop->next_tick(sub ($ioloop) {
        app->log->info("Worker $$ star...ALL GLORY TO THE HYPNOTOAD!");
    });

to get this special behaviour.  It is way nicer to be able to say:

    app->hook(before_app_start => sub ($app) {
        $app->log->info("App in $$ star...ALL GLORY TO MOJOLICIOUS!");
    });

to get that behaviour.

It is more consistent with the over hooks, and also it is a better
abstraction than having to know the internals of the IOLoop to be
able to get such a hooking point in pre-forked processes.

Now the application has a unique and consistent entry point where it can
initialize its global state.