### PR TITLE
Add missing reference to comma_separated filter in POD

### DIFF
--- a/lib/Mojolicious/Validator.pm
+++ b/lib/Mojolicious/Validator.pm
@@ -169,7 +169,7 @@ L</"upload"> are already defined.
   my $filters = $validator->filters;
   $validator  = $validator->filters({trim => sub {...}});
 
-Registered filters, by default only L</"not_empty"> and L</"trim"> are already defined.
+Registered filters, by default only L</"comma_separated">, L</"not_empty"> and L</"trim"> are already defined.
 
 =head1 METHODS
 


### PR DESCRIPTION
### Summary
Update to the documentation that seems to have been missed for new `comma_separated` filter.

### Motivation
Up to date docs.

### References
None
