### PR TITLE
Mojolicious::Guides::Testing - mention how to test Mojolicious::Lite applications

### DIFF
--- a/lib/Mojolicious/Guides/Testing.pod
+++ b/lib/Mojolicious/Guides/Testing.pod
@@ -153,6 +153,12 @@ the tests have completed, the L<Mojolicious> application will be torn down.
   # Listens on localhost:32114 (some unused TCP port)
   my $t = Test::Mojo->new('Frogs');
 
+To test a L<Mojolicious::Lite> application, pass the file path to the application script to the constructor.
+
+  # Load application script relative to the "t" directory
+  use Mojo::File qw(curfile);
+  my $t = Test::Mojo->new(curfile->dirname->sibling('myapp.pl'));
+
 This object initializes a L<Mojo::UserAgent> object, loads the Mojolicious application C<Frogs>, binds and listens on a
 free TCP port (e.g., 32114), and starts the application event loop. When the L<Test::Mojo> object (C<$t>) goes out of
 scope, the application is stopped.


### PR DESCRIPTION
### Summary
Include the example from Test::Mojo/new to show how to load a Mojolicious::Lite application with Test::Mojo.

### Motivation
The guide does not currently specify how to test a Mojolicious::Lite application which doesn't have an application class.