### PR TITLE
Promise map improved

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -61,7 +61,8 @@ sub finally { shift->_finally(1, @_) }
 sub map {
   my ($class, $options, $cb, @items) = (shift, ref $_[0] eq 'HASH' ? shift : {}, @_);
 
-  return $class->all(map { $_->$cb } @items) if !$options->{concurrency} || @items <= $options->{concurrency};
+  return $options->{any} ? $class->any(map { $_->$cb } @items) : $class->all(map { $_->$cb } @items)
+    if !$options->{concurrency} || @items <= $options->{concurrency};
 
   my @start = map { $_->$cb } splice @items, 0, $options->{concurrency};
   my @wait  = map { $start[0]->clone } 0 .. $#items;
@@ -69,13 +70,23 @@ sub map {
   my $start_next = sub {
     return () unless my $item = shift @items;
     my ($start_next, $chain) = (__SUB__, shift @wait);
-    $_->$cb->then(sub { $chain->resolve(@_); $start_next->() }, sub { $chain->reject(@_); @items = () }) for $item;
+    if ($options->{any}) {
+      $_->$cb->then(sub { $chain->resolve(@_); @items = () }, sub { $chain->reject(@_); $start_next->() }) for $item;
+    }
+    else {
+      $_->$cb->then(sub { $chain->resolve(@_); $start_next->() }, sub { $chain->reject(@_); @items = () }) for $item;
+    }
     return ();
   };
 
-  $_->then($start_next, sub { }) for @start;
+  if ($options->{any}) {
+    $_->then(sub { }, $start_next) for @start;
+  }
+  else {
+    $_->then($start_next, sub { }) for @start;
+  }
 
-  return $class->all(@start, @wait);
+  return $options->{any} ? $class->any(@start, @wait) : $class->all(@start, @wait);
 }
 
 sub new {
@@ -411,6 +422,9 @@ Apply a function that returns a L<Mojo::Promise> to each item in a list of items
 Returns a L<Mojo::Promise> that collects the results in the same manner as L</all>. If any item's promise is rejected,
 any remaining items which have not yet been mapped will not be.
 
+With the C<any> option, the behaviour can be changed to the same manner as L</any>. If any item's promise is resolved,
+any remaining items which have not yet been mapped will not be.
+
   # Perform 3 requests at a time concurrently
   Mojo::Promise->map({concurrency => 3}, sub { $ua->get_p($_) }, @urls)
     ->then(sub{ say $_->[0]->res->dom->at('title')->text for @_ });
@@ -418,6 +432,12 @@ any remaining items which have not yet been mapped will not be.
 These options are currently available:
 
 =over 2
+
+=item any
+
+  any => 1
+
+Changes the aggregation behaviour from 'all' to 'any' if set to a true value.
 
 =item concurrency
 

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -676,6 +676,43 @@ that create them for you.
 
   app->start;
 
+When processing a number of requests towards a non-robust or external resource, the kind of aggregation, maximum
+concurrency and an optional delay can be specified using L<Mojo::Promise/"map">.
+
+  use Mojolicious::Lite -signatures;
+  use Mojo::Promise;
+  use Mojo::URL;
+
+  # Search MetaCPAN for a larger number of items, with mild concurrency and some throttling
+  get '/' => sub ($c) {
+
+    my $url   = Mojo::URL->new('http://fastapi.metacpan.org/v1/module/_search');
+    my @items = (qw(perl mojolicious mojo minion));
+
+    # Render a response once all promises have been resolved
+    Mojo::Promise->map(
+      {concurrency => 2, delay => 0.5}, # average max 4 requests/s
+      sub {
+        my $item = $_;
+        $c->ua->get_p($url->clone->query({q => $item}))->then(sub { my @res = @_; Mojo::Promise->resolve($item, @res); });
+      },
+      @items
+    )->then(sub (@results) {
+      $c->render(
+        json => {
+          map {
+            my ($item, $res) = @$_;
+            $item => $res->result->json('/hits/hits/0/_source/release');
+          } @results
+        }
+      );
+    })->catch(sub ($err) {
+      $c->reply->exception($err);
+    })->wait;
+  };
+
+  app->start;
+
 To create promises manually you just wrap your continuation-passing style APIs in functions that return promises.
 Here's an example for how L<Mojo::UserAgent/"get_p"> works internally.
 


### PR DESCRIPTION
### Summary
Generalized Mojo::Promise::Map to also support 'any' and 'all_settled' aggregations plus an optional delay

### Motivation
Since the deprecation/removal of Mojo::IOLoop::delay, the only concurrency-limiting elegant way is to use Mojo::Promise::map.
Since I need the limiting as part of a general purpose functionality, I augmented Mojo::Promise::map to support various kinds of aggregation (all[default], any, all_settled) and an optional delay between processing the promises.
Test cases as well as a cookbook entry for Mojo::Promise::map is supplied.

### References
LIST RELEVANT ISSUES, PULL REQUESTS AND FORUM DISCUSSIONS HERE
