### PR TITLE
Add Try/Catch syntax feature

### DIFF
--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -128,6 +128,13 @@ sub import {
       experimental->import($_) for qw(signatures postderef);
     }
 
+    # Try/Catch syntax (Perl 5.34+)
+    elsif ($flag eq '-try_catch') {
+      Carp::croak 'Try/Catch syntax requires Perl 5.34+' if $] < 5.034;
+      require experimental;
+      experimental->import('try');
+    }
+
     # Module
     elsif ($flag !~ /^-/) {
       no strict 'refs';

--- a/t/mojo/try_catch.t
+++ b/t/mojo/try_catch.t
@@ -1,0 +1,70 @@
+use Mojo::Base -strict;
+
+use Test::More;
+
+BEGIN { plan skip_all => 'Perl 5.34+ required for this test!' if $] < 5.034 }
+
+package MojoTryCatchBaseTest;
+use Mojo::Base -base, -try_catch;
+
+sub foo {
+  my $self = shift;
+
+  try {
+    $self->bar($_) for (0..5);
+  }
+  catch ($e) {
+    return $e;
+  }
+
+  return 0;
+}
+
+sub bar {
+  my($self, $number) = @_;
+
+  if ($number == 3) {
+    die "$number is not allowed";
+  }
+
+  return 1;
+}
+
+package MojoTryCatchBaseTest2;
+use Mojo::Base -try_catch, -base, -strict;
+
+use Mojo::Exception qw(raise check);
+
+sub foo {
+  my $result;
+
+  try {
+    raise 'something wrong'
+  }
+  catch ($e) {
+    check $e => [
+      'Mojo::Exception' => sub {$result = $_}
+    ];
+  }
+
+  return $result;
+}
+
+package main;
+
+subtest 'Handle die message' => sub {
+  my $test = MojoTryCatchBaseTest->new;
+  is($test->foo(), "3 is not allowed at ./t/mojo/try_catch.t line 27.\n", 'right result');
+};
+
+subtest 'Random order flags' => sub {
+  my $test2 = MojoTryCatchBaseTest2->new;
+  isa_ok($test2->foo(), 'Mojo::Exception', 'Exception handled');
+};
+
+subtest 'Bad flag' => sub {
+  eval "package MojoSignaturesTest3; use Mojo::Base -unsupported";
+  like $@, qr/Unsupported flag: -unsupported/, 'right error';
+};
+
+done_testing();

--- a/t/mojo/try_catch.t
+++ b/t/mojo/try_catch.t
@@ -54,12 +54,14 @@ package main;
 
 subtest 'Handle die message' => sub {
   my $test = MojoTryCatchBaseTest->new;
-  is($test->foo(), "3 is not allowed at ./t/mojo/try_catch.t line 27.\n", 'right result');
+  like($test->foo(), qr/3 is not allowed/, 'right result');
 };
 
 subtest 'Random order flags' => sub {
   my $test2 = MojoTryCatchBaseTest2->new;
-  isa_ok($test2->foo(), 'Mojo::Exception', 'Exception handled');
+  my $result = $test2->foo();
+  isa_ok($result, 'Mojo::Exception', 'Exception handled');
+  is($result->message, 'something wrong', 'Exception message is ok');
 };
 
 subtest 'Bad flag' => sub {


### PR DESCRIPTION
### Summary
In Perl 5.34 try-catch syntax [was added](https://metacpan.org/pod/release/XSAWYERX/perl-5.34.0-RC1/pod/perldelta.pod). So I think that it's a good idea to add flag to Mojo::Base import subroutine for this feature
### Motivation
Try/Catch syntax is using to avoid [some problems](https://metacpan.org/pod/Try::Tiny#Clobbering-$@) with eval and $@
### References
I created discussion [here](https://github.com/mojolicious/mojo/discussions/1778)