### PR TITLE
Allow inline templates to use layouts.

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -133,13 +133,14 @@ sub render {
 
   # Localize "extends" and "layout" to allow argument overrides
   my ($maybe, $ts) = @{$args}{'mojo.maybe', 'mojo.string'};
-  my $stash = $self->stash;
+  my $stash  = $self->stash;
+  my $inline = exists $args->{inline} || exists $stash->{inline};
   local $stash->{layout}  = $stash->{layout}  if exists $stash->{layout};
   local $stash->{extends} = $stash->{extends} if exists $stash->{extends};
 
-  # Rendering to string
+  # Rendering to string or using inline templates
   local @{$stash}{keys %$args}         if $ts || $maybe;
-  delete @{$stash}{qw(layout extends)} if $ts;
+  delete @{$stash}{qw(layout extends)} if $ts || $inline;
 
   # All other arguments just become part of the stash
   @$stash{keys %$args} = values %$args;

--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -525,8 +525,9 @@ To set a C<layout> stash value application-wide you can use L<Mojolicious/"defau
 
   $app->defaults(layout => 'mylayout');
 
-Layouts can also be used with L<Mojolicious::Controller/"render_to_string">, but the C<layout> value needs to be passed
-as a render argument (not a stash value).
+Layouts can also be used with L<Mojolicious::Controller/"render_to_string">, or when rendering
+L<inline templates|/"Rendering inline templates">, but the C<layout> value needs to be passed as a render argument
+(not a stash value).
 
   my $html = $c->render_to_string('reminder', layout => 'mail');
 

--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -108,7 +108,8 @@ sub render {
   # Inheritance
   my $content = $stash->{'mojo.content'} //= {};
   local $content->{content} = $output =~ /\S/ ? $output : undef if $stash->{extends} || $stash->{layout};
-  while ((my $next = _next($stash)) && !defined $inline) {
+  delete $options->{inline};
+  while ((my $next = _next($stash))) {
     @$options{qw(handler template)} = ($stash->{handler}, $next);
     $options->{format} = $stash->{format} || $self->default_format;
     if ($self->_render_template($c, \my $tmp, $options)) { $output = $tmp }

--- a/t/mojolicious/layouted_lite_app.t
+++ b/t/mojolicious/layouted_lite_app.t
@@ -97,6 +97,11 @@ get '/content_with';
 
 get '/inline' => {inline => '<%= "inline!" %>'};
 
+get '/inline/explicit_layout' => sub {
+  my $c = shift;
+  $c->render(inline => '<%= "inline!" %>', layout => 'layout');
+};
+
 get '/inline/again' => {inline => 0};
 
 get '/data' => {data => 0};
@@ -252,6 +257,11 @@ subtest 'Content blocks' => sub {
 
 subtest 'Inline template' => sub {
   $t->get_ok('/inline')->status_is(200)->header_is(Server => 'Mojolicious (Perl)')->content_is("inline!\n");
+};
+
+subtest 'Inline with layout' => sub {
+  $t->get_ok('/inline/explicit_layout')->status_is(200)->header_is(Server => 'Mojolicious (Perl)')
+    ->content_is("layouted inline!\n\n");
 };
 
 subtest '"0" inline template' => sub {


### PR DESCRIPTION
### Summary
Allow inline templates to use layouts. This requires the layout to be specified directly in the call to `render` or in the template itself, same as when using the `render_to_string` method.

**Note**:  this is edited from the initial version where a layout set in the stash was also applied. The current version of this PR starts at [this comment](https://github.com/mojolicious/mojo/pull/1780#issuecomment-859111008).

### Motivation
There is no reason to *disallow* inline templates from using layouts if they can work and if doing so won’t break existing users.

In my particular case I am building a site where users can provide custom themes that are mostly implemented as templates. These templates can’ be guaranteed to have unique names so i can’t add there parents directory to the templates directories of the application. Using inline template is a workaround but currently prevent using layouts. This PR is attempting to fix this.

This is my first contributing to Mojolicious, so I may be missing something and the fix may not be correct (although all current tests pass, except those that specifically tested that inline template didn’t work with layouts and that are now fixed).

### References
None.
