### PR TITLE
Add a template_path option to Mojolicious::Renderer::render

### DIFF
--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -198,6 +198,11 @@ L<Mojolicious::Controller/"render_maybe"> to try multiple alternatives.
 
   $c->render_maybe('localized/baz') or $c->render('foo/bar/baz');
 
+If you want to render a template from a specific file not in a C<templates> directory, you can pass it with the
+C<template_path> option.
+
+  $c->render(template_path => '/path/to/the/template');
+
 =head2 Rendering to strings
 
 Sometimes you might want to use the rendered result directly instead of generating a response, for example, to send

--- a/t/mojolicious/layouted_lite_app.t
+++ b/t/mojolicious/layouted_lite_app.t
@@ -107,6 +107,8 @@ get '/variants' => [format => ['txt']] => {layout => 'variants', format => undef
   $c->render('variants');
 };
 
+get '/specific_template' => {template_path => curfile->sibling('templates2')->child('42.html.ep')->to_string};
+
 my $t = Test::Mojo->new;
 
 subtest '"0" content reassignment' => sub {
@@ -280,6 +282,10 @@ subtest 'Variants (desktop fallback)' => sub {
 subtest 'Variants ("0")' => sub {
   $t->get_ok('/variants.txt?device=0')->status_is(200)->content_type_is('text/plain;charset=UTF-8')
     ->content_is('Another variant: Desktop!');
+};
+
+subtest 'Specific template path' => sub {
+  $t->get_ok('/specific_template')->status_is(200)->content_is("DefaultThe answer is 42.\n\n");
 };
 
 done_testing();


### PR DESCRIPTION
Add a template_path option to Mojolicious::Renderer::render that allow to pass the path to a specific template file.

### Summary
Currently only templates found inside directories registered with Mojolicious::Renderer::paths can be used. This PR allows to use arbitrary template files.

### Motivation
This is useful to reference template files that may have clashing names within different directories (so using relative paths from registered directory would be ambiguous).

In my case, I want to allow my user to provide path to plugins directories (themes for a website) that may each contain a "template/view.html.ep" files for example (so they would all look the same if added the the renderer paths).

### References
PR #1780 is actually a work-around for the same feature request (loading an arbitrary file in memory and then rendering it as an inline template with a layout). While I think that the other PR has merit on its own, this here is actually a more straightforward solution to my problem which has the advantage of not changing an existing API so it should not break existing users.