### PR TITLE
The #mojo channel is moving to libera.chat

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,7 +27,7 @@ WriteMakefile(
         url  => 'https://github.com/mojolicious/mojo.git',
         web  => 'https://github.com/mojolicious/mojo',
       },
-      x_IRC => {url => 'irc://chat.freenode.net/#mojo', web => 'https://webchat.freenode.net/#mojo'}
+      x_IRC => {url => 'irc://irc.libera.chat/#mojo', web => 'https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo'}
     },
   },
   PREREQ_PM => {'IO::Socket::IP' => '0.37', 'Sub::Util' => '1.41'},

--- a/lib/Mojolicious/Guides.pod
+++ b/lib/Mojolicious/Guides.pod
@@ -510,7 +510,7 @@ wiki|https://github.com/mojolicious/mojo/wiki>.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/Guides/Contributing.pod
+++ b/lib/Mojolicious/Guides/Contributing.pod
@@ -70,9 +70,9 @@ relevant documentation.
 
 While the L<Mojolicious> distribution covers a wide range of features, we are rather conservative when it comes to
 adding new ones. So if your contribution is not a simple bug fix, it is B<strongly recommended> that you discuss it in
-advance in the L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>), to avoid unnecessary work and to increase its chances of getting
-accepted.
+advance in the L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>), to avoid unnecessary work and to increase
+its chances of getting accepted.
 
 The following mission statement and rules are the foundation of all L<Mojo> and L<Mojolicious> development. Please make
 sure that your contribution aligns well with them before sending a pull request.
@@ -258,7 +258,7 @@ authors.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -1918,7 +1918,7 @@ authors.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/Guides/FAQ.pod
+++ b/lib/Mojolicious/Guides/FAQ.pod
@@ -54,8 +54,8 @@ already have done in the past.
 
 =head2 Where can I discuss my patches for Mojolicious?
 
-We'd love to discuss your contributions to L<Mojolicious> on our official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+We'd love to discuss your contributions to L<Mojolicious> on our official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =head2 Which versions of Perl are supported by Mojolicious?
 
@@ -244,7 +244,7 @@ authors.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -769,7 +769,7 @@ authors.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -1421,7 +1421,7 @@ authors.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/Guides/Routing.pod
+++ b/lib/Mojolicious/Guides/Routing.pod
@@ -985,7 +985,7 @@ authors.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/Guides/Testing.pod
+++ b/lib/Mojolicious/Guides/Testing.pod
@@ -644,7 +644,7 @@ authors.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/Guides/Tutorial.pod
+++ b/lib/Mojolicious/Guides/Tutorial.pod
@@ -933,7 +933,7 @@ authors.
 =head1 SUPPORT
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
-L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<chat.freenode.net>
-(L<chat now!|https://webchat.freenode.net/#mojo>).
+L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
+(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
 
 =cut

--- a/lib/Mojolicious/resources/templates/mojo/debug.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/debug.html.ep
@@ -63,7 +63,7 @@
                 Community
               </a>
               <div class="dropdown-menu" aria-labelledby="communityDropdown">
-                <a class="dropdown-item" href="https://webchat.freenode.net/#mojo">Chat</a>
+                <a class="dropdown-item" href="https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo">Chat</a>
                 <a class="dropdown-item" href="https://forum.mojolicious.org">Forum</a>
                 <a class="dropdown-item" href="https://twitter.com/mojolicious_org">Twitter</a>
                 <a class="dropdown-item" href="https://blogs.mojolicious.org">Blogs</a>


### PR DESCRIPTION
### Summary
Replace references to the freenode channel with libera.chat

### Motivation
IRC channel is moving

### References
https://www.kline.sh/
