### PR TITLE
Do not close paragraphs due to div inside svg or mathml.

### DIFF
--- a/lib/Mojo/DOM/HTML.pm
+++ b/lib/Mojo/DOM/HTML.pm
@@ -58,7 +58,7 @@ map { $END{$_} = 'p' } (
   qw(header hgroup hr main menu nav ol p pre section table ul)
 );
 
-# Container HTML elements that create their own scope.
+# Container HTML elements that create their own scope
 my %SCOPE = map { $_ => 1 } qw(math svg);
 
 # HTML table elements with optional end tags
@@ -185,7 +185,7 @@ sub _end {
     # Ignore useless end tag
     return if $next->[0] eq 'root';
 
-    # Don’t traverse a container tag.
+    # Don’t traverse a container tag
     return if $SCOPE{$next->[1]} && $next->[1] ne $end;
 
     # Right tag

--- a/lib/Mojo/DOM/HTML.pm
+++ b/lib/Mojo/DOM/HTML.pm
@@ -58,6 +58,9 @@ map { $END{$_} = 'p' } (
   qw(header hgroup hr main menu nav ol p pre section table ul)
 );
 
+# Container HTML elements that create their own scope.
+my %SCOPE = map { $_ => 1 } qw(math svg);
+
 # HTML table elements with optional end tags
 my %TABLE = map { $_ => 1 } qw(colgroup tbody td tfoot th thead tr);
 
@@ -181,6 +184,9 @@ sub _end {
 
     # Ignore useless end tag
     return if $next->[0] eq 'root';
+
+    # Don’t traverse a container tag.
+    return if $SCOPE{$next->[1]} && $next->[1] ne $end;
 
     # Right tag
     return $$current = $next->[3] if $next->[1] eq $end;

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -2596,6 +2596,25 @@ subtest 'Not self-closing' => sub {
   is "$dom", '<p><svg><circle></circle><circle></circle></svg></p>', 'right result';
 };
 
+subtest 'Auto-close tag' => sub {
+  my $dom = Mojo::DOM->new('<p><div />');
+  is "$dom", '<p></p><div></div>', 'right result';
+};
+
+subtest 'No auto-close in scope' => sub {
+  my $dom = Mojo::DOM->new('<p><svg><div /></svg>');
+  is "$dom", '<p><svg><div></div></svg></p>', 'with SVG';
+  $dom = Mojo::DOM->new('<p><math><div /></math>');
+  is "$dom", '<p><math><div></div></math></p>', 'with MathML';
+};
+
+subtest 'Auto-close scope' => sub {
+  my $dom = Mojo::DOM->new('<p><svg></p>');
+  is "$dom", '<p><svg></svg></p>', 'closing tag';
+  $dom = Mojo::DOM->new('<p><math>');
+  is "$dom", '<p><math></math></p>', 'close eof';
+};
+
 subtest '"image"' => sub {
   my $dom = Mojo::DOM->new('<image src="foo.png">test');
   is $dom->at('img')->{src}, 'foo.png', 'right attribute';


### PR DESCRIPTION
### Summary
This is a tentative to fix #1536 by not crossing container element while going up the tree to auto-close other tags.

### Motivation
Seemed easy to fix. But then I’m sure that there are plenty of edge cases that I didn’t think of, feel free to suggest tests to add here.

### References
#1536
