### PR TITLE
return undef for nonexisting _attr and _text selectors in tests

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -333,7 +333,7 @@ sub websocket_ok {
 
 sub _attr {
   my ($self, $selector, $attr) = @_;
-  return '' unless my $e = $self->tx->res->dom->at($selector);
+  return undef unless my $e = $self->tx->res->dom->at($selector);
   return $e->attr($attr) // '';
 }
 
@@ -404,7 +404,7 @@ sub _request_ok {
 }
 
 sub _text {
-  return '' unless my $e = shift->tx->res->dom->at(shift);
+  return undef unless my $e = shift->tx->res->dom->at(shift);
   return $e->text;
 }
 

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -196,13 +196,14 @@ $t->get_ok($url => {'X-Test' => 'Hi there!'})->status_isnt(404)->status_is(200)-
   ->content_like(qr/fun/, 'with description')->content_unlike(qr/boring/)
   ->content_unlike(qr/boring/, 'with description')->element_exists('p')->element_exists('p', 'with description')
   ->element_exists_not('b')->element_exists_not('b', 'with description')->text_is('p', 'Have fun!')
-  ->text_is('p', 'Have fun!', 'with description')->text_isnt('p', 'Have')->text_isnt('p', 'Have', 'with description')
-  ->text_like('p', qr/fun/)->text_like('p', qr/fun/, 'with description')->text_unlike('p', qr/boring/)
-  ->text_unlike('p', qr/boring/, 'with description');
+  ->text_is('p', 'Have fun!', 'with description')->text_is('notfound',                 undef)->text_isnt('p', 'Have')
+  ->text_isnt('p', 'Have', 'with description')->text_like('p', qr/fun/)->text_like('p', qr/fun/, 'with description')
+  ->text_unlike('p', qr/boring/)->text_unlike('p', qr/boring/, 'with description');
 
 # Foo::joy (testing HTML attributes in template)
 $t->get_ok('/fun/joy')->status_is(200)->attr_is('p.joy', 'style', 'background-color: darkred;')
   ->attr_is('p.joy', 'style', 'background-color: darkred;', 'with description')->attr_is('p.joy', 'data-foo', '0')
+  ->attr_is('p.joy', 'data-empty', '')->attr_is('notfound', 'style', undef)
   ->attr_isnt('p.joy', 'style', 'float: left;')->attr_isnt('p.joy', 'style', 'float: left;', 'with description')
   ->attr_like('p.joy', 'style', qr/color/)->attr_like('p.joy', 'style', qr/color/, 'with description')
   ->attr_unlike('p.joy', 'style', qr/^float/)->attr_unlike('p.joy', 'style', qr/^float/, 'with description');

--- a/t/mojolicious/lib/MojoliciousTest/Foo.pm
+++ b/t/mojolicious/lib/MojoliciousTest/Foo.pm
@@ -103,7 +103,7 @@ __DATA__
 <p>Have fun!</p>\
 
 @@ foo/joy.html.ep
-<p class="joy" style="background-color: darkred;" data-foo="0">Joy for all!</p>\
+<p class="joy" style="background-color: darkred;" data-foo="0" data-empty="">Joy for all!</p>\
 
 @@ just/some/template.html.epl
 Development template with high precedence.


### PR DESCRIPTION
### Summary
Return undef instead of empty string for nonexistent _attr and _text selectors in tests.

### Motivation
This can be helpful to prevent tests with a typo in the selector from passing.

For example this test will now fail (notice the typo):
`$t->attr_is('form inputt[name=user]', 'value, '');`
