### PR TITLE
Mojo::IOLoop example fix (minor)

### DIFF
--- a/lib/Mojo/IOLoop.pm
+++ b/lib/Mojo/IOLoop.pm
@@ -233,7 +233,7 @@ Mojo::IOLoop - Minimalistic event loop
   use Mojo::IOLoop;
 
   # Listen on port 3000
-  Mojo::IOLoop->server({port => 3000} => sub ($loop, $stream) {
+  Mojo::IOLoop->server({port => 3000} => sub ($loop, $stream, $id) {
     $stream->on(read => sub ($stream, $bytes) {
       # Process input chunk
       say $bytes;


### PR DESCRIPTION
The example from the Mojo::IOLoop page needs '-signatures',
and even with '-signatures' it fails with

Mojo::Reactor::Poll: I/O watcher failed: Too many arguments for subroutine 'main::__ANON__' at /usr/local/share/perl5/5.32/Mojo/IOLoop.pm line 112.

because the server handler gets third argument - the $id.
