### PR TITLE
Fix two bugs in the Cookbook.pod

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -839,7 +839,7 @@ or they would just keep getting emitted.
     });
 
     # Stop recurring timer
-    $c->on(finish => sub ($ioloop) { $ioloop->remove($id) });
+    $c->on(finish => sub ($c) { Mojo::IOLoop->remove($id) });
   };
 
   app->start;
@@ -1062,7 +1062,7 @@ almost all layers, and which can be combined to solve some of the hardest proble
   use Scalar::Util qw(weaken);
 
   # Intercept multipart uploads and log each chunk received
-  hook after_build_tx => sub ($tx) {
+  hook after_build_tx => sub ($tx, $app) {
 
     # Subscribe to "upgrade" event to identify multipart uploads
     weaken $tx;
@@ -1080,7 +1080,7 @@ almost all layers, and which can be combined to solve some of the hardest proble
           $single->unsubscribe('read')->on(read => sub ($single, $bytes) {
 
             # Log size of every chunk we receive
-            app->log->debug(length($bytes) . ' bytes uploaded');
+            $app->log->debug(length($bytes) . ' bytes uploaded');
           });
         });
       });


### PR DESCRIPTION
### Summary
Fix two bugs in the Cookbook.pod (examples)

### Motivation
Any student who want to learn more about Mojolicious should have a bugfree experience

### References
bug 1.)  Mojolicious -> hook -> after_build_tx
bug 2.) Mojolicious::Cotroller -> on -> finish
