### PR TITLE
doc: reword testing guide paragraph

### DIFF
--- a/lib/Mojolicious/Guides/Testing.pod
+++ b/lib/Mojolicious/Guides/Testing.pod
@@ -159,9 +159,9 @@ To test a L<Mojolicious::Lite> application, pass the file path to the applicatio
   use Mojo::File qw(curfile);
   my $t = Test::Mojo->new(curfile->dirname->sibling('myapp.pl'));
 
-This object initializes a L<Mojo::UserAgent> object, loads the Mojolicious application C<Frogs>, binds and listens on a
-free TCP port (e.g., 32114), and starts the application event loop. When the L<Test::Mojo> object (C<$t>) goes out of
-scope, the application is stopped.
+The object initializes a L<Mojo::UserAgent> object, loads the Mojolicious application, binds and listens on a free TCP
+port (e.g., 32114), and starts the application event loop. When the L<Test::Mojo> object (C<$t>) goes out of scope, the
+application is stopped.
 
 Relative URLs in the test object method assertions (C<get_ok>, C<post_ok>, etc.) will be sent to the Mojolicious
 application started by L<Test::Mojo>:


### PR DESCRIPTION
### Summary
Reword the paragraph explaining the same code but with two different approaches.

### Motivation
The way the paragraph is written now may lead the reader to think that explanation is valid only for one of the snippets instead of the two it's actually referring to. To avoid it, slightly change the first sentence.
