### PR TITLE
Minor tweaks to Growing guide.

### DIFF
--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -71,13 +71,13 @@ and all session state is kept client-side.
   |         | <-    200 OK        <- |            |
   +---------+                        +------------+
 
-While HTTP methods such as C<PUT>, C<GET> and C<DELETE> are not directly part of REST they go very well with it and are
+While HTTP methods such as C<PUT>, C<GET> and C<DELETE> are not directly part of REST they go well with it and are
 commonly used to manipulate I<resources>.
 
 =head2 Sessions
 
 HTTP was designed as a stateless protocol, web servers don't know anything about previous requests, which makes
-user-friendly login systems very tricky. Sessions solve this problem by allowing web applications to keep stateful
+user-friendly login systems tricky. Sessions solve this problem by allowing web applications to keep stateful
 information across several HTTP requests.
 
   GET /login?user=sebastian&pass=s3cret HTTP/1.1
@@ -97,7 +97,7 @@ information across several HTTP requests.
   Content-Length: 16
   Hello again sebastian.
 
-Traditionally all session data was stored on the server-side and only session ids were exchanged between browser and
+Traditionally all session data was stored on the server-side and only session IDs were exchanged between browser and
 web server in the form of cookies.
 
   Set-Cookie: session=hmac-sha1(base64(json($session)))


### PR DESCRIPTION

### Summary
Remove very and capitalize ID

### Motivation
Remove 'very' as it's frowned upon in English style guides and not contributing much to these sentences.
ID should be be capitalized according to English guides. I'd say the exception would be when we're directly referring to an 'id' attribute in markup.

### References

https://www.forbes.com/sites/katelee/2012/11/30/mark-twain-on-writing-kill-your-adjectives/
https://english.stackexchange.com/questions/101248/how-should-the-abbreviation-for-identifier-be-capitalized
Originally raised in https://github.com/mojolicious/mojo.js/pull/44