### PR TITLE
Finish rendering early in Mojolicious::dispatch

### DIFF
--- a/t/mojolicious/dispatcher_lite_app.t
+++ b/t/mojolicious/dispatcher_lite_app.t
@@ -186,3 +186,5 @@ __DATA__
 Static response!
 @@ test.txt
 Normal static file!
+@@ hello-delay.txt
+This is never rendered and overloaded by before_dispatch


### PR DESCRIPTION
### Summary
If rendering happened in before_dispatch (e.g. dynamic paths were processed), no need to try to render with static or find a route.

### Motivation
If before_dispatch sets 'rendered' flag, further actions around static and routes not only waste of resources, but may also finish rendering, which will suppress delayed rendering from before_dispatch

### References
#1534
