### PR TITLE
More grammar fixes for Growing guide

### DIFF
--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -303,13 +303,13 @@ route placeholders, all at once.
 
 =head2 Testing
 
-In L<Mojolicious> we take testing very serious and try to make it a pleasant experience.
+In L<Mojolicious> we take testing very seriously and try to make it a pleasant experience.
 
   $ mkdir t
   $ touch t/login.t
   $ chmod 644 t/login.t
 
-L<Test::Mojo> is a scriptable HTTP user agent designed specifically for testing, with many fun state of the art
+L<Test::Mojo> is a scriptable HTTP user agent designed specifically for testing, with many fun state-of-the-art
 features such as CSS selectors based on L<Mojo::DOM>.
 
   use Test::More;


### PR DESCRIPTION
### Summary
Fix a couple of grammar issues in Testing section

### Motivation
The adjective state-of-the-art should be written with dashes, and we should use the adverb seriously in this context.

### References
https://writingexplained.org/state-of-the-art-vs-state-of-the-art