### PR TITLE
Add sprintf wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@
     * JSON and HTML/XML parser with CSS selector support.
   * Very clean, portable and object-oriented pure-Perl API with no hidden magic and no requirements besides Perl 5.26.0
     (versions as old as 5.16.0 can be used too, but may require additional CPAN modules to be installed)
-  * Fresh code based upon years of experience developing [Catalyst](https://en.wikipedia.org/wiki/Catalyst_(software)),
-    free and open source.
+  * Fresh code based upon years of experience developing [Catalyst](http://catalyst.perl.org), free and open source.
   * Hundreds of 3rd party [extensions](https://metacpan.org/requires/distribution/Mojolicious) and high quality spin-off
     projects like the [Minion](https://metacpan.org/pod/Minion) job queue.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
     * JSON and HTML/XML parser with CSS selector support.
   * Very clean, portable and object-oriented pure-Perl API with no hidden magic and no requirements besides Perl 5.26.0
     (versions as old as 5.16.0 can be used too, but may require additional CPAN modules to be installed)
-  * Fresh code based upon years of experience developing [Catalyst](http://www.catalystframework.org), free and open
-    source.
+  * Fresh code based upon years of experience developing [Catalyst](https://en.wikipedia.org/wiki/Catalyst_(software)),
+    free and open source.
   * Hundreds of 3rd party [extensions](https://metacpan.org/requires/distribution/Mojolicious) and high quality spin-off
     projects like the [Minion](https://metacpan.org/pod/Minion) job queue.
 

--- a/lib/Mojo/Log.pm
+++ b/lib/Mojo/Log.pm
@@ -42,16 +42,22 @@ sub append {
   flock $handle, LOCK_UN;
 }
 
-sub debug { 2 >= $LEVEL{$_[0]->level} ? _log(@_, 'debug') : $_[0] }
+sub debug  { 2 >= $LEVEL{$_[0]->level} ? _log(@_, 'debug') : $_[0] }
+sub debugf { shift->debug(sprintf(shift, @_)) }
 
 sub context {
   my ($self, @context) = @_;
   return $self->new(parent => $self, context => \@context, level => $self->level);
 }
 
-sub error { 5 >= $LEVEL{$_[0]->level} ? _log(@_, 'error') : $_[0] }
-sub fatal { 6 >= $LEVEL{$_[0]->level} ? _log(@_, 'fatal') : $_[0] }
+sub error  { 5 >= $LEVEL{$_[0]->level} ? _log(@_, 'error') : $_[0] }
+sub errorf { shift->error(sprintf(shift, @_)) }
+
+sub fatal  { 6 >= $LEVEL{$_[0]->level} ? _log(@_, 'fatal') : $_[0] }
+sub fatalf { shift->fatal(sprintf(shift, @_)) }
+
 sub info  { 3 >= $LEVEL{$_[0]->level} ? _log(@_, 'info')  : $_[0] }
+sub infof { shift->info(sprintf(shift, @_)) }
 
 sub is_level { $LEVEL{pop()} >= $LEVEL{shift->level} }
 
@@ -61,8 +67,11 @@ sub new {
   return $self;
 }
 
-sub trace { 1 >= $LEVEL{$_[0]->level} ? _log(@_, 'trace') : $_[0] }
+sub trace  { 1 >= $LEVEL{$_[0]->level} ? _log(@_, 'trace') : $_[0] }
+sub tracef { shift->trace(sprintf(shift, @_)) }
+
 sub warn  { 4 >= $LEVEL{$_[0]->level} ? _log(@_, 'warn')  : $_[0] }
+sub warnf { shift->warn(sprintf(shift, @_)) }
 
 sub _color {
   my $msg = _default(shift, my $level = shift, @_);
@@ -239,6 +248,12 @@ Construct a new child L<Mojo::Log> object that will include context information 
 
 Emit L</"message"> event and log C<debug> message.
 
+=head2 debugf
+
+  $log = $log->debugf('%s is %s', 'Mojolicious', 'cool');
+
+Simple sprint-based wrapper over L</"debug"> method.
+
 =head2 error
 
   $log = $log->error('You really screwed up this time');
@@ -246,6 +261,12 @@ Emit L</"message"> event and log C<debug> message.
   $log = $log->error(sub {...});
 
 Emit L</"message"> event and log C<error> message.
+
+=head2 errorf
+
+  $log = $log->errorf('%s is %s', 'Mojolicious', 'cool');
+
+Simple sprint-based wrapper over L</"error"> method.
 
 =head2 fatal
 
@@ -255,6 +276,12 @@ Emit L</"message"> event and log C<error> message.
 
 Emit L</"message"> event and log C<fatal> message.
 
+=head2 fatalf
+
+  $log = $log->fatalf('%s is %s', 'Mojolicious', 'cool');
+
+Simple sprint-based wrapper over L</"fatal"> method.
+
 =head2 info
 
   $log = $log->info('You are bad, but you prolly know already');
@@ -262,6 +289,12 @@ Emit L</"message"> event and log C<fatal> message.
   $log = $log->info(sub {...});
 
 Emit L</"message"> event and log C<info> message.
+
+=head2 infof
+
+  $log = $log->infof('%s is %s', 'Mojolicious', 'cool');
+
+Simple sprint-based wrapper over L</"info"> method.
 
 =head2 is_level
 
@@ -293,6 +326,12 @@ Construct a new L<Mojo::Log> object and subscribe to L</"message"> event with de
 
 Emit L</"message"> event and log C<trace> message.
 
+=head2 tracef
+
+  $log = $log->tracef('%s is %s', 'Mojolicious', 'cool');
+
+Simple sprint-based wrapper over L</"trace"> method.
+
 =head2 warn
 
   $log = $log->warn('Dont do that Dave...');
@@ -300,6 +339,12 @@ Emit L</"message"> event and log C<trace> message.
   $log = $log->warn(sub {...});
 
 Emit L</"message"> event and log C<warn> message.
+
+=head2 warnf
+
+  $log = $log->warnf('%s is %s', 'Mojolicious', 'cool');
+
+Simple sprint-based wrapper over L</"warn"> method.
 
 =head1 SEE ALSO
 

--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -301,13 +301,13 @@ route placeholders, all at once.
 
 =head2 Testing
 
-In L<Mojolicious> we take testing very serious and try to make it a pleasant experience.
+In L<Mojolicious> we take testing very seriously and try to make it a pleasant experience.
 
   $ mkdir t
   $ touch t/login.t
   $ chmod 644 t/login.t
 
-L<Test::Mojo> is a scriptable HTTP user agent designed specifically for testing, with many fun state of the art
+L<Test::Mojo> is a scriptable HTTP user agent designed specifically for testing, with many fun state-of-the-art
 features such as CSS selectors based on L<Mojo::DOM>.
 
   use Test::More;

--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -281,7 +281,7 @@ Any of the native Perl data types can be passed to templates as references throu
 L<Mojolicious::Controller/"stash">.
 
   $c->stash(description => 'web framework');
-  $c->stash(frameworks  => ['Catalyst', 'Mojolicious']);
+  $c->stash(frameworks  => ['Catalyst', 'Mojolicious', 'mojo.js']);
   $c->stash(spinoffs    => {minion => 'job queue'});
 
   %= $description

--- a/lib/Mojolicious/Guides/Tutorial.pod
+++ b/lib/Mojolicious/Guides/Tutorial.pod
@@ -277,7 +277,7 @@ they are the foundation for many helpers.
     <head><title>Sebastians frameworks</title></head>
     <body>
       %= $link->('http://mojolicious.org', 'Mojolicious')
-      %= $link->('http://catalystframework.org', 'Catalyst')
+      %= $link->('http://mojojs.org', 'mojo.js')
     </body>
   </html>
 

--- a/t/mojo/log.t
+++ b/t/mojo/log.t
@@ -229,4 +229,27 @@ subtest 'Context' => sub {
   like $buffer,   qr/\[.*\] \[fatal\] \[123\] Mojolicious rocks\n/, 'right fatal message';
 };
 
+subtest 'Text formatting wrappers' => sub {
+  my $log    = Mojo::Log->new(level => 'trace', path => $path);
+  my $buffer = '';
+  {
+    open my $handle, '>', \$buffer;
+    local *STDERR = $handle;
+    my $log = Mojo::Log->new;
+    $log->tracef('Mojolicious %s', 'works');
+    $log->debugf('Mojolicious %s', 'just works');
+    $log->infof( 'Mojolicious %s', 'really works');
+    $log->warnf( 'Mojolicious %s', 'works, really');
+    $log->errorf('Mojolicious %s', 'works great');
+    $log->fatalf('Mojolicious %s', 'works well');
+  }
+  my $content = decode 'UTF-8', $buffer;
+  like $content, qr/\[.*\] \[trace\] Mojolicious works\n/,        'right error message';
+  like $content, qr/\[.*\] \[debug\] Mojolicious just works\n/,   'right error message';
+  like $content, qr/\[.*\] \[info\] Mojolicious really works\n/,  'right error message';
+  like $content, qr/\[.*\] \[warn\] Mojolicious works, really\n/, 'right error message';
+  like $content, qr/\[.*\] \[error\] Mojolicious works great\n/,  'right error message';
+  like $content, qr/\[.*\] \[fatal\] Mojolicious works well\n/,   'right error message';
+};
+
 done_testing();


### PR DESCRIPTION
### Summary
Add sprintf-based wrappers over standard logging methods (debug(), info(), error(), ...)

### Motivation
This is just a port of a Log::Any feature:
https://metacpan.org/pod/Log::Any#Logging