### PR TITLE
Convert t/mojolicious/command.t to use subtests

### DIFF
--- a/t/mojolicious/command.t
+++ b/t/mojolicious/command.t
@@ -6,34 +6,42 @@ use Test::More;
 use Mojo::File qw(path tempdir);
 use Mojolicious::Command;
 
-# Application
-my $command = Mojolicious::Command->new;
-isa_ok $command->app, 'Mojolicious', 'right application';
+subtest 'Application' => sub {
+  my $command = Mojolicious::Command->new;
+  isa_ok $command->app, 'Mojolicious', 'right application';
+};
 
-# Creating directories
-my $cwd = path;
-my $dir = tempdir;
-chdir $dir;
-my $buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDOUT = $handle;
-  $command->create_rel_dir('foo/bar');
-}
-like $buffer, qr/[mkdir]/, 'right output';
-ok -d path('foo', 'bar'), 'directory exists';
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDOUT = $handle;
-  $command->create_rel_dir('foo/bar');
-}
-like $buffer, qr/\[exist\]/, 'right output';
-chdir $cwd;
+subtest 'Creating directories' => sub {
+  my $command = Mojolicious::Command->new;
+  my $cwd     = path;
+  my $dir     = tempdir;
+  my $buffer  = '';
+  chdir $dir;
+  {
+    open my $handle, '>', \$buffer;
+    local *STDOUT = $handle;
+    $command->create_rel_dir('foo/bar');
+  }
+  like $buffer, qr/[mkdir]/, 'right output';
+  ok -d path('foo', 'bar'), 'directory exists';
 
-# Generating files
-is $command->rel_file('foo/bar.txt')->basename, 'bar.txt', 'right result';
-my $template = <<'EOF';
+  $buffer = '';
+  {
+    open my $handle, '>', \$buffer;
+    local *STDOUT = $handle;
+    $command->create_rel_dir('foo/bar');
+  }
+  like $buffer, qr/\[exist\]/, 'right output';
+  chdir $cwd;
+};
+
+subtest 'Generating files' => sub {
+  my $command = Mojolicious::Command->new;
+  my $cwd     = path;
+  my $dir     = tempdir;
+  is $command->rel_file('foo/bar.txt')->basename, 'bar.txt', 'right result';
+
+  my $template = <<'EOF';
 @@ foo_bar
 % my $word = shift;
 just <%= $word %>!
@@ -42,69 +50,80 @@ just <%= $word %>!
 @@ bar_baz
 just <%= $word %> too!
 EOF
-open my $data, '<', \$template;
-no strict 'refs';
-*{"Mojolicious::Command::DATA"} = $data;
-chdir $dir;
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDOUT = $handle;
-  $command->template({})->render_to_rel_file('foo_bar', 'bar/baz.txt', 'works');
-}
-like $buffer, qr/\[mkdir\].*\[write\]/s, 'right output';
-open my $txt, '<', $command->rel_file('bar/baz.txt');
-is join('', <$txt>), "just works!\n", 'right result';
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDOUT = $handle;
-  $command->template({vars => 1})->render_to_rel_file('bar_baz', 'bar/two.txt', {word => 'works'});
-}
-like $buffer, qr/\[exist\].*\[write\]/s, 'right output';
-open $txt, '<', $command->rel_file('bar/two.txt');
-is join('', <$txt>), "just works too!\n", 'right result';
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDOUT = $handle;
-  $command->chmod_rel_file('bar/baz.txt', 0700);
-}
-like $buffer, qr/\[chmod\]/, 'right output';
-ok -e $command->rel_file('bar/baz.txt'), 'file is executable';
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDOUT = $handle;
-  $command->write_rel_file('123.xml', "seems\nto\nwork");
-}
-like $buffer, qr/\[exist\].*\[write\]/s, 'right output';
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDOUT = $handle;
-  $command->write_rel_file('123.xml', 'fail');
-}
-like $buffer, qr/\[exist\]/, 'right output';
-open my $xml, '<', $command->rel_file('123.xml');
-is join('', <$xml>), "seems\nto\nwork", 'right result';
-eval { $command->render_data('dies') };
-like $@, qr/template error/, 'right error';
-chdir $cwd;
+  open my $data, '<', \$template;
+  no strict 'refs';
+  *{"Mojolicious::Command::DATA"} = $data;
+  chdir $dir;
+  my $buffer = '';
+  {
+    open my $handle, '>', \$buffer;
+    local *STDOUT = $handle;
+    $command->template({})->render_to_rel_file('foo_bar', 'bar/baz.txt', 'works');
+  }
+  like $buffer, qr/\[mkdir\].*\[write\]/s, 'right output';
+  open my $txt, '<', $command->rel_file('bar/baz.txt');
+  is join('', <$txt>), "just works!\n", 'right result';
 
-# Quiet
-chdir $dir;
-$buffer = '';
-{
-  open my $handle, '>', \$buffer;
-  local *STDOUT = $handle;
-  $command->quiet(1)->write_rel_file('123.xml', 'fail');
-}
-is $buffer, '', 'no output';
-chdir $cwd;
+  $buffer = '';
+  {
+    open my $handle, '>', \$buffer;
+    local *STDOUT = $handle;
+    $command->template({vars => 1})->render_to_rel_file('bar_baz', 'bar/two.txt', {word => 'works'});
+  }
+  like $buffer, qr/\[exist\].*\[write\]/s, 'right output';
+  open $txt, '<', $command->rel_file('bar/two.txt');
+  is join('', <$txt>), "just works too!\n", 'right result';
 
-# Abstract methods
-eval { Mojolicious::Command->run };
-like $@, qr/Method "run" not implemented by subclass/, 'right error';
+  $buffer = '';
+  {
+    open my $handle, '>', \$buffer;
+    local *STDOUT = $handle;
+    $command->chmod_rel_file('bar/baz.txt', 0700);
+  }
+  like $buffer, qr/\[chmod\]/, 'right output';
+  ok -e $command->rel_file('bar/baz.txt'), 'file is executable';
+
+  $buffer = '';
+  {
+    open my $handle, '>', \$buffer;
+    local *STDOUT = $handle;
+    $command->write_rel_file('123.xml', "seems\nto\nwork");
+  }
+  like $buffer, qr/\[exist\].*\[write\]/s, 'right output';
+
+  $buffer = '';
+  {
+    open my $handle, '>', \$buffer;
+    local *STDOUT = $handle;
+    $command->write_rel_file('123.xml', 'fail');
+  }
+  like $buffer, qr/\[exist\]/, 'right output';
+  open my $xml, '<', $command->rel_file('123.xml');
+  is join('', <$xml>), "seems\nto\nwork", 'right result';
+
+  eval { $command->render_data('dies') };
+  like $@, qr/template error/, 'right error';
+  chdir $cwd;
+};
+
+subtest 'Quiet' => sub {
+  my $command = Mojolicious::Command->new;
+  my $cwd     = path;
+  my $dir     = tempdir;
+  chdir $dir;
+  my $buffer = '';
+  {
+    open my $handle, '>', \$buffer;
+    local *STDOUT = $handle;
+    $command->quiet(1)->write_rel_file('123.xml', 'fail');
+  }
+  is $buffer, '', 'no output';
+  chdir $cwd;
+};
+
+subtest 'Abstract methods' => sub {
+  eval { Mojolicious::Command->run };
+  like $@, qr/Method "run" not implemented by subclass/, 'right error';
+};
 
 done_testing();


### PR DESCRIPTION
### Summary
The file `t/mojolicious/command.t` has been organised into subtests, and spacing added to create blocks within.

Note that the following variables were originally global, but have now been scoped to each subtest requiring them:
* `$buffer`
* `$template`
* `$command`
* `$cwd`
* `$dir`

### Motivation
Towards resolution of #1520

### References
Refer to discussion in #1520
