### PR TITLE
Ensure naming of files during app and dockerfile generation is consistent

### DIFF
--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -35,7 +35,7 @@ has log              => sub {
 };
 has 'max_request_size';
 has mode               => sub { $ENV{MOJO_MODE} || $ENV{PLACK_ENV} || 'development' };
-has moniker            => sub { Mojo::Util::decamelize ref shift };
+has moniker            => sub { Mojo::Util::class_to_file ref shift };
 has plugins            => sub { Mojolicious::Plugins->new };
 has preload_namespaces => sub { [] };
 has renderer           => sub { Mojolicious::Renderer->new };
@@ -425,7 +425,7 @@ variables or C<development>.
   $app        = $app->moniker('foo_bar');
 
 Moniker of this application, often used as default filename for configuration files and the like, defaults to
-decamelizing the application class with L<Mojo::Util/"decamelize">.
+transforming the application class with L<Mojo::Util/"class_to_file">.
 
 =head2 plugins
 

--- a/lib/Mojolicious/Command/Author/generate/app.pm
+++ b/lib/Mojolicious/Command/Author/generate/app.pm
@@ -19,7 +19,7 @@ sub run {
   $self->render_to_rel_file('appclass', "$name/lib/$app", {class => $class});
 
   # Config file (using the default moniker)
-  $self->render_to_rel_file('config', "$name/@{[decamelize $class]}.yml");
+  $self->render_to_rel_file('config', "$name/$name.yml");
 
   # Controller
   my $controller = "${class}::Controller::Example";

--- a/t/mojo/daemon.t
+++ b/t/mojo/daemon.t
@@ -270,7 +270,7 @@ subtest 'Timeout' => sub {
 subtest 'Pipelined' => sub {
   my $daemon = Mojo::Server::Daemon->new({listen => ['http://127.0.0.1'], silent => 1});
   my $port   = $daemon->start->ports->[0];
-  is $daemon->app->moniker, 'mojo-hello_world', 'right moniker';
+  is $daemon->app->moniker, 'mojo_hello_world', 'right moniker';
   my $buffer = '';
   my $id;
   $id = Mojo::IOLoop->client(


### PR DESCRIPTION

### Summary

* Use `Mojo::Util::class_to_file()` for file names generated from class names
* Update documentation

Currently, if generating an app named `MyApp::HTMLBuilder` and its dockerfile, the following inconsistent naming is formed:

```perl
$ mojo generate app MyApp::HTMLBuilder
$ cd my_app_htmlbuilder && ./script/my_app_htmlbuilder generate dockerfile
```

Name                   | Translation                  |Uses
 ---                   | ---                          | ---
App directory          | my_app_htmlbuilder           | `class_to_file()`
App script name        | my_app_htmlbuilder           | `class_to_file()`
App config name        | my_app-h_t_m_l_builder.yml   | `decamelize()`
Dockerfile content refs | my_app-h_t_m_l_builder       | `decamelize()`

This PR ensures only that `class_to_file()` is used consistently.


#### Important - This change will break existing apps!

For an app generated before this change, the former, inconsistent naming of the files will be in place.

```shell
$ ./script/my_app_original_app
Configuration file "/home/kat/tmp/~/mojo-app-gen-test/my_app_original_app/my_app_original_app.yml" missing, maybe you need to create it?
```

Steps for fixing:

* Rename the config file from `my_app-original_app.yml` to `my_app_original_app.yml`
* Regenerate or edit existing Dockerfiles to the changed naming for config


### Motivation

The goal of this PR is to ensure that naming files based on class names is predictable, by utilising only the `class_to_file()` function for this purpose - not mixing between that and `decamelize()`.

Whilst there are other improvements to be made, I have left these to future PRs to avoid including too much change here.  Once usage is standardised, the following further improvements might be considered.

* Ensure generated dockerfiles work out-of-the-box
* Consider adopting generic naming within the app dir (suggested by @jberger in #1905)
* Modify `class_to_file()` to produce unambiguous and reversible file names
* Modify `decamelize()` to produce output that is reversible with `camelize()`
* Validate that class names passed to `class_to_file()` are valid


### References

#1905 - Generating Dockerfile refers to wrong script name