### PR TITLE
Clarify link_to arguments

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -488,6 +488,12 @@ content.
   <a href="https://mojolicious.org">Mojolicious</a>
   <a href="http://127.0.0.1:3000/current/path?foo=bar">Retry</a>
 
+The first argument to C<link_to> is the link content, except when the
+final argument is Perl code such as a template block (created with the
+C<begin> and C<end> keywords); in that case, the link content is
+omitted at the start of the argument list, and the block will become
+the link content.
+
 =head2 month_field
 
   %= month_field 'vacation'


### PR DESCRIPTION
### Summary
In the `link_to` documentation, add a sentence explaining why, in the examples, sometimes there is a title given first, and sometimes a block of code or a template block as the final argument.

### Motivation
Without an explanation, some folks (e.g., me) may be confused about the correct or possible ways to call or use `link_to`… the truly devoted (or truly stubborn; me again) may even resort to deciphering the Mojo source to see what's really going on.  

