### PR TITLE
traceback in Mojo::Exception print fully qualified sub names

### DIFF
--- a/lib/Mojo/Exception.pm
+++ b/lib/Mojo/Exception.pm
@@ -99,7 +99,7 @@ sub to_string {
 
   if (my $max = @$frames) {
     $str .= "Traceback (most recent call first):\n";
-    $str .= qq{  File "$_->[1]", line $_->[2], in "$_->[0]"\n} for @$frames;
+    $str .= qq{  File "$_->[1]", line $_->[2], in "$_->[3]"\n} for @$frames;
   }
 
   return $str;

--- a/t/mojo/template.t
+++ b/t/mojo/template.t
@@ -708,7 +708,7 @@ is $output->lines_after->[0][0],  6,                'right number';
 is $output->lines_after->[0][1],  '%= 1 + 1',       'right line';
 is $output->lines_after->[1][0],  7,                'right number';
 is $output->lines_after->[1][1],  'test',           'right line';
-$output->frames([['Sandbox', 'template', 5], ['main', 'template.t', 673]]);
+$output->frames([['Sandbox', 'template', 5, 'Sandbox::sub'], ['main', 'template.t', 673, 'main::sub']]);
 is $output, <<EOF, 'right result';
 oops! at template line 5.
 Context:
@@ -720,8 +720,8 @@ Context:
   6: %= 1 + 1
   7: test
 Traceback (most recent call first):
-  File "template", line 5, in "Sandbox"
-  File "template.t", line 673, in "main"
+  File "template", line 5, in "Sandbox::sub"
+  File "template.t", line 673, in "main::sub"
 EOF
 
 # Exception in template (empty perl lines)


### PR DESCRIPTION
This should fix the situation with traceback produced by Mojo::Exception much less informative than traceback produced by Carp

```
exception: raise at /home/agrechkin/tmp/test-exception line 9.
Traceback (most recent call first):
  File "/home/agrechkin/tmp/test-exception", line 9, in "main"
  File "/home/agrechkin/tmp/test-exception", line 12, in "main"
  File "/home/agrechkin/tmp/test-exception", line 24, in "main"
  File "/home/agrechkin/tmp/test-exception", line 29, in "main"

exception: croak at /home/agrechkin/tmp/test-exception line 17.
        eval {...} called at /home/agrechkin/tmp/test-exception line 20
        main::carp_croak() called at /home/agrechkin/tmp/test-exception line 25
        main::main() called at /home/agrechkin/tmp/test-exception line 29
```

Closes: #1947
