### PR TITLE
Convert t/mojo/ioloop_ipv6.t to use subtests

### DIFF
--- a/t/mojo/ioloop_ipv6.t
+++ b/t/mojo/ioloop_ipv6.t
@@ -10,30 +10,31 @@ plan skip_all => 'set TEST_IPV6 to enable this test (developer only!)' unless $E
 
 use Mojo::IOLoop;
 
-# IPv6 roundtrip
-my ($server, $client);
-my $promise = Mojo::Promise->new;
-my $id      = Mojo::IOLoop->server(
-  {address => '[::1]'} => sub {
-    my ($loop, $stream) = @_;
-    $stream->write('test' => sub { shift->write('321') });
-    $stream->on(close => sub { $promise->resolve });
-    $stream->on(read  => sub { $server .= pop });
-  }
-);
-my $port     = Mojo::IOLoop->acceptor($id)->port;
-my $promise2 = Mojo::Promise->new;
-Mojo::IOLoop->client(
-  {address => '[::1]', port => $port} => sub {
-    my ($loop, $err, $stream) = @_;
-    $stream->write('tset' => sub { shift->write('123') });
-    $stream->on(close => sub { $promise2->resolve });
-    $stream->on(read  => sub { $client .= pop });
-    $stream->timeout(0.5);
-  }
-);
-Mojo::Promise->all($promise, $promise2)->wait;
-is $server, 'tset123', 'right content';
-is $client, 'test321', 'right content';
+subtest 'IPv6 roundtrip' => sub {
+  my ($server, $client);
+  my $promise = Mojo::Promise->new;
+  my $id      = Mojo::IOLoop->server(
+    {address => '[::1]'} => sub {
+      my ($loop, $stream) = @_;
+      $stream->write('test' => sub { shift->write('321') });
+      $stream->on(close => sub { $promise->resolve });
+      $stream->on(read  => sub { $server .= pop });
+    }
+  );
+  my $port     = Mojo::IOLoop->acceptor($id)->port;
+  my $promise2 = Mojo::Promise->new;
+  Mojo::IOLoop->client(
+    {address => '[::1]', port => $port} => sub {
+      my ($loop, $err, $stream) = @_;
+      $stream->write('tset' => sub { shift->write('123') });
+      $stream->on(close => sub { $promise2->resolve });
+      $stream->on(read  => sub { $client .= pop });
+      $stream->timeout(0.5);
+    }
+  );
+  Mojo::Promise->all($promise, $promise2)->wait;
+  is $server, 'tset123', 'right content';
+  is $client, 'test321', 'right content';
+};
 
 done_testing();


### PR DESCRIPTION
### Summary
Tests in `t/mojo/ioloop_ipv6.t` converted to use subtests.

### Motivation
Help convert remaining subtests.

### References
#1520 
