### PR TITLE
Include SHA-256 functions in Mojo::Util

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -4,7 +4,7 @@ use Mojo::Base -strict;
 use Carp           qw(carp croak);
 use Data::Dumper   ();
 use Digest::MD5    qw(md5 md5_hex);
-use Digest::SHA    qw(hmac_sha1_hex sha1 sha1_hex);
+use Digest::SHA    qw(hmac_sha1_hex sha1 sha1_hex hmac_sha256_hex sha256 sha256_hex);
 use Encode         qw(find_encoding);
 use Exporter       qw(import);
 use File::Basename qw(dirname);
@@ -65,10 +65,10 @@ my (%ENCODING, %PATTERN);
 
 our @EXPORT_OK = (
   qw(b64_decode b64_encode camelize class_to_file class_to_path decamelize decode deprecated dumper encode),
-  qw(extract_usage getopt gunzip gzip hmac_sha1_sum html_attr_unescape html_unescape humanize_bytes md5_bytes md5_sum),
-  qw(monkey_patch network_contains punycode_decode punycode_encode quote scope_guard secure_compare sha1_bytes),
-  qw(sha1_sum slugify split_cookie_header split_header steady_time tablify term_escape trim unindent unquote),
-  qw(url_escape url_unescape xml_escape xor_encode)
+  qw(extract_usage getopt gunzip gzip hmac_sha1_sum hmac_sha256_sum html_attr_unescape html_unescape humanize_bytes),
+  qw(md5_bytes md5_sum monkey_patch network_contains punycode_decode punycode_encode quote scope_guard secure_compare),
+  qw(sha1_bytes sha256_bytes sha1_sum sha256_sum slugify split_cookie_header split_header steady_time tablify),
+  qw(term_escape trim unindent unquote url_escape url_unescape xml_escape xor_encode)
 );
 
 # Aliases
@@ -79,6 +79,9 @@ monkey_patch(__PACKAGE__, 'md5_bytes',     \&md5);
 monkey_patch(__PACKAGE__, 'md5_sum',       \&md5_hex);
 monkey_patch(__PACKAGE__, 'sha1_bytes',    \&sha1);
 monkey_patch(__PACKAGE__, 'sha1_sum',      \&sha1_hex);
+monkey_patch(__PACKAGE__, 'hmac_sha256_sum', \&hmac_sha256_hex);
+monkey_patch(__PACKAGE__, 'sha256_bytes',    \&sha256);
+monkey_patch(__PACKAGE__, 'sha256_sum',      \&sha256_hex);
 
 # Use a monotonic clock if possible
 monkey_patch(__PACKAGE__, 'steady_time',
@@ -701,6 +704,15 @@ Generate HMAC-SHA1 checksum for bytes with L<Digest::SHA>.
   # "11cedfd5ec11adc0ec234466d8a0f2a83736aa68"
   hmac_sha1_sum 'foo', 'passw0rd';
 
+=head2 hmac_sha256_sum
+
+  my $checksum = hmac_sha256_sum $bytes, 'passw0rd';
+
+Generate HMAC-SHA-256 checksum for bytes with L<Digest::SHA>.
+
+  # "e54ce0e8e81828088bc8e81b9f2d96816e4a56ffe691d40f1426365e83623c8c"
+  hmac_sha256_sum 'foo', 'passw0rd';
+
 =head2 html_attr_unescape
 
   my $str = html_attr_unescape $escaped;
@@ -834,6 +846,12 @@ leaking information about the length of the string.
 
 Generate binary SHA1 checksum for bytes with L<Digest::SHA>.
 
+=head2 sha256_bytes
+
+  my $checksum = sha256_bytes $bytes;
+
+Generate binary SHA-256 checksum for bytes with L<Digest::SHA>.
+
 =head2 sha1_sum
 
   my $checksum = sha1_sum $bytes;
@@ -842,6 +860,15 @@ Generate SHA1 checksum for bytes with L<Digest::SHA>.
 
   # "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
   sha1_sum 'foo';
+
+=head2 sha256_sum
+
+  my $checksum = sha256_sum $bytes;
+
+Generate SHA-256 checksum for bytes with L<Digest::SHA>.
+
+  # "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+  sha256_sum 'foo';
 
 =head2 slugify
 

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -9,10 +9,10 @@ use Mojo::DeprecationTest;
 use Sub::Util qw(subname);
 
 use Mojo::Util qw(b64_decode b64_encode camelize class_to_file class_to_path decamelize decode dumper encode),
-  qw(extract_usage getopt gunzip gzip hmac_sha1_sum html_unescape html_attr_unescape humanize_bytes md5_bytes md5_sum),
-  qw(monkey_patch network_contains punycode_decode punycode_encode quote scope_guard secure_compare sha1_bytes),
-  qw(sha1_sum slugify split_cookie_header split_header steady_time tablify term_escape trim unindent unquote),
-  qw(url_escape url_unescape xml_escape xor_encode);
+  qw(extract_usage getopt gunzip gzip hmac_sha1_sum hmac_sha256_sum html_unescape html_attr_unescape humanize_bytes),
+  qw(md5_bytes md5_sum monkey_patch network_contains punycode_decode punycode_encode quote scope_guard secure_compare),
+  qw(sha1_bytes sha256_bytes sha1_sum sha256_sum slugify split_cookie_header split_header steady_time tablify),
+  qw(term_escape trim unindent unquote url_escape url_unescape xml_escape xor_encode);
 
 subtest 'camelize' => sub {
   is camelize('foo_bar_baz'), 'FooBarBaz', 'right camelized result';
@@ -411,6 +411,21 @@ subtest 'sha1_sum' => sub {
 
 subtest 'hmac_sha1_sum' => sub {
   is hmac_sha1_sum('Hi there', 'abc1234567890'), '5344f37e1948dd3ffb07243a4d9201a227abd6e1', 'right hmac sha1 checksum';
+};
+
+subtest 'sha256_bytes' => sub {
+  is unpack('H*', sha256_bytes 'foo bar baz'), 'dbd318c1c462aee872f41109a4dfd3048871a03dedd0fe0e757ced57dad6f2d7',
+    'right binary sha-256 checksum';
+};
+
+subtest 'sha256_sum' => sub {
+  is sha256_sum('foo bar baz'), 'dbd318c1c462aee872f41109a4dfd3048871a03dedd0fe0e757ced57dad6f2d7',
+    'right sha-256 checksum';
+};
+
+subtest 'hmac_sha256_sum' => sub {
+  is hmac_sha256_sum('Hi there', 'abc256234567890'), 'e6cca557cc5c4843bbd370cffd36ae3df33609da1b5b4743aa0a1acd3168f655',
+    'right hmac sha-256 checksum';
 };
 
 subtest 'secure_compare' => sub {


### PR DESCRIPTION
### Summary
Import SHA-256 functions from Digest::SHA into Mojo::Util

### Motivation
As of v9.19, signed cookies now use HMAC-SHA-256 instead of HMAC-SHA1.
Import the equivalent SHA-256 functions into **Mojo::Util** in line with the current available SHA-1 functions.

I tripped over this last week while migrating a module from Mojo 8 to 9.  Our test module was mocking the
signed cookie and when I reached for the updated `hmac_sha256_hex` function, it wasn't in **Mojo::Util**
and I was sad.  Was just going to raise an issue and thought that a PR was just as quick and explains the change
better than I could.

### References
 Switch away from HMAC SHA1 for signed cookies #1790 