### PR TITLE
Avoid "Unhandled rejected promise warning" when using async/await

### DIFF
--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -79,6 +79,10 @@ get '/six' => sub {
 
 my $ua = Mojo::UserAgent->new(ioloop => Mojo::IOLoop->singleton);
 
+async sub reject_p {
+  await Mojo::Promise->reject('Rejected promise');
+}
+
 async sub test_one {
   await $ua->get_p('/one');
 }
@@ -126,6 +130,18 @@ subtest 'Application with async/await action' => sub {
 
 subtest 'Exception handling and async/await' => sub {
   $t->get_ok('/four')->status_is(500)->content_like(qr/this went perfectly/);
+};
+
+subtest 'Exception handling without "Unhandled rejected promise" warning' => sub {
+  my ($error, @warn);
+  local $SIG{__WARN__} = sub { push @warn, $_[0] };
+  reject_p()->catch(sub { $error = shift })->wait;
+  like $error, qr{^Rejected promise at}, 'right content';
+  is @warn, 0, 'no waring';
+
+  @warn = ();
+  reject_p()->wait;
+  like "@warn", qr{Unhandled rejected promise}, 'unhandled promise';
 };
 
 subtest 'Runaway exception' => sub {


### PR DESCRIPTION
### Summary
This PR will avoid warning "Unhandled rejected promise warning" when using async/await and a promise gets rejected.

I think this change is correct after reading https://metacpan.org/pod/Future::AsyncAwait::Awaitable#AWAIT_DONE where it says "...result of an existing still-pending future", which means there's no reason to create new promise objects.

### Motivation
Less warnings.