### PR TITLE
Fix handling returned $promise from async method, closes #1990

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -230,8 +230,10 @@ sub _settle {
 }
 
 sub _settle_await {
-  my ($status, $self) = (shift, shift);
-  @{$self}{qw(results status)} = ([@_], $status) if !$self->{results};
+  my ($status, $self, @results) = @_;
+  return $results[0]->then(sub { $self->resolve(@_); () }, sub { $self->reject(@_); () })
+    if blessed $results[0] && $results[0]->can('then');
+  @{$self}{qw(results status)} = ([@results], $status) if !$self->{results};
   $self->_defer;
 }
 

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -79,6 +79,11 @@ get '/six' => sub {
 
 my $ua = Mojo::UserAgent->new(ioloop => Mojo::IOLoop->singleton);
 
+async sub await_then_return_promise {
+  my $method = shift;
+  return Mojo::Promise->resolve(await Mojo::Promise->$method(0.01, $method));
+}
+
 async sub reject_p {
   await Mojo::Promise->reject('Rejected promise');
 }
@@ -136,12 +141,12 @@ subtest 'Exception handling without "Unhandled rejected promise" warning' => sub
   my ($error, @warn);
   local $SIG{__WARN__} = sub { push @warn, $_[0] };
   reject_p()->catch(sub { $error = shift })->wait;
-  like $error, qr{^Rejected promise at}, 'right content';
+  like $error, qr/^Rejected promise at/, 'right content';
   is @warn, 0, 'no waring';
 
   @warn = ();
   reject_p()->wait;
-  like "@warn", qr{Unhandled rejected promise}, 'unhandled promise';
+  like "@warn", qr/Unhandled rejected promise/, 'unhandled promise';
 };
 
 subtest 'Runaway exception' => sub {
@@ -155,6 +160,15 @@ subtest 'Async function body returning a promise' => sub {
   $text = undef;
   test_three(0)->then(sub { warn @_ })->catch(sub { $text = shift })->wait;
   is $text, 'value', 'right content';
+};
+
+subtest 'Async nested function returning a promise' => sub {
+  my $res;
+  await_then_return_promise('timer')->then(sub { $res = shift })->catch(sub { $res = shift })->wait;
+  is $res, 'timer', 'right content';
+
+  await_then_return_promise('timeout')->then(sub { $res = shift })->catch(sub { $res = shift })->wait;
+  like $res, qr/^timeout at/, 'right content';
 };
 
 subtest 'Async WebSocket' => sub {


### PR DESCRIPTION
### Summary
Fix issue introduced in 166cedb244009e956bd8c3de16d86292bb0f59ee when an async method returns a promise.

### Motivation
@jberger reported the issue.

### References
166cedb244009e956bd8c3de16d86292bb0f59ee
