### PR TITLE
Improved "at ... line ..." reporting for rejected async method

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -1,7 +1,7 @@
 package Mojo::Promise;
 use Mojo::Base -base;
 
-use Carp qw(carp);
+use Carp qw(carp croak);
 use Mojo::Exception;
 use Mojo::IOLoop;
 use Scalar::Util qw(blessed);
@@ -18,8 +18,9 @@ sub AWAIT_FAIL         { _settle_await(reject  => @_) }
 sub AWAIT_GET {
   my $self    = shift;
   my @results = @{$self->{results} // []};
-  die $results[0] unless $self->{status} eq 'resolve';
-  return wantarray ? @results : $results[0];
+  return wantarray ? @results : $results[0] if $self->{status} eq 'resolve';
+  die $results[0]                           if ref $results[0] || $results[0] =~ m!\n!;
+  croak $results[0];
 }
 
 sub AWAIT_IS_CANCELLED {undef}

--- a/t/mojo/promise_async_await.t
+++ b/t/mojo/promise_async_await.t
@@ -132,16 +132,22 @@ subtest 'Exception handling and async/await' => sub {
   $t->get_ok('/four')->status_is(500)->content_like(qr/this went perfectly/);
 };
 
+subtest 'Exception handling with file and line reporting' => sub {
+  my $error;
+  reject_p()->catch(sub { $error = shift })->wait;
+  like $error, qr/^Rejected promise at .*promise_async_await\.t line \d+\.$/, 'right content';
+};
+
 subtest 'Exception handling without "Unhandled rejected promise" warning' => sub {
   my ($error, @warn);
   local $SIG{__WARN__} = sub { push @warn, $_[0] };
   reject_p()->catch(sub { $error = shift })->wait;
-  like $error, qr{^Rejected promise at}, 'right content';
+  like $error, qr/^Rejected promise at/, 'right content';
   is @warn, 0, 'no waring';
 
   @warn = ();
   reject_p()->wait;
-  like "@warn", qr{Unhandled rejected promise}, 'unhandled promise';
+  like "@warn", qr/Unhandled rejected promise/, 'unhandled promise';
 };
 
 subtest 'Runaway exception' => sub {


### PR DESCRIPTION
### Summary
Before this commit:
> Rejected promise at Mojo/Promise.pm line 23.

After this commit:
> Rejected promise at t/mojo/promise_async_await.t line 88.

### Motivation
I think it would be useful to see where the promise was rejected.