### PR TITLE
Will run async/await tests in github linux workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,10 +29,11 @@ jobs:
       - name: Install dependencies
         run: |
           cpanm -n --installdeps .
-          cpanm -n Cpanel::JSON::XS EV Role::Tiny
+          cpanm -n Cpanel::JSON::XS EV Future::AsyncAwait Role::Tiny
           cpanm -n Test::Pod Test::Pod::Coverage
       - name: Run tests
         run: prove -l t t/mojo t/mojolicious
         env:
+          TEST_ASYNC_AWAIT: 1
           TEST_POD: 1
           TEST_EV: 1


### PR DESCRIPTION
### Summary
This PR will run t/mojo/promise_async_await.t in the GitHub workflow.

### Motivation
On Sunday I pushed a bad commit to #1991, which of course I should've noticed locally, but it would be nice to get feedback from github as well. I think that will make it easier to review related PRs as well.