### PR TITLE
add a possible controller in method 'to' if it's not an app

### DIFF
--- a/lib/Mojolicious/Routes.pm
+++ b/lib/Mojolicious/Routes.pm
@@ -103,7 +103,12 @@ sub _class {
   # Application class
   my @classes;
   my $class = $field->{controller} ? camelize $field->{controller} : '';
-  if ($field->{app}) { push @classes, $field->{app} }
+  if ($field->{app}) { 
+    push @classes, $field->{app};
+    
+    # Maybe add a possible controller
+    push @classes, "${_}::" . camelize $field->{app} for @{$self->namespaces};
+  }
 
   # Specific namespace
   elsif (defined(my $ns = $field->{namespace})) {

--- a/t/mojolicious/routes.t
+++ b/t/mojolicious/routes.t
@@ -1023,4 +1023,22 @@ subtest 'Unknown placeholder type (matches nothing)' => sub {
   is_deeply $m->stack, [], 'empty stack';
 };
 
+subtest 'Intuitive controller (when it is not app)' => sub {
+  my $c = Mojolicious::Controller->new;
+
+  $r = Mojolicious::Routes->new;
+  my $panel = $r->any('/panel')->to('panel'); # not added # at the end
+  $panel->get('/users')->to('#users'); 
+  my $m = Mojolicious::Routes::Match->new(root => $r);
+  $m->find($c => {method => 'GET', path => '/panel/users'});
+  is_deeply $m->stack, [{app => 'panel', action => 'users'}], 'right structure';
+
+  $r = Mojolicious::Routes->new;
+  my $admin = $r->any('/admin')->to('admin'); # not added # at the end
+  $admin->get('/articles')->to('#articles'); 
+  $m = Mojolicious::Routes::Match->new(root => $r);
+  $m->find($c => {method => 'GET', path => '/admin/articles'});
+  is_deeply $m->stack, [{app => 'admin', action => 'articles'}], 'right structure';
+};
+
 done_testing();


### PR DESCRIPTION
### Summary
This change to add a possible controller in method 'to' when it's not an app

### Motivation
When the value set is not an app, the mojo tests if it is a controller, but normally returns an error for not having a namespace defined.

When you write the code:

```
my $foo = $r->any('/foo')->to('foo');
$foo->get('/test')->to('#test');
```

Return the error:
Controller "foo" does not exist at Mojolicious.pm line 127.

This change solves the problem above.

