### PR TITLE
eliminate warning reported by #1739

### DIFF
--- a/lib/Mojo/UserAgent.pm
+++ b/lib/Mojo/UserAgent.pm
@@ -286,6 +286,7 @@ sub _redirect {
 sub _remove {
   my ($self, $id) = @_;
   my $c = delete $self->{connections}{$id};
+  return unless $c->{loop};
   $self->_dequeue($c->{ioloop}, $id);
   $c->{ioloop}->remove($id);
 }


### PR DESCRIPTION
### Summary
Eliminate warnings generated by `t/mojolicious/websocket_lite_app.t`.

Before this patch:
```
$ prove -l t/mojolicious/websocket_lite_app.t 
t/mojolicious/websocket_lite_app.t .. 1/? Use of uninitialized value $loop in hash element at /tmp/mojo/lib/Mojo/UserAgent.pm line 201.
Mojo::Reactor::Poll: I/O watcher failed: Can't call method "remove" on an undefined value at /tmp/mojo/lib/Mojo/UserAgent.pm line 291.
t/mojolicious/websocket_lite_app.t .. ok    
All tests successful.
Files=1, Tests=35,  1 wallclock secs ( 0.04 usr  0.02 sys +  0.51 cusr  0.06 csys =  0.63 CPU)
Result: PASS
```

After this patch:
```
$ prove -l t/mojolicious/websocket_lite_app.t 
t/mojolicious/websocket_lite_app.t .. ok    
All tests successful.
Files=1, Tests=35,  1 wallclock secs ( 0.04 usr  0.01 sys +  0.49 cusr  0.07 csys =  0.61 CPU)
Result: PASS
```

### Motivation
Sometimes `$c->{loop}` is `undefined`, as reported by #1739 18mo ago and as I confirm today with perl 5.34 and Mojolicious 9.29.  This patch exits the function when the connection loop is undefined and prevents subsequent code from acting on the variable with the assumption that it is defined.

### References
Failure in `t/mojolicious/websocket_lite_app.t` test #1739.