### PR TITLE
fix UNIX domain socket debugging reported by #1980

### DIFF
--- a/lib/Mojo/Server/Daemon.pm
+++ b/lib/Mojo/Server/Daemon.pm
@@ -194,7 +194,7 @@ sub _listen {
       my ($loop, $stream, $id) = @_;
 
       $self->{connections}{$id} = {tls => $tls};
-      warn "-- Accept $id (@{[$stream->handle->peerhost]})\n" if DEBUG;
+      warn "-- Accept $id (@{[_peer($stream->handle)]})\n" if DEBUG;
       $stream->timeout($self->inactivity_timeout);
 
       $stream->on(close   => sub { $self && $self->_close($id) });
@@ -211,6 +211,8 @@ sub _listen {
   $url->port($self->ports->[-1]) if !$options->{path} && !$url->port;
   say 'Web application available at ', $options->{path} // $url;
 }
+
+sub _peer { $_[0]->isa('IO::Socket::UNIX') ? $_[0]->peerpath : $_[0]->peerhost }
 
 sub _read {
   my ($self, $id, $chunk) = @_;


### PR DESCRIPTION
### Summary
This patch logs the handle's `peerpath` if the handle is a `IO::Socket::UNIX` object, otherwise logs the handle's `peeraddr`.

### Motivation
The server fails when debugging a server listening on a unix domain socket because a `IO::Socket::UNIX` object does not have a `peerhost` method.  This patch retains existing functionality except when the handle is an `IO::Socket::UNIX` object (i.e. listening on a unix domain socket).

### References
MOJO_SERVER_DEBUG=1 fails with UNIX domain sockets #1980.
