### PR TITLE
forward empty body responses as reported by #2008

### DIFF
--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -242,9 +242,7 @@ sub _proxy_start_p {
         }
       );
 
-      # Unknown length (fall back to connection close)
-      $source_res->once(finish => sub { $content->$write('') and $tx->resume })
-        unless length($headers->content_length // '');
+      $source_res->once(finish => sub { $content->$write('') and $tx->resume });
     }
   );
   weaken $source_tx;


### PR DESCRIPTION
### Summary
This patch allows proxying empty body responses such as those with code 200 and length 0, and, more importantly, 301 and 302 redirects with length 0.

While this patch still passes all tests -- as well as the 12 tests added -- I don't know if this solution is acceptable and in the spirit of the comment that was there.  It seems the conditional that is currently used is insufficient, and I don't know what would be better; moreover, no tests fail with this change.

### Motivation
The gateway (proxy) server using `proxy->start_p` is unable to successfully handle redirects received from the origin (backend) server.

### References
proxy->start_p helper doesn't forward empty body responses #2008.
