### PR TITLE
echo.websocket.org service no longer available

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -1460,7 +1460,7 @@ that the connection has been established and it can start using the bi-direction
 
   # Open WebSocket to echo service
   my $ua = Mojo::UserAgent->new;
-  $ua->websocket_p('ws://echo.websocket.org')->then(sub ($tx) {
+  $ua->websocket_p('wss://ws.postman-echo.com/raw')->then(sub ($tx) {
 
     # Prepare a followup promise so we can wait for messages
     my $promise = Mojo::Promise->new;


### PR DESCRIPTION
### Summary
`wss://ws.postman-echo.com/raw` is a drop-in replacement for this example that works.

### Motivation
`ws://echo.websocket.org` service no longer available  ([http://echo.websocket.org](http://echo.websocket.org))

### References
None.