### PR TITLE
Set correct namespace in example code

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -1799,10 +1799,10 @@ installed application so they can be excluded.
     $self->renderer->paths->[0] = $self->home->child('templates');
 
     # Exclude author commands
-    $self->commands->namespaces(['Mojolicious::Commands']);
+    $self->commands->namespaces(['Mojolicious::Command']);
 
     my $r = $self->routes;
-    $r->get('/welcome')->to('example#welcome');
+    $r->get('/')->to('example#welcome');
   }
 
   1;


### PR DESCRIPTION
### Summary
Set the correct namespace in example code and also change the example route to be `/` instead of `/welcome` so that the test generated by the Cookbook's example running `mojo generate app MyApp` works.

### Motivation
Make example code more ready-to-use.

### References
None.