### PR TITLE
tutorial typo: "lite_app" instead of "lite-app" with "mojo generate"

### DIFF
--- a/lib/Mojolicious/Guides/Tutorial.pod
+++ b/lib/Mojolicious/Guides/Tutorial.pod
@@ -33,7 +33,7 @@ L<Mojolicious::Lite>, turning your script into a full featured web application.
 With L<Mojolicious::Command::Author::generate::lite_app> there is also a helper command to generate a small example
 application.
 
-  $ mojo generate lite-app myapp.pl
+  $ mojo generate lite_app myapp.pl
 
 =head2 Commands
 


### PR DESCRIPTION
### Summary
Tutorial mentions `mojo generate lite-app` instead of `mojo generate lite_app` which is the correct syntax _(at least in my version of mojolicious, maybe this has been changed over time)_

### Motivation
Docs are rather useless if they are wrong...