### PR TITLE
ensure eval is always called in scalar context (#2051)

### DIFF
--- a/lib/Mojo/IOLoop/Client.pm
+++ b/lib/Mojo/IOLoop/Client.pm
@@ -10,13 +10,13 @@ use Scalar::Util qw(weaken);
 use Socket       qw(IPPROTO_TCP SOCK_STREAM TCP_NODELAY);
 
 # Non-blocking name resolution requires Net::DNS::Native
-use constant NNR => $ENV{MOJO_NO_NNR} ? 0 : eval { require Net::DNS::Native; Net::DNS::Native->VERSION('0.15'); 1 };
+use constant NNR => $ENV{MOJO_NO_NNR} ? 0 : !!eval { require Net::DNS::Native; Net::DNS::Native->VERSION('0.15'); 1 };
 my $NDN;
 
 # SOCKS support requires IO::Socket::Socks
 use constant SOCKS => $ENV{MOJO_NO_SOCKS}
   ? 0
-  : eval { require IO::Socket::Socks; IO::Socket::Socks->VERSION('0.64'); 1 };
+  : !!eval { require IO::Socket::Socks; IO::Socket::Socks->VERSION('0.64'); 1 };
 use constant READ  => SOCKS ? IO::Socket::Socks::SOCKS_WANT_READ()  : 0;
 use constant WRITE => SOCKS ? IO::Socket::Socks::SOCKS_WANT_WRITE() : 0;
 

--- a/lib/Mojo/IOLoop/TLS.pm
+++ b/lib/Mojo/IOLoop/TLS.pm
@@ -6,7 +6,7 @@ use Mojo::IOLoop;
 use Scalar::Util qw(weaken);
 
 # TLS support requires IO::Socket::SSL
-use constant TLS   => $ENV{MOJO_NO_TLS} ? 0 : eval { require IO::Socket::SSL; IO::Socket::SSL->VERSION('2.009'); 1 };
+use constant TLS   => $ENV{MOJO_NO_TLS} ? 0 : !!eval { require IO::Socket::SSL; IO::Socket::SSL->VERSION('2.009'); 1 };
 use constant READ  => TLS               ? IO::Socket::SSL::SSL_WANT_READ()  : 0;
 use constant WRITE => TLS               ? IO::Socket::SSL::SSL_WANT_WRITE() : 0;
 

--- a/lib/Mojo/JSON.pm
+++ b/lib/Mojo/JSON.pm
@@ -10,7 +10,7 @@ use Scalar::Util qw(blessed);
 # For better performance Cpanel::JSON::XS is required
 use constant JSON_XS => $ENV{MOJO_NO_JSON_XS}
   ? 0
-  : eval { require Cpanel::JSON::XS; Cpanel::JSON::XS->VERSION('4.09'); 1 };
+  : !!eval { require Cpanel::JSON::XS; Cpanel::JSON::XS->VERSION('4.09'); 1 };
 
 our @EXPORT_OK = qw(decode_json encode_json false from_json j to_json true);
 
@@ -49,7 +49,7 @@ sub from_json {
 
 sub j {
   return encode_json($_[0]) if ref $_[0] eq 'ARRAY' || ref $_[0] eq 'HASH';
-  return eval { decode_json($_[0]) };
+  return scalar eval { decode_json($_[0]) };
 }
 
 sub to_json { _encode_value(shift) }

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -22,7 +22,7 @@ use Time::HiRes        ();
 use Unicode::Normalize ();
 
 # Check for monotonic clock support
-use constant MONOTONIC => eval { !!Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC()) };
+use constant MONOTONIC => !!eval { Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC()) };
 
 # Punycode bootstring parameters
 use constant {


### PR DESCRIPTION
### Summary
eval in list context returns empty list when it fails, not undef. List context includes "use constant" because list constants unfortunately exist.

### Motivation
We want to ensure no danger of bugs due to context sensitivity.

### References
#2051 
