### PR TITLE
Call POSIX::setsid() as a function

### DIFF
--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -34,7 +34,7 @@ sub daemonize {
   # Fork and kill parent
   die "Can't fork: $!" unless defined(my $pid = fork);
   exit 0 if $pid;
-  POSIX::setsid == -1 and die "Can't start a new session: $!";
+  POSIX::setsid() == -1 and die "Can't start a new session: $!";
 
   # Close filehandles
   open STDIN,  '<',  '/dev/null';


### PR DESCRIPTION
This is avoiding a warning when load with strict sub enabled:

    Bareword "POSIX::setsid" not allowed while "strict subs" in use

### Summary
DESCRIBE THE BIG PICTURE OF YOUR CHANGES HERE

### Motivation
EXPLAIN WHY YOU BELIEVE THESE CHANGES ARE NECESSARY HERE

### References
LIST RELEVANT ISSUES, PULL REQUESTS AND FORUM DISCUSSIONS HERE
