### PR TITLE
Add exceptions to stash regardless of format

### DIFF
--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -90,6 +90,11 @@ sub _content {
   return Mojo::ByteStream->new($hash->{$name} // '');
 }
 
+sub _convert_to_exception {
+  my $e = shift;
+  return (blessed $e && $e->isa('Mojo::Exception')) ? $e : Mojo::Exception->new($e);
+}
+
 sub _csrf_token { $_[0]->session->{csrf_token} ||= hmac_sha1_sum($$ . steady_time . rand, $_[0]->app->secrets->[0]) }
 
 sub _current_route {
@@ -100,7 +105,7 @@ sub _current_route {
 sub _development {
   my ($page, $c, $e) = @_;
 
-  $c->helpers->log->error(($e = _is_e($e) ? $e : Mojo::Exception->new($e))->inspect) if $page eq 'exception';
+  $c->helpers->log->error(($e = _convert_to_exception($e))->inspect) if $page eq 'exception';
 
   # Filtered stash snapshot
   my $stash = $c->stash;
@@ -187,8 +192,6 @@ sub _inactivity_timeout {
   return $c;
 }
 
-sub _is_e { blessed $_[0] && $_[0]->isa('Mojo::Exception') }
-
 sub _is_fresh {
   my ($c, %options) = @_;
   return $c->app->static->is_fresh($c, \%options);
@@ -196,6 +199,7 @@ sub _is_fresh {
 
 sub _json_exception {
   my ($c, $e) = @_;
+  $c->stash->{exception} = _convert_to_exception($e);
   return $c->render(json => {error => $e},                      status => 500) if $c->app->mode eq 'development';
   return $c->render(json => {error => 'Internal Server Error'}, status => 500);
 }
@@ -315,6 +319,7 @@ sub _tx_error { (shift->error // {})->{message} // 'Unknown error' }
 
 sub _txt_exception {
   my ($c, $e) = @_;
+  $c->stash->{exception} = _convert_to_exception($e);
   return $c->render(text => $e,                      format => 'txt', status => 500) if $c->app->mode eq 'development';
   return $c->render(text => 'Internal Server Error', format => 'txt', status => 500);
 }

--- a/t/mojolicious/exception_lite_app.t
+++ b/t/mojolicious/exception_lite_app.t
@@ -302,9 +302,12 @@ subtest 'JSON exceptions' => sub {
     ->json_like('/error', qr/dead template!/);
   $t->get_ok('/does_not_exist')->status_is(404)->content_type_is('application/json;charset=UTF-8')
     ->json_is({error => 'Not Found'});
-
+  my $stash;
+  $t->app->hook(after_dispatch => sub { $stash = shift->stash });
   $t->get_ok('/txt/exception')->status_is(500)->header_is('X-Text' => 'txt')
     ->content_type_is('text/plain;charset=UTF-8')->content_like(qr/Text exception/);
+  ok $stash->{exception}, 'exception exists in stash';
+  isa_ok $stash->{exception}, 'Mojo::Exception', 'is stash exception correct type?';
 
   $t->app->mode('production');
   $t->get_ok('/dead_template')->status_is(500)->content_type_is('application/json;charset=UTF-8')
@@ -319,9 +322,12 @@ subtest 'Text exceptions' => sub {
   $t->get_ok('/dead_template')->status_is(500)->content_type_is('text/plain;charset=UTF-8')
     ->content_like(qr/dead template!/);
   $t->get_ok('/does_not_exist')->status_is(404)->content_type_is('text/plain;charset=UTF-8')->content_is('Not Found');
-
+  my $stash;
+  $t->app->hook(after_dispatch => sub { $stash = shift->stash });
   $t->get_ok('/txt/exception')->status_is(500)->header_is('X-Text' => 'txt')
     ->content_type_is('text/plain;charset=UTF-8')->content_like(qr/Text exception/);
+  ok $stash->{exception}, 'exception exists in stash';
+  isa_ok $stash->{exception}, 'Mojo::Exception', 'is stash exception correct type?';
 
   $t->app->mode('production');
   $t->get_ok('/dead_template')->status_is(500)->content_type_is('text/plain;charset=UTF-8')


### PR DESCRIPTION
**Summary**

Make it easier to use exceptions, when exception format is not HTML

**Motivation**

It doesn't make sense for exceptions to be stored in the stash only if the format is HTML, instead it makes more sense, and is more consistent to store them in the stash for all formats

**References**

fixes #2048 

I annihilated my branch on the other PR like a goof #2061 and github auto closed the PR because of it.