### PR TITLE
Do not send redundant SIGQUITs

### DIFF
--- a/lib/Mojo/Server/Prefork.pm
+++ b/lib/Mojo/Server/Prefork.pm
@@ -181,7 +181,10 @@ sub _wait {
   while ($chunk =~ /(\d+):(\d)\n/g) {
     next unless my $w = $self->{pool}{$1};
     @$w{qw(healthy time)} = (1, $time) and $self->emit(heartbeat => $1);
-    $w->{graceful} ||= $time if $2;
+    if ($2) {
+      $w->{graceful} ||= $time;
+      $w->{quit}++;
+    }
   }
 }
 


### PR DESCRIPTION
If the worker reports itself as shutting down, do not second another SIGQUIT to the worker. It already knows it is shutting down, and this can cause a race with signal handlers that triggers coredumps.

### Summary
Full writeup in #2046
The short version:
- When a worker receives a SIGQUIT, it begins to gracefully shut down
- During graceful shutdown, the worker notifies the manager thread of its shutdown
- If the manager sent the initial SIGQUIT, then it already knows the worker is shutting down and takes no action
- If the manager did not send the initial SIGQUIT, then it marks the worker for graceful shutdown, causing it to send a second SIGQUIT
- This second SIGQUIT can arrive once Perl has already de-registered the QUIT signal handler, which causes it to perform the default QUIT action (coredump)

The patch here increments the worker's `quit` state in the managing thread so that it does not send a second SIGQUIT to the worker if the manager finds out about the graceful shutdown from the worker

### Motivation
This behavior was causing coredumps in our application, since we were using SIGQUIT to gracefully end workers.
I understand from #1883/#1449 that there are also other ways for the worker to initiate graceful shutdown, which can trigger the same race condition

### References
Tested via the test app uploaded to #2046
Attempts to fix the same issue seen in #1883
