### PR TITLE
Fix Promise->map hang on false values after concurrency limit

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -72,7 +72,8 @@ sub map {
   my @wait  = map { $start[0]->clone } 0 .. $#items;
 
   my $start_next = sub {
-    return () unless my $item = shift @items;
+    return () unless @items;
+    my $item = shift @items;
     my ($start_next, $chain) = (__SUB__, shift @wait);
     $_->$cb->then(sub { $chain->resolve(@_); $start_next->() }, sub { $chain->reject(@_); @items = () }) for $item;
     return ();

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -482,12 +482,12 @@ subtest 'Warnings (multiple branches)' => sub {
 
 subtest 'Map' => sub {
   my (@results, @errors, @started);
-  my $promise = Mojo::Promise->map(sub { push @started, $_; Mojo::Promise->resolve($_) }, 1 .. 5)
+  my $promise = Mojo::Promise->map(sub { push @started, $_; Mojo::Promise->resolve($_) }, 1 .. 5, undef, 0)
     ->then(sub { @results = @_ }, sub { @errors = @_ });
-  is_deeply \@started, [1, 2, 3, 4, 5], 'all started without concurrency';
+  is_deeply \@started, [1, 2, 3, 4, 5, undef, 0], 'all started without concurrency';
   $promise->wait;
-  is_deeply \@results, [[1], [2], [3], [4], [5]], 'correct result';
-  is_deeply \@errors,  [],                        'promise not rejected';
+  is_deeply \@results, [[1], [2], [3], [4], [5], [undef], [0]], 'correct result';
+  is_deeply \@errors,  [],                                      'promise not rejected';
 };
 
 subtest 'Map (with concurrency limit)' => sub {
@@ -503,10 +503,12 @@ subtest 'Map (with concurrency limit)' => sub {
         $n;
       });
     },
-    1 .. 7
+    1 .. 7,
+    undef,
+    0,
   )->then(sub { @results = @_ }, sub { @errors = @_ })->wait;
-  is_deeply \@results, [[1], [2], [3], [4], [5], [6], [7]], 'correct result';
-  is_deeply \@errors,  [],                                  'promise not rejected';
+  is_deeply \@results, [[1], [2], [3], [4], [5], [6], [7], [undef], [0]], 'correct result';
+  is_deeply \@errors,  [],                                                'promise not rejected';
 };
 
 subtest 'Map (with reject)' => sub {


### PR DESCRIPTION
The check for whether to call the callback returned early if the item was falsy.  Instead, it needs to only return early if there are no items left.
