### PR TITLE
Allow selection of an encoding on slurp/spew in Mojo::File

### DIFF
--- a/lib/Mojo/File.pm
+++ b/lib/Mojo/File.pm
@@ -14,6 +14,7 @@ use File::stat            ();
 use File::Temp            ();
 use IO::File              ();
 use Mojo::Collection;
+use Mojo::Util qw(decode encode);
 
 our @EXPORT_OK = ('curfile', 'path', 'tempdir', 'tempfile');
 
@@ -127,22 +128,25 @@ sub sibling {
 }
 
 sub slurp {
-  my $self = shift;
+  my ($self, $encoding) = @_;
 
   CORE::open my $file, '<', $$self or croak qq{Can't open file "$$self": $!};
   my $ret = my $content = '';
   while ($ret = $file->sysread(my $buffer, 131072, 0)) { $content .= $buffer }
   croak qq{Can't read from file "$$self": $!} unless defined $ret;
 
-  return $content;
+  return $encoding ? decode($encoding, $content) : $content;
 }
 
-sub spurt {
-  my ($self, $content) = (shift, join '', @_);
+sub spew {
+  my ($self, $content, $encoding) = @_;
+  $content = encode($encoding, $content) if $encoding;
   CORE::open my $file, '>', $$self or croak qq{Can't open file "$$self": $!};
   ($file->syswrite($content) // -1) == length $content or croak qq{Can't write to file "$$self": $!};
   return $self;
 }
+
+sub spurt { shift->spew(join '', @_) }
 
 sub stat { File::stat::stat(${shift()}) }
 
@@ -471,8 +475,17 @@ Return a new L<Mojo::File> object relative to the directory part of the path.
 =head2 slurp
 
   my $bytes = $path->slurp;
+  my $chars = $path->slurp('UTF-8');
 
-Read all data at once from the file.
+Read all data at once from the file. If an encoding is provided, an attempt will be made to decode the content.
+
+=head2 spew
+
+  $path = $path->spew($bytes);
+  $path = $path->spew($chars, $encoding);
+
+Write all data at once to the file. If an encoding is provided, an attempt to encode the content will be made prior
+to writing.
 
 =head2 spurt
 

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -342,25 +342,23 @@ subtest 'I/O' => sub {
   }
 };
 
-subtest 'I/O with Encoding' => sub {
+subtest 'I/O with encoding' => sub {
   my $dir  = tempdir;
   my $file = $dir->child('test.txt')->spew('♥1', 'UTF-8');
   is $file->slurp('UTF-8'),            '♥1',         'right content';
   is decode('UTF-8', $file->slurp()),  '♥1',         'right content';
   is $file->spew('works too!')->slurp, 'works too!', 'right content';
-  $file->spew(encode('UTF-8', '♥1'));
-  is $file->slurp('UTF-8'),           '♥1', 'right content';
-  is decode('UTF-8', $file->slurp()), '♥1', 'right content';
   {
     eval { $file->spew('♥1') };
     like $@, qr/Wide character/, 'right error';
   }
-  {
-    no warnings 'redefine';
-    local *IO::Handle::syswrite = sub { $! = 0; 5 };
-    eval { $file->spew("just\nworks!") };
-    like $@, qr/Can't write to file ".*/, 'right error';
-  }
+};
+
+subtest 'I/O with manual encoding' => sub {
+  my $dir  = tempdir;
+  my $file = $dir->child('test.txt')->spew(encode('UTF-8', '♥1'));
+  is $file->slurp('UTF-8'),           '♥1', 'right content';
+  is decode('UTF-8', $file->slurp()), '♥1', 'right content';
 };
 
 done_testing();

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -348,17 +348,18 @@ subtest 'I/O with encoding' => sub {
   is $file->slurp('UTF-8'),            '♥1',         'right content';
   is decode('UTF-8', $file->slurp()),  '♥1',         'right content';
   is $file->spew('works too!')->slurp, 'works too!', 'right content';
+
+  subtest 'I/O with manual encoding' => sub {
+    $file->spew(encode('UTF-8', '♥1'));
+    is $file->slurp('UTF-8'),           '♥1', 'right content';
+    is decode('UTF-8', $file->slurp()), '♥1', 'right content';
+  };
+
   {
+    local $@;
     eval { $file->spew('♥1') };
     like $@, qr/Wide character/, 'right error';
   }
-};
-
-subtest 'I/O with manual encoding' => sub {
-  my $dir  = tempdir;
-  my $file = $dir->child('test.txt')->spew(encode('UTF-8', '♥1'));
-  is $file->slurp('UTF-8'),           '♥1', 'right content';
-  is decode('UTF-8', $file->slurp()), '♥1', 'right content';
 };
 
 done_testing();


### PR DESCRIPTION
### Summary
Alter Mojo::File to:
* Allow slurp and decode with ```$file->slurp('UTF-8');``` etc.
* Allow spew and encode with ```$file->spew('contents', 'UTF-8');``` etc.

### Motivation
As we discussed on IRC, allowing these options not only makes it easier for users as well as bring things more inline with what is allowed in the Mojo.js framework.

