### PR TITLE
Allow decoding of JSON messages in non-standard character sets

### DIFF
--- a/lib/Mojo/Message.pm
+++ b/lib/Mojo/Message.pm
@@ -9,7 +9,7 @@ use Mojo::JSON qw(j);
 use Mojo::JSON::Pointer;
 use Mojo::Parameters;
 use Mojo::Upload;
-use Mojo::Util qw(decode);
+use Mojo::Util qw(encode decode);
 
 has content          => sub { Mojo::Content::Single->new };
 has default_charset  => 'UTF-8';
@@ -132,7 +132,8 @@ sub is_limit_exceeded { !!shift->{limit} }
 sub json {
   my ($self, $pointer) = @_;
   return undef if $self->content->is_multipart;
-  my $data = $self->{json} //= j($self->body);
+  my $charset = $self->body_params->charset || $self->default_charset;
+  my $data    = $self->{json} //= j($charset eq 'UTF-8' ? $self->body : encode('UTF-8', decode($charset, $self->body)));
   return $pointer ? Mojo::JSON::Pointer->new($data)->get($pointer) : $data;
 }
 

--- a/t/mojolicious/json_charset_lite_app.t
+++ b/t/mojolicious/json_charset_lite_app.t
@@ -1,0 +1,63 @@
+use Mojo::Base -strict;
+
+BEGIN {$ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll'}
+
+use Test::Mojo;
+use Test::More;
+use Mojo::ByteStream qw(b);
+use Mojolicious::Lite;
+
+my $ascii = 'abc';
+my $yatta = 'やった';
+my $yatta_sjis = b($yatta)->encode('shift_jis')->to_string;
+my $miyagawa = '宮川';
+my $miyagawa_jp = b($miyagawa)->encode('euc-jp')->to_string;
+my $hola = "áèñ";
+my $hola_latin1 = "\x{e1}\x{e8}\x{f1}";
+
+get '/' => [ format => [ $yatta ] ] => { format => undef } => 'index';
+
+post '/' => sub {
+    my $c = shift;
+    $c->render(text => "foo: " . $c->param('foo'));
+};
+
+get '/ascii' => sub {
+    my $c = shift;
+    $c->render(json => { test => $ascii })
+};
+
+get '/unicode' => sub {
+    my $c = shift;
+    $c->render(json => { test => $yatta })
+};
+
+get '/shift_jis' => sub {
+    my $c = shift;
+    $c->res->headers->content_type("application/json;charset=Shift_JIS");
+    $c->render(data => qq({"test":"$yatta_sjis"}));
+};
+
+get '/euc_jp' => sub {
+    my $c = shift;
+    $c->res->headers->content_type("application/json;charset=euc-jp");
+    $c->render(data => qq({"test":"$miyagawa_jp"}));
+};
+
+get '/latin1' => sub {
+    my $c = shift;
+    $c->res->headers->content_type("application/json;charset=ISO-8859-1");
+    $c->stash(data => qq({"test":"$hola_latin1"}));
+};
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/ascii')->status_is(200)->content_is('{"test":"abc"}');
+$t->get_ok('/ascii')->status_is(200)->json_is('/test' => $ascii);
+$t->get_ok('/unicode')->status_is(200)->content_type_is('application/json;charset=UTF-8')->json_is('/test' => $yatta);
+$t->get_ok('/shift_jis')->status_is(200)->content_type_is('application/json;charset=Shift_JIS')->json_is('/test' => $yatta);
+$t->get_ok('/euc_jp')->status_is(200)->content_type_is('application/json;charset=euc-jp')->json_is('/test' => $miyagawa);
+$t->get_ok('/latin1')->status_is(200)->content_type_is('application/json;charset=ISO-8859-1')->json_is('/test' => $hola);
+
+
+done_testing();


### PR DESCRIPTION
### Summary
This PR modifies Mojo::Message to allow JSON decoding when a charset is specified. Currently all messages are decoded as UTF-8, so JSON messages with other encodings may fail silently.

### Motivation
Mojo::UserAgent always tries to decode messages in UTF-8 ignoring the message character set. When a message does not meet the UTF-8  specification, `Mojo::JSON::json_decode()` fails silently and `Mojo::UserAgent::json()` returns `undef`. In character sets with a large overlap with UTF-8 such as ISO-8859-1, message decoding fails only when accented characters are present, so JSON messages migh seem empty at random.
This is critical to interface with legacy systems that expose JSON messages in charsets different from UTF-8. 

### References
No public issues or PRs for Mojolicious as far as I'm aware. 
Other Perl frameworks allow non-UTF-8 charsets for JSON messages from very early on -- e.g. [Catalyst::View::JSON](https://github.com/perl-catalyst/Catalyst-View-JSON/commit/49f7babdfc49d781b83094caa0f64f6613079331).
Some Java frameworks defaulted to ISO-8859-1 encoding as recently as 2020: [Content Type being append with charset=ISO-8859-1 #1428](https://github.com/spring-cloud/spring-cloud-contract/issues/1428).
Even though [RFC4627](https://www.rfc-editor.org/rfc/rfc4627) tried to stardardize UTF-8 encoding for JSON messages as far back as 2006 (at around the same time some frameworks implemented charset specification to allow non-ascii characters in JSON) [RFC8259](https://www.rfc-editor.org/rfc/rfc8259#page-8)'s language leaves enough slack for systems that are part of a closed ecosystem. 
