### PR TITLE
fix error reporting when loading applications with compile errors

### DIFF
--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -54,9 +54,11 @@ sub load_app {
     local @ARGS_OVERRIDE = @args;
 
     # Try to load application from script into sandbox
-    my $app = eval "package Mojo::Server::Sandbox::@{[md5_sum $path]}; do \$path";
-    my $err = $app ? undef : $@ || $! || "$path did not return a true value";
-    die qq{Can't load application from file "$path": $err} if $err;
+    my $app = eval sprintf <<'END_CODE', md5_sum($path);
+      package Mojo::Server::Sandbox::%s;
+      do $path or die $@ || $! || "$path did not return a true value";
+END_CODE
+    die qq{Can't load application from file "$path": $@} if $@;
     die qq{File "$path" did not return an application object.\n} unless blessed $app && $app->can('handler');
     $self->app($app);
   };

--- a/t/mojo/daemon.t
+++ b/t/mojo/daemon.t
@@ -88,7 +88,8 @@ subtest 'Load broken app' => sub {
   eval { Mojo::Server::Daemon->new->load_app("$bin/lib/Mojo/LoaderTest/A.pm") };
   like $@, qr/did not return an application object/, 'right error';
   eval { Mojo::Server::Daemon->new->load_app("$bin/lib/Mojo/LoaderException.pm") };
-  like $@, qr/^Can't load application/, 'right error';
+  like $@, qr/Missing right curly or square bracket/, 'right error';
+  like $@, qr/^Can't load application/,               'right error';
 };
 
 subtest 'Load app using module_true' => sub {


### PR DESCRIPTION
When switching from loading an application from using require to using do, the error was still trying to be captured after a surrounding eval. This error would always be empty, because the error from the do was not rethrown. It would still result in an undef application, so an error would be thrown, but it would not include the actual compile error.

Change the do call inside the eval to throw an error if no application is returned. The error is then recaught outside the eval. Also add a test that shows that the real compilation error is included in the output.

Fixes #2110