### PR TITLE
Add absolute check to url_for_asset and url_for_file to fix appending "/" to absolute file paths

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -11,6 +11,8 @@ use Mojo::Util;
 use Mojolicious::Routes::Match;
 use Scalar::Util ();
 
+my $ABSOLUTE = qr!^(?:[^:/?#]+:|//|#)!;
+
 has [qw(app tx)] => undef, weak => 1;
 has match => sub { Mojolicious::Routes::Match->new(root => shift->app->routes) };
 
@@ -239,7 +241,7 @@ sub url_for {
 
   # Absolute URL
   return $target                 if Scalar::Util::blessed $target && $target->isa('Mojo::URL');
-  return Mojo::URL->new($target) if $target =~ m!^(?:[^:/?#]+:|//|#)!;
+  return Mojo::URL->new($target) if $target =~ $ABSOLUTE;
 
   # Base
   my $url  = Mojo::URL->new;
@@ -274,12 +276,12 @@ sub url_for {
 
 sub url_for_asset {
   my ($self, $asset) = @_;
-  return $self->url_for($self->app->static->asset_path($asset));
+  return $self->url_for($asset =~ $ABSOLUTE ? $asset : $self->app->static->asset_path($asset));
 }
 
 sub url_for_file {
   my ($self, $file) = @_;
-  return $self->url_for($self->app->static->file_path($file));
+  return $self->url_for($file =~ $ABSOLUTE ? $file : $self->app->static->file_path($file));
 }
 
 sub write {

--- a/t/mojolicious/static_prefix_lite_app.t
+++ b/t/mojolicious/static_prefix_lite_app.t
@@ -77,6 +77,10 @@ subtest 'File' => sub {
   my $c = $t->app->build_controller;
   is $c->url_for_file('/unknown.css')->path, '/static/unknown.css', 'right file path';
   is $c->url_for_file('/foo/bar.css')->path, '/static/foo/bar.css', 'right file path';
+  is $c->url_for_file('https://somesite.com/file.css')->to_string, 'https://somesite.com/file.css',
+    'right absolute file path?';
+  is $c->url_for_asset('https://somesite.com/file.css')->to_string, 'https://somesite.com/file.css',
+    'right absolute asset path?';
 };
 
 done_testing();


### PR DESCRIPTION
### Summary
There is currently a bug where:

```
%= image('https://www.somesite.com/image.png')
```

produces

```
<img src="/https://www.somesite.com/image.png">
```

This PR adds an absolute check to the `file_path` and `asset_path` methods that currently breaks this.

### Motivation
This is breaking multiple of my systems in production. (And it seems its breaking others as well)

### References
#2107
