### PR TITLE
RFC: resolve aggregated Promises with Collections

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -4,6 +4,7 @@ use Mojo::Base -base;
 use Carp qw(carp croak);
 use Mojo::Exception;
 use Mojo::IOLoop;
+use Mojo::Collection;
 use Scalar::Util qw(blessed);
 
 use constant DEBUG => $ENV{MOJO_PROMISE_DEBUG} || 0;
@@ -137,7 +138,7 @@ sub _all {
     elsif ($type == 2) {
       $promises[$i]->then(
         sub {
-          $results->[$i] = [@_];
+          $results->[$i] = Mojo::Collection->new(@_);
           $all->resolve(@$results) if --$remaining <= 0;
           return ();
         },
@@ -161,12 +162,12 @@ sub _all {
     else {
       $promises[$i]->then(
         sub {
-          $results->[$i] = {status => 'fulfilled', value => [@_]};
+          $results->[$i] = {status => 'fulfilled', value => Mojo::Collection->new(@_)};
           $all->resolve(@$results) if --$remaining <= 0;
           return ();
         },
         sub {
-          $results->[$i] = {status => 'rejected', reason => [@_]};
+          $results->[$i] = {status => 'rejected', reason => Mojo::Collection->new(@_)};
           $all->resolve(@$results) if --$remaining <= 0;
           return ();
         }
@@ -297,7 +298,8 @@ Mojo::Promise - Promises/A+
   my $cpan = get_p('https://metacpan.org');
   Mojo::Promise->all($mojo, $cpan)->then(sub ($mojo, $cpan) {
     say $mojo->[0]->res->code;
-    say $cpan->[0]->res->code;
+    # or
+    say $cpan->first->res->code;
   })->catch(sub ($err) {
     warn "Something went wrong: $err";
   })->wait;


### PR DESCRIPTION
### Summary
pass `Mojo::Collection`s to `->then` callbacks when they receive the results of multiple `Promise`s 

### Motivation
Being able to call `->first` instead of using `->[0]` on the array-ref I receive:

```perl
my $mojo = get_p('https://mojolicious.org');
my $cpan = get_p('https://metacpan.org');
Mojo::Promise->all($mojo, $cpan)->then(sub ($mojo, $cpan) {
  say $mojo->first->res->code;   # <-- Mojo::Collection::first
  say $cpan->[0]->res->code;     # <-- Just like all the code on earth has now
})->catch(sub ($err) {
  warn "Something went wrong: $err";
})->wait;
```

### Other considerations
- On one hand nobody asked for this, on the other I don't see any discussions/issues rejecting the idea.
- A PR takes roughly as long to create as a discussion/issue, but the tests run automatically on a PR.
- Calling `Mojo::Collection->new` and the `bless` inside cost CPU time, but Collections are cool, so it's a toss up.
- `Mojo::Collection`s already behave like array-refs, so this change will only upset code that checks `ref` or relies on how array-refs stringify.
- Does it make sense to add tests that check `ref` on the arguments to these callbacks when the current test looks like this: https://github.com/mojolicious/mojo/blob/75124ab7b0e27dc647304067110c2effacc453cf/t/mojo/promise.t#L329