### PR TITLE
Add Mojolicious::Guides::Routing and Mojolicious::Routes::Route to "see also"

### DIFF
--- a/lib/Mojolicious/Routes.pm
+++ b/lib/Mojolicious/Routes.pm
@@ -334,6 +334,8 @@ Match routes with L<Mojolicious::Routes::Match>.
 
 =head1 SEE ALSO
 
-L<Mojolicious>, L<Mojolicious::Guides>, L<https://mojolicious.org>.
+L<Mojolicious>, L<Mojolicious::Guides>,
+L<Mojolicious::Guides::Routing>, L<Mojolicious::Routes::Route>,`
+L<https://mojolicious.org>.
 
 =cut


### PR DESCRIPTION
### Summary
Add Mojolicious::Guides::Routing and Mojolicious::Routes::Route to "see also".

### Motivation
I went looking for `get` documentation and couldn't find it.

### References
Brief discussion on `#mojo`.
