### PR TITLE
Create SECURITY.md.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security issues directly to Sebastian Riedel (kraih(at)mojolicious.org), and give us a few days to develop and release a proper fix.


### PR DESCRIPTION
Create SECURITY.md to avoid security researchers to dive into the actual documentation searching for the correct way to send a found security bug.

### Summary
Adding a file which contains where to report security issues.

### Motivation
Because security researchers could otherwise findd a hard time finding for the correct email.

### References
Github suggests it also.
