### PR TITLE
Cookbook: POST instead of GET in streaming example

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -1350,7 +1350,7 @@ Sending a streaming request is almost just as easy.
 
   # Build a normal transaction
   my $ua = Mojo::UserAgent->new;
-  my $tx = $ua->build_tx(GET => 'http://example.com');
+  my $tx = $ua->build_tx(POST => 'http://example.com');
 
   # Prepare body
   my $body = 'Hello World!';


### PR DESCRIPTION
### Summary
The example with GET makes no sense, as GET method has no body. Use POST instead.

### Motivation
When looking for the way how to do chunked requests I have searched the docs for POST, because I expected that should there be a relevant example, it would use POST. But the Cookbook uses GET for streaming body, which makes no sense.

### References
Discussed on IRC #mojo.
