### PR TITLE
Improve include time of Mojo::Base by extracting monkey_patch

### DIFF
--- a/lib/Mojo/BaseUtil.pm
+++ b/lib/Mojo/BaseUtil.pm
@@ -1,0 +1,46 @@
+package Mojo::BaseUtil;
+
+# Only using pure Perl as the only purpose of this module is to break a circular dependency involving Mojo::Base
+use strict;
+use warnings;
+use feature ':5.16';
+
+use Exporter  qw(import);
+use Sub::Util qw(set_subname);
+
+our @EXPORT_OK = (qw(class_to_path monkey_patch));
+
+sub class_to_path { join '.', join('/', split(/::|'/, shift)), 'pm' }
+
+sub monkey_patch {
+  my ($class, %patch) = @_;
+  no strict 'refs';
+  no warnings 'redefine';
+  *{"${class}::$_"} = set_subname("${class}::$_", $patch{$_}) for keys %patch;
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::BaseUtil - Common utility functions used in Mojo::Base, re-exported in Mojo::Util
+
+=head1 SYNOPSIS
+
+  use Mojo::BaseUtil qw(class_to_patch monkey_path);
+
+  my $path = class_to_path 'Foo::Bar';
+  monkey_patch 'MyApp', foo => sub { say 'Foo!' };
+
+=head1 DESCRIPTION
+
+L<Mojo::BaseUtil> provides functions to both L<Mojo::Base> and L<Mojo::Util> so that C<Mojo::Base> does not have to load
+the rest of L<Mojo::Util> while preventing a circular dependency.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<https://mojolicious.org>.
+
+=cut

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -14,9 +14,9 @@ use IO::Poll qw(POLLIN POLLPRI);
 use IO::Uncompress::Gunzip;
 use List::Util         qw(min);
 use MIME::Base64       qw(decode_base64 encode_base64);
+use Mojo::BaseUtil     qw(class_to_path monkey_patch);
 use Pod::Usage         qw(pod2usage);
 use Socket             qw(inet_pton AF_INET6 AF_INET);
-use Sub::Util          qw(set_subname);
 use Symbol             qw(delete_package);
 use Time::HiRes        ();
 use Unicode::Normalize ();
@@ -104,8 +104,6 @@ sub class_to_file {
   $class =~ s/([A-Z])([A-Z]*)/$1 . lc $2/ge;
   return decamelize($class);
 }
-
-sub class_to_path { join '.', join('/', split(/::|'/, shift)), 'pm' }
 
 sub decamelize {
   my $str = shift;
@@ -196,13 +194,6 @@ sub humanize_bytes {
   return $prefix . _round($size) . 'MiB' if ($size /= 1024) < 1024;
   return $prefix . _round($size) . 'GiB' if ($size /= 1024) < 1024;
   return $prefix . _round($size /= 1024) . 'TiB';
-}
-
-sub monkey_patch {
-  my ($class, %patch) = @_;
-  no strict 'refs';
-  no warnings 'redefine';
-  *{"${class}::$_"} = set_subname("${class}::$_", $patch{$_}) for keys %patch;
 }
 
 sub network_contains {

--- a/t/mojo/base_util.t
+++ b/t/mojo/base_util.t
@@ -1,0 +1,48 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Sub::Util qw(subname);
+
+use Mojo::BaseUtil qw(class_to_path monkey_patch);
+
+subtest 'class_to_path' => sub {
+  is Mojo::BaseUtil::class_to_path('Foo::Bar'),      'Foo/Bar.pm',     'right path';
+  is Mojo::BaseUtil::class_to_path("Foo'Bar"),       'Foo/Bar.pm',     'right path';
+  is Mojo::BaseUtil::class_to_path("Foo'Bar::Baz"),  'Foo/Bar/Baz.pm', 'right path';
+  is Mojo::BaseUtil::class_to_path("Foo::Bar'Baz"),  'Foo/Bar/Baz.pm', 'right path';
+  is Mojo::BaseUtil::class_to_path("Foo::Bar::Baz"), 'Foo/Bar/Baz.pm', 'right path';
+  is Mojo::BaseUtil::class_to_path("Foo'Bar'Baz"),   'Foo/Bar/Baz.pm', 'right path';
+};
+
+subtest 'monkey_patch' => sub {
+  {
+
+    package MojoMonkeyTest;
+    sub foo {'foo'}
+  }
+  ok !!MojoMonkeyTest->can('foo'), 'function "foo" exists';
+  is MojoMonkeyTest::foo(), 'foo', 'right result';
+  ok !MojoMonkeyTest->can('bar'), 'function "bar" does not exist';
+  monkey_patch 'MojoMonkeyTest', bar => sub {'bar'};
+  ok !!MojoMonkeyTest->can('bar'), 'function "bar" exists';
+  is MojoMonkeyTest::bar(), 'bar', 'right result';
+  monkey_patch 'MojoMonkeyTest', foo => sub {'baz'};
+  ok !!MojoMonkeyTest->can('foo'), 'function "foo" exists';
+  is MojoMonkeyTest::foo(), 'baz', 'right result';
+  ok !MojoMonkeyTest->can('yin'),  'function "yin" does not exist';
+  ok !MojoMonkeyTest->can('yang'), 'function "yang" does not exist';
+  monkey_patch 'MojoMonkeyTest',
+    yin  => sub {'yin'},
+    yang => sub {'yang'};
+  ok !!MojoMonkeyTest->can('yin'), 'function "yin" exists';
+  is MojoMonkeyTest::yin(), 'yin', 'right result';
+  ok !!MojoMonkeyTest->can('yang'), 'function "yang" exists';
+  is MojoMonkeyTest::yang(), 'yang', 'right result';
+};
+
+subtest 'monkey_patch (with name)' => sub {
+  is subname(MojoMonkeyTest->can('foo')), 'MojoMonkeyTest::foo', 'right name';
+  is subname(MojoMonkeyTest->can('bar')), 'MojoMonkeyTest::bar', 'right name';
+};
+
+done_testing();

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -11,4 +11,7 @@ my @await = (
   qw(AWAIT_NEW_FAIL AWAIT_ON_CANCEL AWAIT_ON_READY AWAIT_WAIT)
 );
 
-all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', @await, 'spurt']});
+# These are base utils only to be used in Mojo::Base and not elsewhere
+my @base_utils = (qw(class_to_path monkey_patch));
+
+all_pod_coverage_ok({also_private => ['BUILD_DYNAMIC', @await, @base_utils, 'spurt']});


### PR DESCRIPTION
### Motivation
Commit 7e9a2ad introduced a "require Mojo::Util" causing a significant chain of further dependencies being pulled in which IMHO should be avoided for the very base module which is in particular being advertised as useful for just enabling static code checks and common import checks.

### Summary
This commit moves out the function "monkey_patch" into its own module to break or prevent the circular dependency between Mojo::Base and Mojo::Util.

With that the import of Mojo::Base is more efficient, `time perl -e 'use Mojo::Base`
on my system reduced from 224±12.08 ms to 52.0±2.3 ms which I consider a considerable improvement for Mojo::Base which is used as a baseclass in many cases.