### PR TITLE
Mojo::JSON: encode core boolean values as json bools

### DIFF
--- a/lib/Mojo/JSON.pm
+++ b/lib/Mojo/JSON.pm
@@ -12,6 +12,12 @@ use constant JSON_XS => $ENV{MOJO_NO_JSON_XS}
   ? 0
   : !!eval { require Cpanel::JSON::XS; Cpanel::JSON::XS->VERSION('4.09'); 1 };
 
+use constant CORE_BOOLS => defined &builtin::is_bool;
+
+BEGIN {
+  warnings->unimport('experimental::builtin') if CORE_BOOLS;
+}
+
 our @EXPORT_OK = qw(decode_json encode_json false from_json j to_json true);
 
 # Escaped special character map
@@ -249,6 +255,9 @@ sub _encode_value {
 
   # Null
   return 'null' unless defined $value;
+
+  # Boolean
+  return $value ? 'true' : 'false' if CORE_BOOLS && builtin::is_bool($value);
 
   # Number
   no warnings 'numeric';

--- a/t/mojo/json.t
+++ b/t/mojo/json.t
@@ -218,6 +218,14 @@ subtest 'Encode number' => sub {
   is $bytes, '23.3', 'encode 23.3';
 };
 
+subtest 'Encode boolean' => sub {
+  plan skip_all => 'No core boolean support' if !defined &builtin::is_bool;
+  my $bytes = encode_json [!!1];
+  is $bytes, '[true]', 'encode [!!1]';
+  $bytes = encode_json [!!0];
+  is $bytes, '[false]', 'encode [!!0]';
+};
+
 subtest 'Faihu roundtrip' => sub {
   my $bytes = j(["\x{10346}"]);
   is b($bytes)->decode('UTF-8'), "[\"\x{10346}\"]", 'encode ["\x{10346}"]';


### PR DESCRIPTION
### Summary
Encode perl's built in boolean values on perl 5.36 and newer

### Motivation
Newer perl versions can track if a value is a boolean rather than just a string or number. Since we can identify them as being booleans, they can be encoded in JSON as booleans. This also matches the behavior of newer versions of JSON::PP and Cpanel::JSON::XS

### References
Fixes #2191