### PR TITLE
Deprecate accepting old apostrophe package separator in Mojo::Loader

### DIFF
--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -4,7 +4,7 @@ use Mojo::Base -strict;
 use Exporter qw(import);
 use Mojo::Exception;
 use Mojo::File qw(path);
-use Mojo::Util qw(b64_decode class_to_path);
+use Mojo::Util qw(b64_decode class_to_path deprecated);
 
 our @EXPORT_OK = qw(data_section file_is_binary find_modules find_packages load_class load_classes);
 
@@ -42,6 +42,9 @@ sub load_class {
 
   # Invalid class name
   return 1 if ($class || '') !~ /^\w(?:[\w:']*\w)?$/;
+  deprecated
+    q{Calling Mojo::Loader::load_class with a class name using the old package separator "'" is deprecated; use "::"}
+    if $class =~ m/'/;
 
   # Load if not already loaded
   return undef if $class->can('new') || eval "require $class; 1";

--- a/t/mojo/base.t
+++ b/t/mojo/base.t
@@ -19,7 +19,7 @@ package Mojo::BaseTestTest;
 use Mojo::Base 'Mojo::BaseTest';
 
 package Mojo::BaseTestTestTest;
-use Mojo::Base "Mojo'BaseTestTest";
+use Mojo::Base 'Mojo::BaseTestTest';
 
 package Mojo::BaseTest::Weak1;
 use Mojo::Base -base;

--- a/t/mojo/loader.t
+++ b/t/mojo/loader.t
@@ -76,8 +76,8 @@ subtest 'Search packages' => sub {
 };
 
 subtest 'Load' => sub {
-  ok !load_class("Mojo'LoaderTest::A"), 'loaded successfully';
-  ok !!Mojo::LoaderTest::A->can('new'), 'loaded successfully';
+  ok !load_class('Mojo::LoaderTest::A'), 'loaded successfully';
+  ok !!Mojo::LoaderTest::A->can('new'),  'loaded successfully';
   load_class $_ for find_modules 'Mojo::LoaderTest';
   ok !!Mojo::LoaderTest::B->can('new'), 'loaded successfully';
   ok !!Mojo::LoaderTest::C->can('new'), 'loaded successfully';


### PR DESCRIPTION
### Summary
The first commit removes use of the ' package separator in tests, to resolve #2085 (which is now an error in the latest Perl development releases which will remove that feature).

The second commit deprecates calls to Mojo::Loader::load_class that contain a ' package separator.

### Motivation
The feature will be removed in upcoming versions of Perl.

### References
#2085, https://github.com/Perl/perl5/issues/22504
