### PR TITLE
Add support for partitioned cookies

### DIFF
--- a/lib/Mojolicious/Sessions.pm
+++ b/lib/Mojolicious/Sessions.pm
@@ -4,7 +4,7 @@ use Mojo::Base -base;
 use Mojo::JSON;
 use Mojo::Util qw(b64_decode b64_encode);
 
-has [qw(cookie_domain encrypted secure)];
+has [qw(cookie_domain encrypted partitioned secure)];
 has cookie_name        => 'mojolicious';
 has cookie_path        => '/';
 has default_expiration => 3600;
@@ -52,12 +52,13 @@ sub store {
   my $value = b64_encode $self->serialize->($session), '';
   $value =~ y/=/-/;
   my $options = {
-    domain   => $self->cookie_domain,
-    expires  => $session->{expires},
-    httponly => 1,
-    path     => $self->cookie_path,
-    samesite => $self->samesite,
-    secure   => $self->secure
+    domain      => $self->cookie_domain,
+    expires     => $session->{expires},
+    httponly    => 1,
+    partitioned => $self->partitioned,
+    path        => $self->cookie_path,
+    samesite    => $self->samesite,
+    secure      => $self->secure,
   };
   my $method = $self->encrypted ? 'encrypted_cookie' : 'signed_cookie';
   $c->$method($self->cookie_name, $value, $options);
@@ -148,6 +149,18 @@ A callback used to deserialize sessions, defaults to L<Mojo::JSON/"j">.
   $sessions = $sessions->encrypted($bool);
 
 Use encrypted session cookies instead of merely cryptographically signed ones.
+
+=head2 partitioned
+
+  my $bool  = $sessions->partitioned;
+  $sessions = $sessions->partitioned($bool);
+
+Partitioned flag, this is to be used in accordance to the CHIPS amendment to RFC 6265.
+Note that this attribute is B<EXPERIMENTAL> because even though most commonly used browsers support the
+feature, there is no specification yet besides L<this
+draft|https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-00.html>.
+
+Partitioned cookies are held within a separate cookie jar per top-level site.
 
 =head2 samesite
 

--- a/t/mojo/cookie.t
+++ b/t/mojo/cookie.t
@@ -168,13 +168,14 @@ subtest 'Full response cookie as string' => sub {
   $cookie->value('ba r');
   $cookie->domain('example.com');
   $cookie->path('/test');
+  $cookie->partitioned(1);
   $cookie->max_age(60);
   $cookie->expires(1218092879);
   $cookie->secure(1);
   $cookie->httponly(1);
   $cookie->samesite('Lax');
   is $cookie->to_string, '0="ba r"; expires=Thu, 07 Aug 2008 07:07:59 GMT; domain=example.com;'
-    . ' path=/test; secure; HttpOnly; SameSite=Lax; Max-Age=60', 'right format';
+    . ' path=/test; Partitioned; secure; HttpOnly; SameSite=Lax; Max-Age=60', 'right format';
 };
 
 subtest 'Empty response cookie' => sub {
@@ -214,6 +215,16 @@ subtest 'Parse response cookie (RFC 6265)' => sub {
   is $cookies->[0]->expires, 1218092879,    'right expires value';
   is $cookies->[0]->secure,  1,             'right secure flag';
   is $cookies->[1],          undef,         'no more cookies';
+};
+
+subtest 'Partitioned cookie (RFC 6265 CHIPS)' => sub {
+  my $cookies = Mojo::Cookie::Response->parse('foo="bar"; Domain=example.com; Partitioned; Path=/test;'
+      . 'Max-Age=60; Expires=Thu, 07 Aug 2008 07:07:59 GMT; Secure;');
+  is $cookies->[0]->partitioned, 1, 'right partitioned value';
+
+  $cookies = Mojo::Cookie::Response->parse(
+    'foo="bar"; Domain=example.com; Path=/test; Max-Age=60; Expires=Thu, 07 Aug 2008 07:07:59 GMT; Secure;');
+  is $cookies->[0]->partitioned, undef, 'no partitioned value';
 };
 
 subtest 'Parse response cookie with invalid flag (RFC 6265)' => sub {


### PR DESCRIPTION
### Summary
Firefox is soon going to ignore third-party aka "foreign" aka `SameSite: None`

### Motivation
These changes allow Mojolicious to handle the new "Partitioned" attribute, as well as adding the ability to set `Partitioned` on `Mojolicious::Sessions` cookies.

### References

https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-00.html

https://github.com/privacycg/CHIPS

fixes #2179 
