### PR TITLE
Secure by default sessions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install Dependencies
         run: |
           cpanm --installdeps .
-          cpanm -n TAP::Formatter::GitHubActions
+          cpanm -n TAP::Formatter::GitHubActions Crypt::URandom
       - name: Run Tests
         run: prove --merge --formatter TAP::Formatter::GitHubActions -l t t/mojo t/mojolicious

--- a/lib/Mojolicious/Command/Author/generate/app.pm
+++ b/lib/Mojolicious/Command/Author/generate/app.pm
@@ -196,7 +196,7 @@ done_testing();
 </p>
 
 @@ config
-% use Mojo::Util qw(sha1_sum steady_time);
+% use Mojo::Util qw(urandom_urlsafe);
 ---
 secrets:
-  - <%= sha1_sum $$ . steady_time . rand  %>
+  - <%= urandom_urlsafe %>

--- a/lib/Mojolicious/Command/Author/generate/secret.pm
+++ b/lib/Mojolicious/Command/Author/generate/secret.pm
@@ -1,0 +1,82 @@
+package Mojolicious::Command::Author::generate::secret;
+use Mojo::Base 'Mojolicious::Command';
+use Mojo::File qw(path);
+use Mojo::Util qw(urandom_urlsafe);
+
+has description => 'Generate secret';
+has usage       => sub { shift->extract_usage };
+
+sub run {
+  my ($self, $secret_file) = (shift, shift);
+
+  $secret_file //= $self->app->secrets_file;
+
+  my $token = urandom_urlsafe();
+
+  print "Writing secret to $secret_file\n";
+
+  path($secret_file)->touch->chmod(0600)->spew($token);
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojolicious::Command::Author::generate::secret - Secret generator command
+
+=head1 SYNOPSIS
+
+  Usage: APPLICATION generate secret [PATH]
+
+    mojo generate secret
+    mojo generate secret /path/to/secret
+
+  Options:
+    -h, --help   Show this summary of available options
+
+=head1 DESCRIPTION
+
+L<Mojolicious::Command::Author::generate::secret> generates a secret token for protecting session cookies
+
+This is a core command, that means it is always enabled and its code a good example for learning to build new commands,
+you're welcome to fork it.
+
+See L<Mojolicious::Commands/"COMMANDS"> for a list of commands that are available by default.
+
+=head1 ATTRIBUTES
+
+L<Mojolicious::Command::Author::generate::secret> inherits all attributes from L<Mojolicious::Command> and implements
+the following new ones.
+
+=head2 description
+
+  my $description = $app->description;
+  $app            = $app->description('Foo');
+
+Short description of this command, used for the command list.
+
+=head2 usage
+
+  my $usage = $app->usage;
+  $app      = $app->usage('Foo');
+
+Usage information for this command, used for the help screen.
+
+=head1 METHODS
+
+L<Mojolicious::Command::Author::generate::secret> inherits all methods from L<Mojolicious::Command> and implements
+the following new ones.
+
+=head2 run
+
+  $app->run(@ARGV);
+
+Run this command.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<https://mojolicious.org>.
+
+=cut

--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -8,7 +8,7 @@ use Mojo::Collection;
 use Mojo::Exception;
 use Mojo::IOLoop;
 use Mojo::Promise;
-use Mojo::Util   qw(dumper hmac_sha1_sum steady_time);
+use Mojo::Util   qw(dumper urandom_urlsafe);
 use Time::HiRes  qw(gettimeofday tv_interval);
 use Scalar::Util qw(blessed weaken);
 
@@ -95,7 +95,7 @@ sub _convert_to_exception {
   return (blessed $e && $e->isa('Mojo::Exception')) ? $e : Mojo::Exception->new($e);
 }
 
-sub _csrf_token { $_[0]->session->{csrf_token} ||= hmac_sha1_sum($$ . steady_time . rand, $_[0]->app->secrets->[0]) }
+sub _csrf_token { $_[0]->session->{csrf_token} ||= urandom_urlsafe; }
 
 sub _current_route {
   return '' unless my $route = shift->match->endpoint;

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -12,7 +12,7 @@ use Mojo::Util qw(b64_decode b64_encode camelize class_to_file class_to_path dec
   qw(extract_usage getopt gunzip gzip header_params hmac_sha1_sum html_unescape html_attr_unescape humanize_bytes),
   qw(md5_bytes md5_sum monkey_patch network_contains punycode_decode punycode_encode quote scope_guard secure_compare),
   qw(sha1_bytes sha1_sum slugify split_cookie_header split_header steady_time tablify term_escape trim unindent),
-  qw(unquote url_escape url_unescape xml_escape xor_encode);
+  qw(unquote urandom_bytes urandom_urlsafe url_escape url_unescape xml_escape xor_encode);
 
 subtest 'camelize' => sub {
   is camelize('foo_bar_baz'), 'FooBarBaz', 'right camelized result';
@@ -660,5 +660,19 @@ subtest 'Hide DATA usage from error messages' => sub {
   eval { die 'whatever' };
   unlike $@, qr/DATA/, 'DATA has been hidden';
 };
+
+subtest 'urandom' => sub {
+  isnt urandom_bytes,           urandom_bytes, "two urandom_bytes invocations are not the same";
+  is length(urandom_bytes),     32,            "urandom_bytes returns 32 bytes by default";
+  is length(urandom_bytes(16)), 16,            "urandom_bytes(16) returns 16 bytes";
+
+  isnt urandom_urlsafe, urandom_urlsafe, "two urandom_urlsafe invocations are not the same";
+  like urandom_urlsafe, qr/^[-A-Za-z0-9_]{43}$/, "urandom_urlsafe returns 43 chars of urlsafe encoded base64";
+  like urandom_urlsafe(128), qr/^[-A-Za-z0-9_]{171}$/,
+    "urandom_urlsafe(128) returns 171 chars of urlsafe encoded base64";
+  like urandom_urlsafe(2048), qr/^[-A-Za-z0-9_]{2731}$/,
+    "urandom_urlsafe(2048) returns 2731 chars of urlsafe encoded base64";
+};
+
 
 done_testing();

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -90,9 +90,9 @@ is_deeply $t->app->commands->namespaces,
   ['Mojolicious::Command::Author', 'Mojolicious::Command', 'MojoliciousTest::Command'], 'right namespaces';
 is $t->app,                                   $t->app->commands->app,                         'applications are equal';
 is $t->app->static->file('hello.txt')->slurp, "Hello Mojo from a development static file!\n", 'right content';
-is $t->app->static->file('does_not_exist.html'), undef,              'no file';
-is $t->app->moniker,                             'mojolicious_test', 'right moniker';
-is $t->app->secrets->[0],                        $t->app->moniker,   'secret defaults to moniker';
+is $t->app->static->file('does_not_exist.html'), undef,                                       'no file';
+is $t->app->moniker,                             'mojolicious_test',                          'right moniker';
+is $t->app->secrets->[0], 'NeverGonnaGiveYouUpNeverGonnaLetYouDown', 'secret defaults to content of mojo.secrets';
 is $t->app->renderer->template_handler({template => 'foo/bar/index', format => 'html'}), 'epl',   'right handler';
 is $t->app->build_controller->req->url,                                                  '',      'no URL';
 is $t->app->build_controller->render_to_string('does_not_exist'),                        undef,   'no result';

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -22,10 +22,8 @@ app->defaults(default => 23);
 
 # Secret
 app->log->level('trace')->unsubscribe('message');
-my $logs = app->log->capture('trace');
-is app->secrets->[0], app->moniker, 'secret defaults to moniker';
-like $logs, qr/Your secret passphrase needs to be changed/, 'right message';
-undef $logs;
+
+is app->secrets->[0], 'NeverGonnaGiveYouUpNeverGonnaLetYouDown', 'secret defaults to content of mojo.secrets';
 
 # Test helpers
 helper test_helper  => sub { shift->param(@_) };
@@ -751,7 +749,7 @@ $t->get_ok('/to_string')->status_is(200)->content_is('beforeafter');
 $t->get_ok('/source')->status_is(200)->content_type_is('application/octet-stream')->content_like(qr!get_ok\('/source!);
 
 # File does not exist
-$logs = app->log->capture('trace');
+my $logs = app->log->capture('trace');
 $t->get_ok('/source?fail=1')->status_is(500)->content_like(qr/Static file "does_not_exist.txt" not found/);
 like $logs, qr/Static file "does_not_exist.txt" not found/, 'right message';
 undef $logs;

--- a/t/mojolicious/mojo.secrets
+++ b/t/mojolicious/mojo.secrets
@@ -1,0 +1,1 @@
+NeverGonnaGiveYouUpNeverGonnaLetYouDown

--- a/t/mojolicious/secret/custom.secrets
+++ b/t/mojolicious/secret/custom.secrets
@@ -1,0 +1,3 @@
+NeverGonnaMakeYouCryNeverGonnaSayGoodbye
+skip-me
+NeverGonnaTellALieAndHurtYou

--- a/t/mojolicious/secret/lite-create.t
+++ b/t/mojolicious/secret/lite-create.t
@@ -1,0 +1,16 @@
+use Mojo::Base -strict;
+
+use Mojo::File qw(tempdir path);
+use Test::Mojo;
+use Test::More;
+use Mojolicious::Lite;
+
+
+my $tmpdir = tempdir;
+my $file   = $tmpdir->child("mojo.secrets");
+$ENV{MOJO_SECRETS_FILE} = $file;
+
+like app->secrets->[0], qr/^[-A-Za-z0-9_]{43}$/, 'secret was generated, and matches expected urandom_urlsafe format';
+is app->secrets->[0], $file->slurp, 'secret stored at $ENV{MOJO_SECRETS_FILE} is the same as app->secrets->[0]';
+
+done_testing();

--- a/t/mojolicious/secret/lite-env-file.t
+++ b/t/mojolicious/secret/lite-env-file.t
@@ -1,0 +1,17 @@
+use Mojo::Base -strict;
+
+BEGIN {
+  $ENV{MOJO_SECRETS_FILE} = "t/mojolicious/secret/custom.secrets";
+}
+
+use Test::Mojo;
+use Test::More;
+use Mojolicious::Lite;
+
+is_deeply(
+  app->secrets,
+  ['NeverGonnaMakeYouCryNeverGonnaSayGoodbye', 'NeverGonnaTellALieAndHurtYou'],
+  'only valid secrets are loaded from $ENV{MOJO_SECRETS_FILE}'
+);
+
+done_testing();

--- a/t/mojolicious/secret/lite-home.t
+++ b/t/mojolicious/secret/lite-home.t
@@ -1,0 +1,13 @@
+use Mojo::Base -strict;
+
+BEGIN {
+  $ENV{MOJO_HOME} = "t/mojolicious/";
+}
+
+use Test::Mojo;
+use Test::More;
+use Mojolicious::Lite;
+
+is app->secrets->[0], 'NeverGonnaGiveYouUpNeverGonnaLetYouDown', 'secret is loaded from home';
+
+done_testing();

--- a/t/mojolicious/secret/lite-weak.t
+++ b/t/mojolicious/secret/lite-weak.t
@@ -1,0 +1,14 @@
+use Mojo::Base -strict;
+
+BEGIN {
+  $ENV{MOJO_SECRETS_FILE} = "t/mojolicious/secret/weak.secrets";
+}
+
+use Test::Mojo;
+use Test::More;
+use Mojolicious::Lite;
+
+eval { app->secrets; };
+like $@, qr/does not contain any acceptable secret/;
+
+done_testing();

--- a/t/mojolicious/secret/weak.secrets
+++ b/t/mojolicious/secret/weak.secrets
@@ -1,0 +1,2 @@
+hunter2
+password


### PR DESCRIPTION
### Summary

To make session secrets secure by default, generate and persist a 256 bit session secret:

* Add `urandom_bytes` and `urandom_urlsafe` to `Mojo::Util` for generating secure random bits from either `Crypt::Random` or `/dev/urandom`

* Don't use the hard coded moniker as the default secret

* Generate and store a strong secret if not exists in `$ENV{MOJO_HOME}/mojo.secrets`, overridable with `$ENV{MOJO_SECRETS_FILE}` when app->secrets is called

* Only load secrets from `mojo.secrets` that are over 22 chars

* Use `urandom_urlsafe` when generating CSRF tokens

* Use `urandom_urlsafe` in `mojo generate app`

* Add `mojo generate secret`

* Tests:
   - Add misc tests for generating and loading mojo.secrets in `t/mojolicious/secret/` and for `mojo generate secret`.
   - Add a default secret in `t/mojolicious/mojo.secrets` so other session checks work

* Install `Crypt::URandom` in GH Windows workflow so `urandom_bytes` works on that platform

### Also consider

- Disallowing insecure secrets from being passed to `app->secrets()`
- Removing padding of HMAC message to 1025 bytes introduced by #1791

### Motivation

Making HMAC protected sessions secure by default after discussing with @jberger at PTS24. 

It has been demonstrated by [Baking Mojolicious cookies](https://www.synacktiv.com/publications/baking-mojolicious-cookies) and the recent discussion in #1791 that this is not the case.


