### PR TITLE
Add support for encrypted sessions with CryptX

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           cpanm -n --installdeps .
-          cpanm -n Cpanel::JSON::XS EV Role::Tiny
+          cpanm -n Cpanel::JSON::XS EV Role::Tiny CryptX
           cpanm -n Test::Pod Test::Pod::Coverage TAP::Formatter::GitHubActions
       - name: Run tests
         run: prove --merge --formatter TAP::Formatter::GitHubActions -l t t/mojo t/mojolicious

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -513,6 +513,9 @@ rotating passphrases, just add new ones to the front and remove old ones from th
 Signed cookie based session manager, defaults to a L<Mojolicious::Sessions> object. You can usually leave this alone,
 see L<Mojolicious::Controller/"session"> for more information about working with session data.
 
+  # Enable encrypted sessions
+  $app->sessions->encrypted(1);
+
   # Change name of cookie used for all sessions
   $app->sessions->cookie_name('mysession');
 

--- a/lib/Mojolicious/Command/Author/generate/app.pm
+++ b/lib/Mojolicious/Command/Author/generate/app.pm
@@ -196,7 +196,7 @@ done_testing();
 </p>
 
 @@ config
-% use Mojo::Util qw(sha1_sum steady_time);
+% use Mojo::Util qw(generate_secret);
 ---
 secrets:
-  - <%= sha1_sum $$ . steady_time . rand  %>
+  - <%= generate_secret() %>

--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -4,6 +4,7 @@ use Mojo::Base 'Mojolicious::Command';
 use Mojo::IOLoop::Client;
 use Mojo::IOLoop::TLS;
 use Mojo::JSON;
+use Mojo::Util;
 use Mojolicious;
 
 has description => 'Show versions of available modules';
@@ -12,13 +13,14 @@ has usage       => sub { shift->extract_usage };
 sub run {
   my $self = shift;
 
-  my $json  = Mojo::JSON->JSON_XS                   ? $Cpanel::JSON::XS::VERSION   : 'n/a';
-  my $ev    = eval { require Mojo::Reactor::EV; 1 } ? $EV::VERSION                 : 'n/a';
-  my $socks = Mojo::IOLoop::Client->can_socks       ? $IO::Socket::Socks::VERSION  : 'n/a';
-  my $tls   = Mojo::IOLoop::TLS->can_tls            ? $IO::Socket::SSL::VERSION    : 'n/a';
-  my $nnr   = Mojo::IOLoop::Client->can_nnr         ? $Net::DNS::Native::VERSION   : 'n/a';
-  my $roles = Mojo::Base->ROLES                     ? $Role::Tiny::VERSION         : 'n/a';
-  my $async = Mojo::Base->ASYNC                     ? $Future::AsyncAwait::VERSION : 'n/a';
+  my $json   = Mojo::JSON->JSON_XS                   ? $Cpanel::JSON::XS::VERSION   : 'n/a';
+  my $cryptx = Mojo::Util->CRYPTX                    ? $CryptX::VERSION             : 'n/a';
+  my $ev     = eval { require Mojo::Reactor::EV; 1 } ? $EV::VERSION                 : 'n/a';
+  my $socks  = Mojo::IOLoop::Client->can_socks       ? $IO::Socket::Socks::VERSION  : 'n/a';
+  my $tls    = Mojo::IOLoop::TLS->can_tls            ? $IO::Socket::SSL::VERSION    : 'n/a';
+  my $nnr    = Mojo::IOLoop::Client->can_nnr         ? $Net::DNS::Native::VERSION   : 'n/a';
+  my $roles  = Mojo::Base->ROLES                     ? $Role::Tiny::VERSION         : 'n/a';
+  my $async  = Mojo::Base->ASYNC                     ? $Future::AsyncAwait::VERSION : 'n/a';
 
   print <<EOF;
 CORE
@@ -27,6 +29,7 @@ CORE
 
 OPTIONAL
   Cpanel::JSON::XS 4.09+   ($json)
+  CryptX 0.080+            ($cryptx)
   EV 4.32+                 ($ev)
   IO::Socket::Socks 0.64+  ($socks)
   IO::Socket::SSL 2.009+   ($tls)

--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -49,7 +49,40 @@ sub cookie {
   return $cookie->value;
 }
 
+sub encrypted_cookie {
+  my ($self, $name, $value, $options) = @_;
+
+  # Request cookie
+  return $self->every_encrypted_cookie($name)->[-1] unless defined $value;
+
+  # Response cookie
+  my $app     = $self->app;
+  my $secret  = $app->secrets->[0];
+  my $moniker = $app->moniker;
+  return $self->cookie($name, Mojo::Util::encrypt_cookie($value, $secret, $moniker), $options);
+}
+
 sub every_cookie { [map { $_->value } @{shift->req->every_cookie(shift)}] }
+
+sub every_encrypted_cookie {
+  my ($self, $name) = @_;
+
+  my $app     = $self->app;
+  my $secrets = $app->secrets;
+  my $moniker = $app->moniker;
+  my @results;
+  for my $value (@{$self->every_cookie($name)}) {
+    my $decrypted;
+    for my $secret (@$secrets) {
+      last if defined($decrypted = Mojo::Util::decrypt_cookie($value, $secret, $moniker));
+    }
+    if (defined $decrypted) { push @results, $decrypted }
+
+    else { $self->helpers->log->trace(qq{Cookie "$name" is not encrypted}) }
+  }
+
+  return \@results;
+}
 
 sub every_param {
   my ($self, $name) = @_;
@@ -399,6 +432,17 @@ you want to access more than just the last one, you can use L</"every_cookie">.
   # Create secure response cookie
   $c->cookie(secret => 'I <3 Mojolicious', {secure => 1, httponly => 1});
 
+=head2 encrypted_cookie
+
+  my $value = $c->encrypted_cookie('foo');
+  $c        = $c->encrypted_cookie(foo => 'bar');
+  $c        = $c->encrypted_cookie(foo => 'bar', {path => '/'});
+
+Access encrypted request cookie values and create new encrypted response cookies. If there are multiple values sharing
+the same name, and you want to access more than just the last one, you can use L</"every_encrypted_cookie">. Cookies
+are encrypted with ChaCha20-Poly1305, to prevent tampering, and the ones failing decryption will be automatically
+discarded. Note that this method is B<EXPERIMENTAL> and might change without warning!
+
 =head2 every_cookie
 
   my $values = $c->every_cookie('foo');
@@ -407,6 +451,16 @@ Similar to L</"cookie">, but returns all request cookie values sharing the same 
 
   $ Get first cookie value
   my $first = $c->every_cookie('foo')->[0];
+
+=head2 every_encrypted_cookie
+
+  my $values = $c->every_encrypted_cookie('foo');
+
+Similar to L</"encrypted_cookie">, but returns all encrypted request cookie values sharing the same name as an array
+reference. Note that this method is B<EXPERIMENTAL> and might change without warning!
+
+  # Get first encrypted cookie value
+  my $first = $c->every_encrypted_cookie('foo')->[0];
 
 =head2 every_param
 

--- a/lib/Mojolicious/Guides/FAQ.pod
+++ b/lib/Mojolicious/Guides/FAQ.pod
@@ -27,8 +27,8 @@ frameworks, it is more of a web toolkit and can even be used as the foundation f
 We are optimizing L<Mojolicious> for user-friendliness and development speed, without compromises. While there are no
 rules in L<Mojolicious::Guides::Contributing> that forbid dependencies, we do currently discourage adding non-optional
 ones in favor of a faster and more painless installation process. And we do in fact already use several optional CPAN
-modules such as L<Cpanel::JSON::XS>, L<EV>, L<IO::Socket::Socks>, L<IO::Socket::SSL>, L<Net::DNS::Native>, L<Plack> and
-L<Role::Tiny> to provide advanced functionality if possible.
+modules such as L<Cpanel::JSON::XS>, L<CryptX>, L<EV>, L<IO::Socket::Socks>, L<IO::Socket::SSL>, L<Net::DNS::Native>,
+L<Plack> and L<Role::Tiny> to provide advanced functionality if possible.
 
 =head2 Why reinvent wheels?
 

--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -104,8 +104,8 @@ web server in the form of cookies.
   Set-Cookie: session=hmac-sha256(base64(json($session)))
 
 In L<Mojolicious> however we are taking this concept one step further by storing everything JSON serialized and Base64
-encoded in HMAC-SHA256 signed cookies, which is more compatible with the REST philosophy and reduces infrastructure
-requirements.
+encoded in HMAC-SHA256 signed, or ChaCha20-Poly1305 encrypted cookies, which is more compatible with the REST
+philosophy and reduces infrastructure requirements.
 
 =head2 Test-Driven Development
 

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -8,11 +8,11 @@ use Mojo::ByteStream qw(b);
 use Mojo::DeprecationTest;
 use Sub::Util qw(subname);
 
-use Mojo::Util qw(b64_decode b64_encode camelize class_to_file class_to_path decamelize decode dumper encode),
-  qw(extract_usage getopt gunzip gzip header_params hmac_sha1_sum html_unescape html_attr_unescape humanize_bytes),
-  qw(md5_bytes md5_sum monkey_patch network_contains punycode_decode punycode_encode quote scope_guard secure_compare),
-  qw(sha1_bytes sha1_sum slugify split_cookie_header split_header steady_time tablify term_escape trim unindent),
-  qw(unquote url_escape url_unescape xml_escape xor_encode);
+use Mojo::Util qw(b64_decode b64_encode camelize class_to_file class_to_path decamelize decode decrypt_cookie dumper),
+  qw(encode encrypt_cookie extract_usage generate_secret getopt gunzip gzip header_params hmac_sha1_sum html_unescape),
+  qw(html_attr_unescape humanize_bytes md5_bytes md5_sum monkey_patch network_contains punycode_decode),
+  qw(punycode_encode quote scope_guard secure_compare sha1_bytes sha1_sum slugify split_cookie_header split_header),
+  qw(steady_time tablify term_escape trim unindent unquote url_escape url_unescape xml_escape xor_encode);
 
 subtest 'camelize' => sub {
   is camelize('foo_bar_baz'), 'FooBarBaz', 'right camelized result';
@@ -654,6 +654,27 @@ subtest 'humanize_bytes' => sub {
   is humanize_bytes( 717946880),                '685MiB',  'large MiB';
   is humanize_bytes(-717946880),                '-685MiB', 'large negative MiB';
   is humanize_bytes( 245760),                   '240KiB',  'less than a MiB';
+};
+
+subtest 'encrypt_cookie/decrypt_cookie' => sub {
+  plan skip_all => 'CryptX required!' unless Mojo::Util->CRYPTX;
+
+  subtest 'Roundtrip' => sub {
+    my $encrypted = encrypt_cookie('test', 'foo', 'salt');
+    isnt $encrypted,                              'test', 'encrypted';
+    is decrypt_cookie($encrypted, 'foo', 'salt'), 'test', 'decrypted';
+  };
+
+  is decrypt_cookie('test',                                               'foo', 'salt'), undef,  'not encrypted';
+  is decrypt_cookie('6Y+LKA==-ROhxLDrUBVkXRKTM-v7Qm+Xgoi1t94GLSHYGkaW==', 'foo', 'salt'), undef,  'wrong tag';
+  is decrypt_cookie('6Y+LKA==-ROhxLDrUBVkXRKTm-v7Qm+Xgoi1t94GLSHYGkaw==', 'foo', 'salt'), undef,  'wrong random bytes';
+  is decrypt_cookie('6Y+LKA==-ROhxLDrUBVkXRKTM-v7Qm+Xgoi1t94GLSHYGkaw==', 'bar', 'salt'), undef,  'wrong password';
+  is decrypt_cookie('6Y+LKA==-ROhxLDrUBVkXRKTM-v7Qm+Xgoi1t94GLSHYGkaw==', 'foo', 'bar'),  undef,  'wrong salt';
+  is decrypt_cookie('6Y+LKA==-ROhxLDrUBVkXRKTM-v7Qm+Xgoi1t94GLSHYGkaw==', 'foo', 'salt'), 'test', 'decrypted';
+};
+
+subtest 'generate_secret' => sub {
+  like generate_secret, qr/^[A-Za-z0-9_-]{32,}$/, 'right format';
 };
 
 subtest 'Hide DATA usage from error messages' => sub {

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -273,12 +273,6 @@ get '/session_cookie/2' => sub {
   $c->render(text => "Session is $value!");
 };
 
-get '/session_length' => sub {
-  my $c = shift;
-  $c->session->{q} = $c->param('q');
-  $c->rendered(204);
-};
-
 get '/foo' => sub {
   my $c = shift;
   $c->render(text => 'Yea baby!');
@@ -801,30 +795,6 @@ $t->reset_session;
 ok !$t->tx, 'session reset';
 $t->get_ok('/session_cookie/2')->status_is(200)->header_is(Server => 'Mojolicious (Perl)')
   ->content_is('Session is missing!');
-
-
-subtest 'Session length' => sub {
-  my $extract = sub {
-    my $value = $_[0]->tx->res->cookie('mojolicious')->value;
-    $value =~ s/--([^\-]+)$//;
-    $value =~ y/-/=/;
-    return Mojo::Util::b64_decode($value);
-  };
-
-  subtest 'Short session' => sub {
-    $t->reset_session;
-    my $value = $t->get_ok('/session_length?q=a')->status_is(204)->$extract;
-    cmp_ok length($value), '>', 1024, 'session is long enough';
-    ok $value =~ /Z+$/, 'session is padded';
-  };
-
-  subtest 'Long session' => sub {
-    $t->reset_session;
-    my $value = $t->get_ok('/session_length?q=' . 'a' x 1025)->status_is(204)->$extract;
-    cmp_ok length($value), '>', 1024, 'session is long enough';
-    ok $value !~ /Z+$/, 'session is not padded';
-  };
-};
 
 # Text
 $t->get_ok('/foo')->status_is(200)->header_is(Server => 'Mojolicious (Perl)')->content_is('Yea baby!');

--- a/t/mojolicious/session_lite_app.t
+++ b/t/mojolicious/session_lite_app.t
@@ -1,0 +1,94 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::Mojo;
+use Test::More;
+
+use Mojo::Util;
+use Mojolicious::Lite;
+
+app->secrets(['test1']);
+
+get '/login' => sub {
+  my $c = shift;
+  $c->session(user => 'sri');
+  $c->render(text => 'logged in');
+};
+
+get '/session' => sub {
+  my $c    = shift;
+  my $user = $c->session->{user} // 'nobody';
+  $c->render(text => "user:$user");
+};
+
+get '/logout' => sub {
+  my $c = shift;
+  delete $c->session->{user};
+  $c->render(text => 'logged out');
+};
+
+my $t = Test::Mojo->new;
+
+subtest 'User session (signed cookie)' => sub {
+  is $t->app->sessions->encrypted, undef, 'not encrypted by default';
+  $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+  $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+  $t->get_ok('/login')->status_is(200)->content_is('logged in');
+  $t->get_ok('/session')->status_is(200)->content_is('user:sri');
+  like $t->tx->res->cookies->[0]->value, qr/^[^-]+-+[^-]+$/, 'signed cookie format';
+  $t->get_ok('/session')->status_is(200)->content_is('user:sri');
+  $t->get_ok('/logout')->status_is(200)->content_is('logged out');
+  $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+  $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+};
+
+subtest 'User session (encrypted cookie)' => sub {
+  plan skip_all => 'CryptX required!' unless Mojo::Util->CRYPTX;
+  $t->reset_session;
+  $t->app->sessions->encrypted(1);
+  $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+  $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+  $t->get_ok('/login')->status_is(200)->content_is('logged in');
+  $t->get_ok('/session')->status_is(200)->content_is('user:sri');
+  like $t->tx->res->cookies->[0]->value, qr/^[^-]+-[^-]+-[^-]+$/, 'encrypted cookie format';
+  $t->get_ok('/session')->status_is(200)->content_is('user:sri');
+  $t->get_ok('/logout')->status_is(200)->content_is('logged out');
+  $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+  $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+};
+
+subtest 'Rotating secrets' => sub {
+  subtest 'User session (signed cookie)' => sub {
+    $t->reset_session;
+    $t->app->secrets(['test1']);
+    $t->app->sessions->encrypted(0);
+    $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+    $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+    $t->get_ok('/login')->status_is(200)->content_is('logged in');
+    $t->get_ok('/session')->status_is(200)->content_is('user:sri');
+    $t->app->secrets(['test2', 'test1']);
+    $t->get_ok('/session')->status_is(200)->content_is('user:sri');
+    $t->get_ok('/logout')->status_is(200)->content_is('logged out');
+    $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+    $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+  };
+
+  subtest 'User session (encrypted cookie)' => sub {
+    plan skip_all => 'CryptX required!' unless Mojo::Util->CRYPTX;
+    $t->reset_session;
+    $t->app->secrets(['test1']);
+    $t->app->sessions->encrypted(1);
+    $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+    $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+    $t->get_ok('/login')->status_is(200)->content_is('logged in');
+    $t->get_ok('/session')->status_is(200)->content_is('user:sri');
+    $t->app->secrets(['test2', 'test1']);
+    $t->get_ok('/session')->status_is(200)->content_is('user:sri');
+    $t->get_ok('/logout')->status_is(200)->content_is('logged out');
+    $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+    $t->get_ok('/session')->status_is(200)->content_is('user:nobody');
+  };
+};
+
+done_testing();


### PR DESCRIPTION
SUSE Hack Week has started, so this is my first proposal for sessions with encrypted cookies. I've tried to stay as close to the mojo.js implementation as possible. To address #2200 i've also added a `Mojo::Util::generate_secret` function.

The feature is only available if [CryptX](https://metacpan.org/pod/CryptX) is installed, and needs to be enabled with `$app->sessions->encrypted(1)`.