### PR TITLE
fix_headers() now initializes Host header when needed

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -73,7 +73,7 @@ sub fix_headers {
 
   # Host
   my $url = $self->url;
-  $headers->host($url->host_port) unless $headers->host;
+  $headers->host($url->host_port // '') unless defined $headers->host;
 
   # Basic authentication
   if ((my $info = $url->userinfo) && !$headers->authorization) {

--- a/t/mojo/request.t
+++ b/t/mojo/request.t
@@ -475,6 +475,11 @@ subtest 'Parse full HTTP 1.0 request (no scheme and empty elements in path)' => 
   is $req->url,                     '//foo/bar//baz.html?foo=13', 'right URL';
   is $req->headers->content_type,   'text/plain',                 'right "Content-Type" value';
   is $req->headers->content_length, 27,                           'right "Content-Length" value';
+  is $req->headers->host,           undef,                        '"Host" value is not defined';
+
+  $req->fix_headers;
+  is $req->url->host,     undef, 'still no URL host';
+  is $req->headers->host, '',    '"Host" value is fixed';
 };
 
 subtest 'Parse full HTTP 1.0 request (behind reverse proxy)' => sub {


### PR DESCRIPTION
RFC9112 §3.2-5 says that Host is mandatory, but can be an empty value.

resolves issue #2232.