### PR TITLE
Add download methods to Mojo::UserAgent and Mojo::UserAgent::Transactor

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -1300,6 +1300,15 @@ L<Mojo::Message/"save_to">.
   my $tx = $ua->get('https://www.github.com/mojolicious/mojo/tarball/main');
   $tx->result->save_to('mojo.tar.gz');
 
+With L<Mojo::UserAgent/"download"> you can also stream file downloads directly into the target file. This allows for
+interrupted downloads to be resumed at a later time.
+
+  use Mojo::UserAgent;
+
+  # Download the latest Mojolicious tarball directly into a file
+  my $ua = Mojo::UserAgent->new(max_redirects => 5);
+  $ua->download('https://www.github.com/mojolicious/mojo/tarball/main' => '/home/sri/mojo.tar.gz');
+
 To protect you from excessively large files there is also a limit of 2GiB by default, which you can tweak with the
 attribute L<Mojo::UserAgent/"max_response_size">.
 

--- a/t/mojo/user_agent_download.t
+++ b/t/mojo/user_agent_download.t
@@ -1,0 +1,117 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+use Mojo::File qw(tempdir);
+use Mojo::UserAgent;
+use Mojolicious::Lite;
+
+# Silence
+app->log->level('trace')->unsubscribe('message');
+
+get '/test1' => sub {
+  my $c = shift;
+  $c->res->headers->accept_ranges('bytes');
+  return $c->render(data => 'CHUNK1CHUNK2CHUNK3');
+};
+
+get '/test2' => sub {
+  my $c = shift;
+  $c->res->headers->accept_ranges('bytes');
+  return $c->render(data => 'CHUNK1CHUNK2CHUNK3') if $c->req->method eq 'HEAD';
+  my $range = $c->req->headers->range;
+  return $c->write('CHUNK1')->finish unless $range;
+  return $c->write('CHUNK2')->finish if $range eq 'bytes=6-18';
+  return $c->write('CHUNK3')->finish;
+};
+
+get '/test4' => sub {
+  my $c      = shift;
+  my $chunks = [qw(CHUNK1 CHUNK2 CHUNK3 CHUNK4)];
+  $c->res->code(200);
+  $c->res->headers->content_type('text/plain');
+  my $cb = sub {
+    my $content = shift;
+    my $chunk   = shift @$chunks || '';
+    $content->write_chunk($chunk, $chunk ? __SUB__ : undef);
+  };
+  $c->res->content->$cb;
+  $c->rendered;
+};
+
+my $dir = tempdir;
+my $ua  = Mojo::UserAgent->new;
+
+subtest 'Basic file download' => sub {
+  my $file = $dir->child('test1a.txt');
+  ok $ua->download('/test1', $file), 'file downloaded';
+  ok -e $file,                       'file exists';
+  is $file->slurp, 'CHUNK1CHUNK2CHUNK3', 'right content';
+};
+
+subtest 'File already downloaded' => sub {
+  my $file = $dir->child('test1a.txt');
+  is $file->slurp, 'CHUNK1CHUNK2CHUNK3', 'right content';
+  ok $ua->download('/test1', $file), 'file downloaded';
+  is $file->slurp, 'CHUNK1CHUNK2CHUNK3', 'right content';
+};
+
+subtest 'Basic file download (non-blocking)' => sub {
+  my $file = $dir->child('test1b.txt');
+  my $result;
+  $ua->download_p('/test1', $file)->then(sub { $result = shift })->wait;
+  ok $result,  'file downloaded';
+  ok -e $file, 'file exists';
+  is $file->slurp, 'CHUNK1CHUNK2CHUNK3', 'right content';
+};
+
+subtest 'Exsiting file is larger' => sub {
+  my $file = $dir->child('test1c.txt')->spew('CHUNK1CHUNK2CHUNK3CHUNK4');
+  eval { $ua->download('/test1', $file) };
+  like $@, qr/Download error: File size mismatch/, 'right error';
+};
+
+subtest 'Resumed file download' => sub {
+  my $file = $dir->child('test2a.txt');
+  ok !$ua->download('/test2', $file), 'file partially downloaded';
+  ok !$ua->download('/test2', $file), 'file continued';
+  ok $ua->download('/test2',  $file), 'file downloaded';
+  ok -e $file, 'file exists';
+  is $file->slurp, 'CHUNK1CHUNK2CHUNK3', 'right content';
+};
+
+subtest 'Missing file' => sub {
+  my $file = $dir->child('test3a.txt');
+  eval { $ua->download('/test3', $file) };
+  like $@, qr/404 response: Not Found/, 'file not found';
+};
+
+subtest 'Missing file (non-blocking)' => sub {
+  my $file = $dir->child('test3b.txt');
+  my $err;
+  $ua->download_p('/test3', $file)->catch(sub { $err = shift })->wait;
+  like $err, qr/404 response: Not Found/, 'file not found';
+};
+
+subtest 'File of unknown size' => sub {
+  my $file = $dir->child('test4a.txt')->spew('C');
+  eval { $ua->download('/test4', $file) };
+  like $@, qr/Download error: Unknown file size/, 'right error';
+};
+
+subtest 'File of unknown size (non-blocking)' => sub {
+  my $file = $dir->child('test4b.txt')->spew('C');
+  my $err;
+  $ua->download_p('/test4', $file)->catch(sub { $err = shift })->wait;
+  like $err, qr/Download error: Unknown file size/, 'right error';
+};
+
+subtest 'File of unknown size downloaded' => sub {
+  my $file = $dir->child('test4c.txt');
+  ok $ua->download('/test4', $file), 'file downloaded';
+  ok -e $file,                       'file exists';
+  is $file->slurp, 'CHUNK1CHUNK2CHUNK3CHUNK4', 'right content';
+};
+
+done_testing();


### PR DESCRIPTION
This is something that has come up for me at work. While trying to explain how to build a client for resumable large file downloads, i realized how tricky doing it right actually is. We already support range requests on the server-side in Mojolicious, so from a consistency point of view the feature would probably fit in.

The `download` and `download_p`methods in `Mojo::UserAgent`  are intentionally very bare-bones. But the option argument (that currently only allows for headers to be set) leaves room for future additions. And the `Mojo::UserAgent::Transactor` method makes more advanced use cases possible.

An argument against the feature might be that it broadens the scope of `Mojo::UserAgent` too much, but i'm ok with that.