### PR TITLE
fix path merge with path object

### DIFF
--- a/lib/Mojo/Path.pm
+++ b/lib/Mojo/Path.pm
@@ -41,11 +41,18 @@ sub merge {
   my ($self, $path) = @_;
 
   # Replace
-  return $self->parse($path) if $path =~ m!^/!;
+  if (ref $path) {
+     if ($path->leading_slash) {
+       @{$self->parts} = @{$path->parts};
+       $self->trailing_slash($path->trailing_slash);
+       return $self->leading_slash($path->leading_slash);
+     }
+  }
+  elsif ($path =~ m!^/!) { return $self->parse($path) }
 
   # Merge
-  pop @{$self->parts} unless $self->trailing_slash;
-  $path = $self->new($path);
+  pop @{$self->parts}       unless $self->trailing_slash;
+  $path = $self->new($path) unless ref $path;
   push @{$self->parts}, @{$path->parts};
   return $self->trailing_slash($path->trailing_slash);
 }


### PR DESCRIPTION
`Mojo::Path`'s support of merging objects of class `Mojo::Path` (vs. strings) until now is implemented by object stringification followed by a reparsing using a default `Mojo::Path` object.

This approach works fine for merged objects with a character set of UTF-8 as this is also the default character set for `Mojo::Path` objects. It can fail however for other character sets.

Instead copy the path parts and the slash attributes from the source to the target object.

The missing tests for merging objects are included using the ISO-8859-15 character set. That way those tests can also function as regression tests. The ISO-8859-15 character set deviates from ISO-8859-1 and in turn from Unicode in that it reassigns code points of less common symbols (code point A4 which is the currency sign in ISO-8859-1/Unicode is replaced by the Euro currency sign e.g.).

Background:
`Mojo::URL::to_abs()` e.g. passes path objects to `Mojo::Path::merge()` in order to merge the path onto the base path today. And can fail in the way outlined above if the path object is not configured to be UTF-8.