### PR TITLE
convert t/mojolicious/log_lite_app.t to use subtests

### DIFF
--- a/t/mojolicious/log_lite_app.t
+++ b/t/mojolicious/log_lite_app.t
@@ -23,33 +23,37 @@ get '/simple' => sub {
 
 my $t = Test::Mojo->new;
 
-# Simple log messages with and without context
-my $buffer = '';
-open my $handle, '>', \$buffer;
-$t->app->log(Mojo::Log->new(handle => $handle));
-$t->get_ok('/simple')->status_is(200)->content_is('Simple!');
-like $buffer, qr/First.*Second.*Third.*No context!.*Fourth.*Fifth/s,    'right order';
-like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[17a60115\] First!/,         'message with request id';
-like $buffer, qr/\[.+\] \[\d+\] \[info\] \[17a60115\] Second! Third!/s, 'message with request id';
-like $buffer, qr/\[.+\] \[\d+\] \[debug\] No context!/,                 'message without request id';
-like $buffer, qr/\[.+\] \[\d+\] \[warn\] \[17a60115\] Fourth! Fifth!/s, 'message with request id';
+subtest 'Simple log messages with and without context' => sub {
+  my $buffer = '';
+  open my $handle, '>', \$buffer;
+  $t->app->log(Mojo::Log->new(handle => $handle));
+  $t->get_ok('/simple')->status_is(200)->content_is('Simple!');
+  like $buffer, qr/First.*Second.*Third.*No context!.*Fourth.*Fifth/s,    'right order';
+  like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[17a60115\] First!/,         'message with request id';
+  like $buffer, qr/\[.+\] \[\d+\] \[info\] \[17a60115\] Second! Third!/s, 'message with request id';
+  like $buffer, qr/\[.+\] \[\d+\] \[debug\] No context!/,                 'message without request id';
+  like $buffer, qr/\[.+\] \[\d+\] \[warn\] \[17a60115\] Fourth! Fifth!/s, 'message with request id';
+};
 
-# Concurrent requests
-$buffer = '';
-my $first = $t->app->build_controller;
-$first->req->request_id('123-first');
-my $second = $t->app->build_controller;
-$second->req->request_id('123-second');
-$first->log->debug('First!');
-$second->log->debug('Second!');
-$first->log->debug('Third!');
-$second->log->debug('Fourth!');
-$t->app->log->debug('Fifth!');
-like $buffer, qr/First.*Second.*Third.*Fourth.*Fifth/s,            'right order';
-like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[123-first\] First!/,   'message with request id';
-like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[123-second\] Second!/, 'message with request id';
-like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[123-first\] Third!/,   'message with request id';
-like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[123-second\] Fourth!/, 'message with request id';
-like $buffer, qr/\[.+\] \[\d+\] \[debug\] Fifth!/,                 'message without request id';
+subtest 'Concurrent requests' => sub {
+  my $buffer = '';
+  open my $handle, '>', \$buffer;
+  $t->app->log(Mojo::Log->new(handle => $handle));
+  my $first = $t->app->build_controller;
+  $first->req->request_id('123-first');
+  my $second = $t->app->build_controller;
+  $second->req->request_id('123-second');
+  $first->log->debug('First!');
+  $second->log->debug('Second!');
+  $first->log->debug('Third!');
+  $second->log->debug('Fourth!');
+  $t->app->log->debug('Fifth!');
+  like $buffer, qr/First.*Second.*Third.*Fourth.*Fifth/s,            'right order';
+  like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[123-first\] First!/,   'message with request id';
+  like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[123-second\] Second!/, 'message with request id';
+  like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[123-first\] Third!/,   'message with request id';
+  like $buffer, qr/\[.+\] \[\d+\] \[debug\] \[123-second\] Fourth!/, 'message with request id';
+  like $buffer, qr/\[.+\] \[\d+\] \[debug\] Fifth!/,                 'message without request id';
+};
 
 done_testing();


### PR DESCRIPTION
### Summary
Convert t/mojolicious/log_lite_app.t to use subtests

### Motivation
This is part of the ongoing effort to address #1520.
Converting this file to use subtests improves test isolation and readability.

### References
https://github.com/mojolicious/mojo/issues/1520
