### PR TITLE
Changing the status code of an exception isn't possible

### DIFF
--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -518,11 +518,7 @@ L<Mojolicious::Plugin::DefaultHelpers/"reply-E<gt>not_found">.
 
   app->start;
 
-To change the HTTP status code of the exception, you can use L<Mojolicious::Controller/"rendered">.
-
-  return $c->reply->exception('Division by zero!')->rendered(400) if $divisor == 0;
-
-You can also change the templates of those pages, since you most likely want to show your users something more closely
+You can change the templates of those pages, since you most likely want to show your users something more closely
 related to your application in production. The renderer will always try to find C<exception.$mode.$format.*> or
 C<not_found.$mode.$format.*> before falling back to the built-in default templates.
 


### PR DESCRIPTION
### Summary
Remove the paragraph stating that the status code of a `reply->exception` can be changed. Amend the "Also" at the beginning of the next paragraph.

### Motivation
Bashed my head too many times trying to understand why `$self->reply->exception->rendered(400)` was returning an HTTP 500 status code. It isn't possible.

### References
IRC chat.

```
16:56 < Lucas_> question: https://docs.mojolicious.org/Mojolicious/Guides/Rendering#Rendering-exception-and-not_found-pages says that I can change the status code of an 
    exception with ->rendered, but that isn't working. Tried both Mojolicious 9.37 and 9.39
16:56 < Lucas_> there is also an issue, https://github.com/mojolicious/mojo/issues/1014 , which says it won't be supported
16:57 < Lucas_> so, which one is it?
17:26 < kraih> The docs are wrong
```
