### PR TITLE
Refuse to set signed or encrypted cookies with an insecure default secret

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -59,6 +59,10 @@ sub encrypted_cookie {
   my $app     = $self->app;
   my $secret  = $app->secrets->[0];
   my $moniker = $app->moniker;
+
+  Carp::croak 'Your secret passphrase must be changed to set encrypted cookies (see FAQ for more)'
+    if !$ENV{MOJO_ALLOW_INSECURE_SECRET} and (!length $secret or $secret eq $moniker);
+
   return $self->cookie($name, Mojo::Util::encrypt_cookie($value, $secret, $moniker), $options);
 }
 
@@ -242,12 +246,24 @@ sub session {
   my $stash = $self->stash;
   $self->app->sessions->load($self) unless exists $stash->{'mojo.active_session'};
 
-  # Hash
   my $session = $stash->{'mojo.session'} //= {};
+
+  # Require changed secret if session data will be set
+  my $set_operation = !!(@_ > 1 || ref $_[0]);
+  if (!$ENV{MOJO_ALLOW_INSECURE_SECRET} and (keys %$session or $set_operation)) {
+    my $app     = $self->app;
+    my $secret  = $app->secrets->[0];
+    my $moniker = $app->moniker;
+
+    Carp::croak 'Your secret passphrase must be changed to set session data (see FAQ for more)'
+      if !length $secret or $secret eq $moniker;
+  }
+
+  # Hash
   return $session unless @_;
 
   # Get
-  return $session->{$_[0]} unless @_ > 1 || ref $_[0];
+  return $session->{$_[0]} unless $set_operation;
 
   # Set
   my $values = ref $_[0] ? $_[0] : {@_};
@@ -262,8 +278,15 @@ sub signed_cookie {
   # Request cookie
   return $self->every_signed_cookie($name)->[-1] unless defined $value;
 
+  my $app     = $self->app;
+  my $secret  = $app->secrets->[0];
+  my $moniker = $app->moniker;
+
+  Carp::croak 'Your secret passphrase must be changed to set signed cookies (see FAQ for more)'
+    if !$ENV{MOJO_ALLOW_INSECURE_SECRET} and (!length $secret or $secret eq $moniker);
+
   # Response cookie
-  my $sum = Digest::SHA::hmac_sha256_hex("$name=$value", $self->app->secrets->[0]);
+  my $sum = Digest::SHA::hmac_sha256_hex("$name=$value", $secret);
   return $self->cookie($name, "$value--$sum", $options);
 }
 
@@ -442,6 +465,9 @@ Access encrypted request cookie values and create new encrypted response cookies
 the same name, and you want to access more than just the last one, you can use L</"every_encrypted_cookie">. Cookies
 are encrypted with ChaCha20-Poly1305, to prevent tampering, and the ones failing decryption will be automatically
 discarded. Note that this method is B<EXPERIMENTAL> and might change without warning!
+
+The L<application secrets|Mojolicious/secrets> B<MUST> be changed from the default to a secure value to set
+encrypted cookies. This requirement can be bypassed by setting the C<MOJO_ALLOW_INSECURE_SECRET> environment variable.
 
 =head2 every_cookie
 
@@ -745,6 +771,10 @@ Persistent data storage for the next few requests, all session data gets seriali
 Base64 encoded in HMAC-SHA256 signed cookies, to prevent tampering. Note that cookies usually have a C<4096> byte
 (4KiB) limit, depending on browser.
 
+The L<application secrets|Mojolicious/secrets> B<MUST> be changed from the default to a secure value to set
+session data in a signed or encrypted cookie. This requirement can be bypassed by setting the
+C<MOJO_ALLOW_INSECURE_SECRET> environment variable.
+
   # Manipulate session
   $c->session->{foo} = 'bar';
   my $foo = $c->session->{foo};
@@ -769,6 +799,9 @@ Access signed request cookie values and create new signed response cookies. If t
 same name, and you want to access more than just the last one, you can use L</"every_signed_cookie">. Cookies are
 cryptographically signed with HMAC-SHA256, to prevent tampering, and the ones failing signature verification will be
 automatically discarded.
+
+The L<application secrets|Mojolicious/secrets> B<MUST> be changed from the default to a secure value to set
+signed cookies. This requirement can be bypassed by setting the C<MOJO_ALLOW_INSECURE_SECRET> environment variable.
 
 =head2 stash
 

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -17,6 +17,7 @@ use Mojo::Date;
 use Mojo::File qw(path);
 use Mojo::Home;
 use Mojo::IOLoop;
+use Mojo::Util qw(generate_secret);
 use Mojolicious;
 use Mojolicious::Controller;
 
@@ -658,6 +659,7 @@ subtest 'Override deployment plugins' => sub {
 };
 
 $t = Test::Mojo->new('MojoliciousTest');
+$t->app->secrets([generate_secret]);
 
 # MojoliciousTestController::Foo::plugin_upper_case
 $t->get_ok('/plugin/upper_case')

--- a/t/mojolicious/embedded_lite_app.t
+++ b/t/mojolicious/embedded_lite_app.t
@@ -15,6 +15,9 @@ use Test::Mojo;
 
 package TestApp;
 use Mojolicious::Lite;
+use Mojo::Util qw(generate_secret);
+
+app->secrets([generate_secret]);
 
 get '/hello' => sub {
   my $c       = shift;

--- a/t/mojolicious/longpolling_lite_app.t
+++ b/t/mojolicious/longpolling_lite_app.t
@@ -5,6 +5,7 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Test::Mojo;
 use Test::More;
 use Mojo::IOLoop;
+use Mojo::Util qw(generate_secret);
 use Mojolicious::Lite;
 
 package MyTestApp::Controller;
@@ -13,6 +14,8 @@ use Mojo::Base 'Mojolicious::Controller';
 sub DESTROY { shift->stash->{destroyed} = 1 }
 
 package main;
+
+app->secrets([generate_secret]);
 
 app->controller_class('MyTestApp::Controller');
 

--- a/t/mojolicious/rebased_lite_app.t
+++ b/t/mojolicious/rebased_lite_app.t
@@ -5,7 +5,10 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Test::Mojo;
 use Test::More;
 use Mojo::URL;
+use Mojo::Util qw(generate_secret);
 use Mojolicious::Lite;
+
+app->secrets([generate_secret]);
 
 # Rebase hook
 app->hook(

--- a/t/mojolicious/session_lite_app.t
+++ b/t/mojolicious/session_lite_app.t
@@ -91,4 +91,21 @@ subtest 'Rotating secrets' => sub {
   };
 };
 
+subtest 'Insecure secret' => sub {
+  subtest 'Insecure secret (signed cookie)' => sub {
+    $t->reset_session;
+    $t->app->secrets([app->moniker]);
+    $t->app->sessions->encrypted(0);
+    $t->get_ok('/login')->status_is(500);
+  };
+
+  subtest 'Insecure secret (encrypted cookie)' => sub {
+    plan skip_all => 'CryptX required!' unless Mojo::Util->CRYPTX;
+    $t->reset_session;
+    $t->app->secrets([app->moniker]);
+    $t->app->sessions->encrypted(1);
+    $t->get_ok('/login')->status_is(500);
+  };
+};
+
 done_testing();

--- a/t/mojolicious/validation_lite_app.t
+++ b/t/mojolicious/validation_lite_app.t
@@ -6,7 +6,10 @@ use Test::Mojo;
 use Test::More;
 use Mojo::Asset::Memory;
 use Mojo::Upload;
+use Mojo::Util qw(generate_secret);
 use Mojolicious::Lite;
+
+app->secrets([generate_secret]);
 
 # Custom check
 app->validator->add_check(two => sub { length $_[2] == 2 ? undef : "e:$_[1]" });


### PR DESCRIPTION
### Summary
Rough attempt at taking the approach of dying if encrypted or signed cookies are requested to be set but the application secret is still set to the default of the application moniker.

This is fairly straightforward to do in the signed_cookie and encrypted_cookie methods, but this also requires a check in the session method, because setting the session cookie occurs too late to error out sensibly. I'm not satisfied with this check in the session method, because: there still may be instances where this session method is called while a response is already being rendered; and session data can be set by assigning to `$c->session->{foo}` and there's no way to know that will happen at this juncture.

This also affects use of features using the session implicitly, such as the flash and csrf_token default helpers.

### Motivation
The risk of insecure secrets being used in applications using signed or encrypted cookies is not sufficiently mitigated by the annoying warning in the logs. But we don't want to cause applications to fail if they are not using these features.

### References
Implements a part of https://github.com/mojolicious/mojo/pull/2200 by refusing to set signed or encrypted cookies by default unless the secret has been changed from the default.
