### PR TITLE
support setting query parameters to undef

### DIFF
--- a/lib/Mojo/Parameters.pm
+++ b/lib/Mojo/Parameters.pm
@@ -110,7 +110,7 @@ sub parse {
   return $self->append(@_) if @_ > 1;
 
   # String
-  $self->{string} = shift;
+  $self->{string} = shift // '';
   return $self;
 }
 

--- a/t/mojo/parameters.t
+++ b/t/mojo/parameters.t
@@ -178,7 +178,12 @@ subtest 'Unicode' => sub {
 subtest 'Reparse' => sub {
   my $params = Mojo::Parameters->new('foo=bar&baz=23');
   $params->parse('foo=bar&baz=23');
-  is "$params", 'foo=bar&baz=23', 'right result';
+  is "$params", 'foo=bar&baz=23', 'right string result after assigning new string';
+  is_deeply $params->pairs, ['foo', 'bar', 'baz', '23'], 'right pairs after assigning new string';
+
+  $params->parse(undef);
+  is "$params", '', 'right result after assigning undef string';
+  is_deeply $params->pairs, [], 'right pairs after assigning undef string';
 };
 
 subtest 'Replace' => sub {


### PR DESCRIPTION

### Summary

Treats `$query->parse(undef)` the same as `$query->parse('')`

### Motivation

This allows for $uri->query(undef) to properly clear the query string, which previously did not happen if the parameters object had already been parsed into `pairs`.

This usage might be seen with `$uri->query(undef)->fragment(undef)` to strip off all trailing components after the path.

