### PR TITLE
Add support for Server-Sent Events

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 
-9.41  2025-05-13
+9.41  2025-07-03
+  - Added EXPERIMENTAL support for Server-Sent Events.
+  - Added EXPERIMENTAL module Mojo::SSE.
+  - Added EXPERIMENTAL sse attribute to Test::Mojo.
+  - Added EXPERIMENTAL get_sse_ok, post_sse_ok, sse_finish_ok, sse_finished_ok, sse_ok, sse_id_is, sse_id_isnt,
+    sse_text_is, sse_text_isnt, sse_text_like, sse_text_unlike, sse_type_is and sse_type_isnt methods to Test::Mojo.
+  - Added EXPERIMENTAL is_sse and write_sse methods to Mojo::Content.
+  - Added EXPERIMENTAL write_sse method to Mojolicious::Controller.
+  - Added EXPERIMENTAL sse event to Mojo::Content.
 
 9.40  2025-05-12
   - Added EXPERIMENTAL support for resumable file downloads.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
   * A powerful **web development toolkit**, that you can use for all kinds of applications, independently of the web
     framework.
     * Full stack HTTP and WebSocket client/server implementation with IPv6, TLS, SNI, IDNA, HTTP/SOCKS5 proxy, UNIX
-      domain socket, Comet (long polling), Promises/A+, async/await, keep-alive, connection pooling, timeout, cookie,
-      multipart, and gzip compression support.
+      domain socket, Comet (long polling), Server-Sent Events (SSE), Promises/A+, async/await, keep-alive, connection
+      pooling, timeout, cookie, multipart, and gzip compression support.
     * Built-in non-blocking I/O web server, supporting multiple event loops as well as optional pre-forking and hot
       deployment, perfect for building highly scalable web services.
     * JSON and HTML/XML parser with CSS selector support.

--- a/examples/responses.pl
+++ b/examples/responses.pl
@@ -27,4 +27,10 @@ get '/res5' => sub {
   die 'Hello World!';
 };
 
+get '/res6' => sub ($c) {
+  $c->write_sse({text => 'hello'});
+  $c->write_sse({text => 'world'});
+  $c->finish;
+};
+
 app->start;

--- a/lib/Mojo/SSE.pm
+++ b/lib/Mojo/SSE.pm
@@ -1,0 +1,91 @@
+package Mojo::SSE;
+use Mojo::Base -strict;
+
+use Carp       qw(croak);
+use Exporter   qw(import);
+use Mojo::Util qw(decode encode);
+
+our @EXPORT_OK = (qw(build_event parse_event));
+
+my $SPLIT_RE = qr/(?:\x0d\x0a|(?<!\x0d)\x0a|\x0d(?!\x0a))/;
+
+sub build_event {
+  my $event = shift;
+
+  my @data    = defined $event->{text}    ? split($SPLIT_RE, $event->{text})    : ();
+  my @comment = defined $event->{comment} ? split($SPLIT_RE, $event->{comment}) : ();
+
+  my @parts;
+  if (@comment) { push @parts, ": $_" for @comment }
+  else {
+    push @parts, "event: $event->{type}" if defined $event->{type};
+    push @parts, "data: $_" for @data;
+    push @parts, "id: $event->{id}" if defined $event->{id};
+  }
+
+  return encode('UTF-8', join("\x0d\x0a", @parts, '', ''));
+}
+
+sub parse_event {
+  my $buffer = shift;
+  my $event  = {id => undef, type => 'message', text => ''};
+
+  while ($$buffer =~ s/^(.*?)(?:(?:\x0d\x0a|(?<!\x0d)\x0a|\x0d(?!\x0a)){2})//s) {
+
+    # Skip lines with encoding errors
+    next unless defined(my $lines = decode 'UTF-8', $1);
+
+    # Skip comments
+    next if $lines =~ /^\s*:/;
+
+    my $first = 0;
+    for my $line (split $SPLIT_RE, $lines) {
+      if    ($line =~ /^event(?::\s*(\S.*))?$/) { $event->{type} = $1 // 'message' }
+      elsif ($line =~ /^data(?::\s*(.*))?$/)    { $event->{text} .= ($first++ ? "\n" : '') . ($1 // '') }
+      elsif ($line =~ /^id(?::\s*(.*))?$/)      { $event->{id} = $1 }
+    }
+
+    return $event;
+  }
+
+  return undef;
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::SSE - Server-Sent Events
+
+=head1 SYNOPSIS
+
+  use Mojo::SSE qw(build_event parse_event);
+
+=head1 DESCRIPTION
+
+L<Mojo::SSE> implements the Server-Sent Events protocol. Note that this module is B<EXPERIMENTAL> and may change
+without warning!
+
+=head1 FUNCTIONS
+
+L<Mojo::SSE> implements the following functions, which can be imported individually.
+
+=head2 build_event
+
+  my $bytes = build_event $event, $chars;
+
+Build Server-Sent Event.
+
+=head2 parse_event
+
+  my $event = parse_event \$bytes;
+
+Parse Server-Sent Event. Returns C<undef> if no complete event was found.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<https://mojolicious.org>.
+
+=cut

--- a/lib/Mojo/UserAgent/Transactor.pm
+++ b/lib/Mojo/UserAgent/Transactor.pm
@@ -144,9 +144,11 @@ sub redirect {
     $headers->remove($_) for grep {/^content-/i} @{$headers->names};
   }
 
-  $new->res->content->auto_decompress(0) unless $self->compressed;
+  my $content = $new->res->content;
+  $content->auto_decompress(0) unless $self->compressed;
   my $headers = $new->req->url($location)->headers;
   $headers->remove($_) for qw(Authorization Cookie Host Referer);
+  if ($res->content->has_subscribers('sse')) { $content->on(sse => $_) for @{$res->content->subscribers('sse')} }
 
   return $new->previous($old);
 }

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -998,12 +998,12 @@ result in much better performance, but also increases memory usage by up to 300K
 
 You can also use L<Mojo::Transaction::WebSocket/"with_protocols"> to negotiate a subprotocol.
 
-=head2 EventSource web service
+=head2 Server-Sent Events web service
 
-EventSource is a special form of long polling where you can use L<Mojolicious::Controller/"write"> to directly send DOM
-events from servers to clients. It is uni-directional, that means you will have to use Ajax requests for sending data
-from clients to servers, the advantage however is low infrastructure requirements, since it reuses the HTTP protocol
-for transport.
+Server-Sent Events (SSE) is a special form of long polling where you can use L<Mojolicious::Controller/"write_sse"> to
+directly send DOM events from servers to clients. It is uni-directional, that means you will have to use Ajax requests
+for sending data from clients to servers, the advantage however is low infrastructure requirements, since it reuses the
+HTTP protocol for transport.
 
   use Mojolicious::Lite -signatures;
 
@@ -1017,12 +1017,11 @@ for transport.
     $c->inactivity_timeout(300);
 
     # Change content type and finalize response headers
-    $c->res->headers->content_type('text/event-stream');
-    $c->write;
+    $c->write_sse;
 
     # Subscribe to "message" event and forward "log" events to browser
     my $cb = $c->app->log->on(message => sub ($log, $level, @lines) {
-      $c->write("event:log\ndata: [$level] @lines\n\n");
+      $c->write_sse({type => 'log', text => "[$level] @lines"});
     });
 
     # Unsubscribe from "message" event again once we are done

--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -25,6 +25,7 @@ has mapping => sub {
     pdf      => ['application/pdf'],
     png      => ['image/png'],
     rss      => ['application/rss+xml'],
+    sse      => ['text/event-stream'],
     svg      => ['image/svg+xml'],
     ttf      => ['font/ttf'],
     txt      => ['text/plain;charset=UTF-8'],
@@ -114,6 +115,7 @@ L<Mojolicious::Types> manages MIME types for L<Mojolicious>.
   pdf      -> application/pdf
   png      -> image/png
   rss      -> application/rss+xml
+  sse      -> text/event-stream
   svg      -> image/svg+xml
   ttf      -> font/ttf
   txt      -> text/plain;charset=UTF-8

--- a/t/mojo/sse.t
+++ b/t/mojo/sse.t
@@ -1,0 +1,162 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Mojo::SSE  qw(build_event parse_event);
+use Mojo::Util qw(encode);
+
+subtest 'Simple event roundtrip' => sub {
+  my $bytes = build_event {type => 'foo', text => 'bar', id => 23};
+  is $bytes, "event: foo\x0d\x0adata: bar\x0d\x0aid: 23\x0d\x0a\x0d\x0a", 'right event';
+  my $event = parse_event \(my $dummy = $bytes);
+  is $event->{type}, 'foo', 'right event type';
+  is $event->{text}, 'bar', 'right event text';
+  is $event->{id},   23,    'right event id';
+};
+
+subtest 'No id and type' => sub {
+  my $bytes = build_event {text => 'bar'};
+  is $bytes, "data: bar\x0d\x0a\x0d\x0a", 'right event';
+  my $event = parse_event \(my $dummy = $bytes);
+  is $event->{type}, 'message', 'default event type';
+  is $event->{text}, 'bar',     'right event text';
+  is $event->{id},   undef,     'no event id';
+};
+
+subtest 'Unicode roundtrip' => sub {
+  my $bytes = build_event {type => 'fo♥o', text => 'I ♥ Mojolicious', id => '1♥3'};
+  my $event = parse_event \(my $dummy = $bytes);
+  is $event->{type}, 'fo♥o',            'right event type';
+  is $event->{text}, 'I ♥ Mojolicious', 'right event text';
+  is $event->{id},   '1♥3',             'right event id';
+};
+
+subtest 'Event with multiple data sections' => sub {
+  my $event = parse_event \(my $dummy = "data: YHOO\x0d\x0adata: +2\x0d\x0adata: 10\x0d\x0a\x0d\x0a");
+  is $event->{type}, 'message',      'right event type';
+  is $event->{text}, "YHOO\n+2\n10", 'right event text';
+  is $event->{id},   undef,          'no event id';
+};
+
+subtest 'Multiple lines' => sub {
+  my $buffer = "data: This is the first message.\x0a\x0adata: This is the second message, it\x0a"
+    . "data: has two lines.\x0a\x0adata: This is the third message.\x0a\x0a";
+  my $event1 = parse_event \$buffer;
+  is $event1->{type}, 'message',                    'right event type';
+  is $event1->{text}, 'This is the first message.', 'right event text';
+  is $event1->{id},   undef,                        'no event id';
+  my $event2 = parse_event \$buffer;
+  is $event2->{type}, 'message',                                        'right event type';
+  is $event2->{text}, "This is the second message, it\nhas two lines.", 'right event text';
+  is $event2->{id},   undef,                                            'no event id';
+  my $event3 = parse_event \$buffer;
+  is $event3->{type},       'message',                    'right event type';
+  is $event3->{text},       'This is the third message.', 'right event text';
+  is $event3->{id},         undef,                        'no event id';
+  is parse_event(\$buffer), undef,                        'no more events';
+};
+
+subtest 'Event types' => sub {
+  my $buffer
+    = "event: add\x0ddata: 73857293\x0d\x0devent: remove\x0ddata: 2153\x0d\x0devent: add\x0ddata: 113411\x0d\x0d";
+  my $event1 = parse_event \$buffer;
+  is $event1->{type}, 'add',    'right event type';
+  is $event1->{text}, 73857293, 'right event text';
+  is $event1->{id},   undef,    'no event id';
+  my $event2 = parse_event \$buffer;
+  is $event2->{type}, 'remove', 'right event type';
+  is $event2->{text}, 2153,     'right event text';
+  is $event2->{id},   undef,    'no event id';
+  my $event3 = parse_event \$buffer;
+  is $event3->{type},       'add',  'right event type';
+  is $event3->{text},       113411, 'right event text';
+  is $event3->{id},         undef,  'no event id';
+  is parse_event(\$buffer), undef,  'no more events';
+};
+
+subtest 'Insignificant whitespace' => sub {
+  my $buffer = "data:test\x0d\x0a\x0d\x0adata: test\x0d\x0a\x0d\x0a";
+  my $event1 = parse_event \$buffer;
+  is $event1->{type}, 'message', 'right event type';
+  is $event1->{text}, 'test',    'right event text';
+  is $event1->{id},   undef,     'no event id';
+  my $event2 = parse_event \$buffer;
+  is $event2->{type},       'message', 'right event type';
+  is $event2->{text},       'test',    'right event text';
+  is $event2->{id},         undef,     'no event id';
+  is parse_event(\$buffer), undef,     'no more events';
+};
+
+subtest 'Events with comment' => sub {
+  my $buffer
+    = ": test stream\x0a\x0ddata: first event\x0did: 1\x0d\x0ddata:second event\x0did\x0d\x0ddata:  third event\x0a\x0a";
+  my $event1 = parse_event \$buffer;
+  is $event1->{type}, 'message',     'right event type';
+  is $event1->{text}, 'first event', 'right event text';
+  is $event1->{id},   1,             'right event id';
+  my $event2 = parse_event \$buffer;
+  is $event2->{type}, 'message',      'right event type';
+  is $event2->{text}, 'second event', 'right event text';
+  is $event2->{id},   undef,          'no event id';
+  my $event3 = parse_event \$buffer;
+  is $event3->{type},       'message',     'right event type';
+  is $event3->{text},       'third event', 'right event text';
+  is $event3->{id},         undef,         'no event id';
+  is parse_event(\$buffer), undef,         'no more events';
+};
+
+subtest 'Lots of data' => sub {
+  my $buffer = "data\x0a\x0adata\x0adata\x0a\x0adata:\x0a\x0a";
+  my $event1 = parse_event \$buffer;
+  is $event1->{type}, 'message', 'right event type';
+  is $event1->{text}, '',        'right event text';
+  is $event1->{id},   undef,     'no event id';
+  my $event2 = parse_event \$buffer;
+  is $event2->{type}, 'message', 'right event type';
+  is $event2->{text}, "\n",      'right event text';
+  is $event2->{id},   undef,     'no event id';
+  my $event3 = parse_event \$buffer;
+  is $event3->{type},       'message', 'right event type';
+  is $event3->{text},       '',        'right event text';
+  is $event3->{id},         undef,     'no event id';
+  is parse_event(\$buffer), undef,     'no more events';
+};
+
+subtest 'Comments' => sub {
+  my $buffer = build_event {comment => 'This is a comment'};
+  is $buffer,               ": This is a comment\x0d\x0a\x0d\x0a", 'right event';
+  is parse_event(\$buffer), undef,                                 'no event';
+  is $buffer,               '',                                    'buffer is empty';
+
+  $buffer = build_event {comment => "This will be\x0atwo comments"};
+  is $buffer,               ": This will be\x0d\x0a: two comments\x0d\x0a\x0d\x0a", 'right event';
+  is parse_event(\$buffer), undef,                                                  'no event';
+  is $buffer,               '',                                                     'buffer is empty';
+};
+
+subtest 'Unallowed characters' => sub {
+  my $buffer = build_event {type => 'foo', text => "bar\x0abaz"};
+  is $buffer, "event: foo\x0d\x0adata: bar\x0d\x0adata: baz\x0d\x0a\x0d\x0a", 'right event';
+  my $event = parse_event \$buffer;
+  is $event->{type}, 'foo',      'right event type';
+  is $event->{text}, "bar\nbaz", 'right event text';
+  is $event->{id},   undef,      'no event id';
+  is $buffer,        '',         'buffer is empty';
+
+  $buffer = build_event {type => 'foo', text => "bar\x0dbaz"};
+  is $buffer, "event: foo\x0d\x0adata: bar\x0d\x0adata: baz\x0d\x0a\x0d\x0a", 'right event';
+  $event = parse_event \$buffer;
+  is $event->{type}, 'foo',      'right event type';
+  is $event->{text}, "bar\nbaz", 'right event text';
+  is $event->{id},   undef,      'no event id';
+  is $buffer,        '',         'buffer is empty';
+
+  $buffer = build_event {type => 'foo', text => "bar\x0d\x0abaz"};
+  is $buffer, "event: foo\x0d\x0adata: bar\x0d\x0adata: baz\x0d\x0a\x0d\x0a", 'right event';
+  $event = parse_event \$buffer;
+  is $event->{type}, 'foo',      'right event type';
+  is $event->{text}, "bar\nbaz", 'right event text';
+  is $event->{id},   undef,      'no event id';
+  is $buffer,        '',         'buffer is empty';
+};
+
+done_testing();

--- a/t/mojolicious/sse_lite_app.t
+++ b/t/mojolicious/sse_lite_app.t
@@ -1,0 +1,90 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::Mojo;
+use Test::More;
+use Mojolicious::Lite;
+
+get '/events' => sub {
+  my $c = shift;
+  $c->write_sse({text => 'One', id => 24});
+  $c->write_sse({text => 'Two'});
+  $c->finish;
+};
+
+post '/delayed' => sub {
+  my $c = shift;
+  $c->write_sse({type => 'test', text => 'One'});
+  Mojo::IOLoop->timer(
+    1 => sub {
+      $c->write_sse(
+        {type => 'test', text => 'Two'} => sub {
+          my $c = shift;
+          $c->finish;
+        }
+      );
+    }
+  );
+};
+
+get '/infinite' => sub {
+  my $c = shift;
+  $c->write_sse;
+  my $id = Mojo::IOLoop->recurring(
+    0.1 => sub {
+      $c->write_sse({type => 'time', text => time});
+    }
+  );
+  $c->tx->on(finish => sub { Mojo::IOLoop->remove($id) });
+};
+
+get '/redirect' => sub {
+  my $c = shift;
+  $c->redirect_to('/infinite');
+};
+
+my $t = Test::Mojo->new;
+$t->ua->max_redirects(10);
+
+subtest 'Basic SSE connection' => sub {
+  $t->get_sse_ok('/events')->status_is(200)->content_type_is('text/event-stream')->sse_ok->sse_type_is('message')
+    ->sse_text_is('One')
+    ->sse_text_isnt('Two')
+    ->sse_id_is(24)
+    ->sse_id_isnt(25)
+    ->sse_ok->sse_type_is('message')
+    ->sse_type_isnt('foo')
+    ->sse_text_is('Two')
+    ->sse_finished_ok;
+  $t->get_sse_ok('/events')->status_is(200)->sse_ok->sse_type_is('message')
+    ->sse_text_is('One')
+    ->sse_ok->sse_type_is('message')->sse_text_is('Two')->sse_finished_ok;
+};
+
+subtest 'Delayed events' => sub {
+  $t->post_sse_ok('/delayed')->status_is(200)->sse_ok->sse_type_is('test')
+    ->sse_text_is('One')
+    ->sse_ok->sse_type_is('test')->sse_text_is('Two')->sse_finished_ok;
+};
+
+subtest 'Infinite stream of events' => sub {
+  $t->get_sse_ok('/infinite')->status_is(200)->sse_ok->sse_type_is('time')
+    ->sse_text_like(qr/\d+/)
+    ->sse_text_unlike(qr/test/)
+    ->sse_ok->sse_type_is('time')->sse_text_like(qr/\d+/)->sse_ok->sse_type_is('time')
+    ->sse_text_like(qr/\d+/)
+    ->sse_finish_ok;
+};
+
+subtest 'Early finish' => sub {
+  $t->get_sse_ok('/events')->status_is(200)->sse_ok->sse_type_is('message')->sse_text_is('One')->sse_finish_ok;
+};
+
+subtest 'Follow redirect' => sub {
+  $t->get_sse_ok('/redirect')->status_is(200)->sse_ok->sse_type_is('time')
+    ->sse_text_like(qr/\d+/)
+    ->sse_ok->sse_type_is('time')->sse_text_like(qr/\d+/)->sse_finish_ok;
+};
+
+done_testing();

--- a/t/mojolicious/types.t
+++ b/t/mojolicious/types.t
@@ -34,6 +34,7 @@ subtest 'Detect common MIME types' => sub {
   is_deeply $t->detect('application/pdf'),          ['pdf'],         'right formats';
   is_deeply $t->detect('image/png'),                ['png'],         'right formats';
   is_deeply $t->detect('application/rss+xml'),      ['rss'],         'right formats';
+  is_deeply $t->detect('text/event-stream'),        ['sse'],         'right formats';
   is_deeply $t->detect('image/svg+xml'),            ['svg'],         'right formats';
   is_deeply $t->detect('font/ttf'),                 ['ttf'],         'right formats';
   is_deeply $t->detect('text/plain'),               ['txt'],         'right formats';
@@ -46,12 +47,13 @@ subtest 'Detect common MIME types' => sub {
 };
 
 subtest 'Detect special cases' => sub {
-  is_deeply $t->detect('Application/Xml'), ['xml'],         'right formats';
-  is_deeply $t->detect(' Text/Xml '),      ['xml'],         'right formats';
-  is_deeply $t->detect('APPLICATION/XML'), ['xml'],         'right formats';
-  is_deeply $t->detect('TEXT/XML'),        ['xml'],         'right formats';
-  is_deeply $t->detect('text/html;q=0.9'), ['htm', 'html'], 'right formats';
-  is_deeply $t->detect('TEXT/HTML;Q=0.9'), ['htm', 'html'], 'right formats';
+  is_deeply $t->detect('Application/Xml'),                     ['xml'],         'right formats';
+  is_deeply $t->detect(' Text/Xml '),                          ['xml'],         'right formats';
+  is_deeply $t->detect('APPLICATION/XML'),                     ['xml'],         'right formats';
+  is_deeply $t->detect('TEXT/XML'),                            ['xml'],         'right formats';
+  is_deeply $t->detect('text/html;q=0.9'),                     ['htm', 'html'], 'right formats';
+  is_deeply $t->detect('TEXT/HTML;Q=0.9'),                     ['htm', 'html'], 'right formats';
+  is_deeply $t->detect('text/event-stream, application/json'), ['json', 'sse'], 'right formats';
 };
 
 subtest 'Alternatives' => sub {


### PR DESCRIPTION
I want to build a `Mojo::MCP` module implementing the [Model Context Protocol](https://modelcontextprotocol.io/introduction). It uses SSE as part of the transport layer, so it's time for Mojolicious to get support.