### PR TITLE
Update FAQ.pod

### DIFF
--- a/lib/Mojolicious/Guides/FAQ.pod
+++ b/lib/Mojolicious/Guides/FAQ.pod
@@ -59,7 +59,7 @@ We'd love to discuss your contributions to L<Mojolicious> on L<IRC|https://web.l
 =head2 Which versions of Perl are supported by Mojolicious?
 
 First of all, you need to be aware that according to the L<perlpolicy>, only the two most recent stable release series
-of Perl are supported by the community and receive bug fixes, which are currently 5.32.x and 5.30.x. L<Mojolicious>
+of Perl are supported by the community and receive bug fixes. L<Mojolicious>
 follows this model and fully supports these two release series. In addition we will also keep the distribution
 installable (and that means passing all tests) up to a certain legacy version that the core team deems worthy of
 supporting, but not specifically optimize for it, this is currently 5.16.0.


### PR DESCRIPTION
Remove Perl versions "supported".

### Summary
Mentioning specific Perl versions here will quickly be outdated again.

### Motivation
Mentioning outdated Perl versions might give the impression that Mojolicious or at least the FAQ is somewhat out of date.

