### PR TITLE
Fix memory leak in AWAIT_ON_READY

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -37,7 +37,9 @@ sub AWAIT_NEW_FAIL { _await('reject',  @_) }
 sub AWAIT_ON_CANCEL { }
 
 sub AWAIT_ON_READY {
-  shift->_finally(0, @_)->catch(sub { });
+  my ($self, $cb) = @_;
+  push @{$self->{resolve}}, $cb;
+  push @{$self->{reject}},  $cb;
 }
 
 sub AWAIT_WAIT {


### PR DESCRIPTION
### Summary
Change implementation of Mojo::Promise::AWAIT_ON_READY() to fix leak.

### Motivation
The original implementation used _finally(), which created multiple intermediate promise objects. These weren't settled until the event loop stopped, creating a memory leak and significant delay on stop. The simplified code directly registers callbacks without intermediate Promises, eliminating the leak while maintaining correct functionality.  This will also be quicker.

Memory::Usage before fix.
```
  time    vsz (  diff)    rss (  diff) shared (  diff)   code (  diff)   data (  diff)
     0  36420 ( 36420)  28800 ( 28800)   7168 (  7168)   1548 (  1548)  21796 ( 21796) START
     1  45032 (  8612)  37376 (  8576)   7168 (     0)   1548 (     0)  30408 (  8612) counter=1000
     3  53952 (  8920)  45952 (  8576)   7168 (     0)   1548 (     0)  39328 (  8920) counter=2000
     5  62840 (  8888)  54784 (  8832)   7168 (     0)   1548 (     0)  48216 (  8888) counter=3000
     6  71776 (  8936)  63616 (  8832)   7168 (     0)   1548 (     0)  57152 (  8936) counter=4000
     8  80644 (  8868)  72320 (  8704)   7168 (     0)   1548 (     0)  66020 (  8868) counter=5000
     9  89432 (  8788)  81408 (  9088)   7168 (     0)   1548 (     0)  74808 (  8788) counter=6000
    11  98352 (  8920)  90240 (  8832)   7168 (     0)   1548 (     0)  83728 (  8920) counter=7000
    12  107300 (  8948)  98944 (  8704)   7168 (     0)   1548 (     0)  92676 (  8948) counter=8000
    14  116048 (  8748)  107776 (  8832)   7168 (     0)   1548 (     0)  101424 (  8748) counter=9000
    15  124940 (  8892)  116608 (  8832)   7168 (     0)   1548 (     0)  110316 (  8892) counter=10000
    19  140432 ( 15492)  131840 ( 15232)   7168 (     0)   1548 (     0)  125808 ( 15492) END
```

Memory::Usage after fix.
```
  time    vsz (  diff)    rss (  diff) shared (  diff)   code (  diff)   data (  diff)
     0  36344 ( 36344)  28800 ( 28800)   7168 (  7168)   1548 (  1548)  21720 ( 21720) START
     1  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=1000
     3  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=2000
     4  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=3000
     5  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=4000
     7  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=5000
     8  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=6000
     9  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=7000
    11  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=8000
    12  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=9000
    13  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) counter=10000
    13  36344 (     0)  28800 (     0)   7168 (     0)   1548 (     0)  21720 (     0) END
``` 

### References
Fixes #2220
