### PR TITLE
Respect HTTP request method casing

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -216,7 +216,7 @@ sub _start_line {
   $path = "/$path" unless $path =~ m!^/!;
 
   # CONNECT
-  my $method = uc $self->method;
+  my $method = $self->method;
   if ($method eq 'CONNECT') {
     my $port = $url->port // ($url->protocol eq 'https' ? '443' : '80');
     $path = $url->ihost . ":$port";

--- a/lib/Mojo/Transaction/HTTP.pm
+++ b/lib/Mojo/Transaction/HTTP.pm
@@ -8,7 +8,7 @@ sub client_read {
 
   # Skip body for HEAD request
   my $res = $self->res;
-  $res->content->skip_body(1) if uc $self->req->method eq 'HEAD';
+  $res->content->skip_body(1) if $self->req->method eq 'HEAD';
   return undef unless $res->parse($chunk)->is_finished;
 
   # Unexpected 1xx response
@@ -20,7 +20,7 @@ sub client_read {
 
 sub client_write { shift->_write(0) }
 
-sub is_empty { !!(uc $_[0]->req->method eq 'HEAD' || $_[0]->res->is_empty) }
+sub is_empty { !!($_[0]->req->method eq 'HEAD' || $_[0]->res->is_empty) }
 
 sub keep_alive {
   my $self = shift;

--- a/lib/Mojo/UserAgent.pm
+++ b/lib/Mojo/UserAgent.pm
@@ -245,7 +245,7 @@ sub _finish {
   }
 
   # CONNECT requests always have a follow-up request
-  $self->_reuse($id, $close) unless uc $old->req->method eq 'CONNECT';
+  $self->_reuse($id, $close) unless $old->req->method eq 'CONNECT';
   $res->error({message => $res->message, code => $res->code}) if $res->is_error;
   $c->{cb}($self, $old) unless $self->_redirect($c, $old);
 }

--- a/lib/Mojo/UserAgent/Transactor.pm
+++ b/lib/Mojo/UserAgent/Transactor.pm
@@ -94,7 +94,7 @@ sub proxy_connect {
 
   # Already a CONNECT request
   my $req = $old->req;
-  return undef if uc $req->method eq 'CONNECT';
+  return undef if $req->method eq 'CONNECT';
 
   # No proxy
   return undef unless (my $proxy = $req->proxy) && $req->via_proxy;
@@ -122,7 +122,7 @@ sub redirect {
 
   # CONNECT requests cannot be redirected
   my $req = $old->req;
-  return undef if uc $req->method eq 'CONNECT';
+  return undef if $req->method eq 'CONNECT';
 
   # Fix location without authority and/or scheme
   return undef unless my $location = $res->headers->every_header('Location')->[0];
@@ -133,7 +133,7 @@ sub redirect {
 
   # Clone request if necessary (QUERY is safe and idempotent, so it keeps its content like 307 and 308)
   my $new    = Mojo::Transaction::HTTP->new;
-  my $method = uc $req->method;
+  my $method = $req->method;
   if ($code == 307 || $code == 308 || ($method eq 'QUERY' && $code != 303)) {
     return undef unless my $clone = $req->clone;
     $new->req($clone);
@@ -229,7 +229,7 @@ sub _form {
   }
 
   # Query parameters or urlencoded
-  my $method = uc $req->method;
+  my $method = $req->method;
   my @form   = map { $_ => $form->{$_} } sort keys %$form;
   if ($method eq 'GET' || $method eq 'HEAD') { $req->url->query->merge(@form) }
   else {

--- a/lib/Mojolicious/Command/routes.pm
+++ b/lib/Mojolicious/Command/routes.pm
@@ -35,7 +35,7 @@ sub _walk {
 
   # Methods
   my $methods = $route->methods;
-  push @$row, !$methods ? '*' : uc join ',', @$methods;
+  push @$row, !$methods ? '*' : join ',', @$methods;
 
   # Name
   my $name = $route->name;

--- a/lib/Mojolicious/Routes.pm
+++ b/lib/Mojolicious/Routes.pm
@@ -65,10 +65,10 @@ sub match {
   else               { $path = $req->url->path->to_route }
 
   # Method (HEAD will be treated as GET)
-  my $method   = uc $req->method;
+  my $method   = $req->method;
   my $override = $req->url->query->clone->param('_method');
-  $method = uc $override if $override && $method eq 'POST';
-  $method = 'GET'        if $method eq 'HEAD';
+  $method = $override if $override && $method eq 'POST';
+  $method = 'GET'     if $method eq 'HEAD';
 
   # Check cache
   my $ws    = $c->tx->is_websocket ? 1 : 0;

--- a/lib/Mojolicious/Routes/Route.pm
+++ b/lib/Mojolicious/Routes/Route.pm
@@ -61,7 +61,7 @@ sub is_websocket { !!shift->{websocket} }
 sub methods {
   my $self = shift;
   return $self->{methods} unless @_;
-  my $methods = [map uc($_), @{ref $_[0] ? $_[0] : [@_]}];
+  my $methods = [@{ref $_[0] ? $_[0] : [@_]}];
   $self->{methods} = $methods if @$methods;
   return $self;
 }

--- a/lib/Mojolicious/resources/templates/mojo/debug.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/debug.html.ep
@@ -240,7 +240,7 @@
                       <pre><%= '  ' x $depth %><%= $unparsed %></pre>
                     </td>
                     <td class="value">
-                      <pre><%= uc(join ',', @{$route->methods // []}) || '*' %></pre>
+                      <pre><%= (join ',', @{$route->methods // []}) || '*' %></pre>
                     </td>
                     <td class="value">
                       % my $name = $route->name;

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -473,7 +473,7 @@ sub _request_ok {
   $self->tx($self->ua->start($tx));
   my $err = $self->tx->error;
   Test::More::diag $err->{message} if !(my $ok = !$err->{message} || $err->{code}) && $err;
-  return $self->test('ok', $ok, _desc("@{[uc $tx->req->method]} $url"));
+  return $self->test('ok', $ok, _desc("@{[$tx->req->method]} $url"));
 }
 
 sub _sse_ok {
@@ -501,7 +501,7 @@ sub _sse_ok {
   );
   Mojo::IOLoop->start;
 
-  return $self->test('ok', $ok, _desc("SSE connection established: @{[uc $tx->req->method]} $url"));
+  return $self->test('ok', $ok, _desc("SSE connection established: @{[$tx->req->method]} $url"));
 }
 
 sub _sse_wait {

--- a/t/mojo/request.t
+++ b/t/mojo/request.t
@@ -1149,11 +1149,24 @@ subtest 'Build HTTP 1.1 start-line and header (with clone and changes)' => sub {
   is $clone->headers->host,   '127.0.0.1',                    'right "Host" value';
 };
 
+subtest 'method case and symbols are preserved' => sub {
+  my $req      = Mojo::Message::Request->new;
+  my $finished = undef;
+  $req->on(finish => sub { $finished = shift->is_finished });
+  $req->method('P0$t!!');
+  $req->url->parse('http://127.0.0.1/foo/bar');
+  $req = Mojo::Message::Request->new->parse($req->to_string);
+  ok $req->is_finished, 'request is finished';
+  is $req->method, 'P0$t!!', 'right method, including weird casing';
+  ok $finished,         'finish event has been emitted';
+  ok $req->is_finished, 'request is finished';
+};
+
 subtest 'Build full HTTP 1.1 request' => sub {
   my $req      = Mojo::Message::Request->new;
   my $finished = undef;
   $req->on(finish => sub { $finished = shift->is_finished });
-  $req->method('get');
+  $req->method('GET');
   $req->url->parse('http://127.0.0.1/foo/bar');
   $req->headers->expect('100-continue');
   $req->body("Hello World!\n");
@@ -1184,7 +1197,7 @@ subtest 'Build HTTP 1.1 request parts with progress' => sub {
       $progress += $offset;
     }
   );
-  $req->method('get');
+  $req->method('GET');
   $req->url->parse('http://127.0.0.1/foo/bar');
   $req->headers->expect('100-continue');
   $req->body("Hello World!\n");
@@ -1211,7 +1224,7 @@ subtest 'Build full HTTP 1.1 request (with clone)' => sub {
   my $req      = Mojo::Message::Request->new;
   my $finished = undef;
   $req->on(finish => sub { $finished = shift->is_finished });
-  $req->method('get');
+  $req->method('GET');
   $req->url->parse('http://127.0.0.1/foo/bar');
   $req->headers->expect('100-continue');
   $req->body("Hello World!\n");

--- a/t/mojo/transactor.t
+++ b/t/mojo/transactor.t
@@ -148,13 +148,13 @@ subtest 'Simple form with multiple values' => sub {
   is $tx->req->body, 'a=1&a=2&a=3&b=4', 'right content';
 };
 
-subtest 'Existing query string (lowercase HEAD)' => sub {
+subtest 'Existing query string (lowercase HEAD is not HEAD)' => sub {
   my $tx = $t->tx(head => 'http://example.com?foo=bar' => form => {baz => [1, 2]});
-  is $tx->req->url->to_abs,           'http://example.com?foo=bar&baz=1&baz=2', 'right URL';
-  is $tx->req->method,                'head',                                   'right method';
-  is $tx->req->headers->content_type, undef,                                    'no "Content-Type" value';
-  ok $tx->is_empty, 'transaction is empty';
-  is $tx->req->body, '', 'no content';
+  is $tx->req->url->to_abs,           'http://example.com?foo=bar',        'right URL';
+  is $tx->req->method,                'head',                              'right method';
+  is $tx->req->headers->content_type, 'application/x-www-form-urlencoded', 'right "Content-Type" value';
+  ok !$tx->is_empty, 'transaction is not empty';
+  is $tx->req->body, 'baz=1&baz=2', 'right content';
 };
 
 subtest 'UTF-8 query' => sub {
@@ -637,7 +637,7 @@ subtest 'Proxy CONNECT' => sub {
   is $tx->req->headers->proxy_authorization, 'Basic c3JpOnNlY3IzdA==', 'right "Proxy-Authorization" header';
   is $tx->req->headers->host,                'mojolicious.org',        'right "Host" header';
   is $t->proxy_connect($tx),                 undef,                    'already a CONNECT request';
-  $tx->req->method('Connect');
+  $tx->req->method('CONNECT');
   is $t->proxy_connect($tx), undef, 'already a CONNECT request';
   $tx = $t->tx(GET => 'https://mojolicious.org');
   $tx->req->proxy(Mojo::URL->new('socks://127.0.0.1:3000'));
@@ -713,8 +713,8 @@ subtest 'Simple 302 redirect' => sub {
   is $tx->res->headers->location, undef,                    'no "Location" value';
 };
 
-subtest '302 redirect (lowercase HEAD)' => sub {
-  my $tx = $t->tx(head => 'http://mojolicious.org/foo');
+subtest '302 redirect (HEAD)' => sub {
+  my $tx = $t->tx(HEAD => 'http://mojolicious.org/foo');
   $tx->res->code(302);
   $tx->res->headers->location('http://example.com/bar');
   $tx = $t->redirect($tx);

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -289,7 +289,7 @@ any '/something' => sub {
   $c->render(text => 'Just works!');
 };
 
-any [qw(get post whatever)] => '/something/else' => sub {
+any [qw(GET POST whatever)] => '/something/else' => sub {
   my $c = shift;
   $c->render(text => 'Yay!');
 };
@@ -511,7 +511,7 @@ $t->head_ok('/')
   ->content_is('');
 
 # HEAD request (lowercase)
-my $tx = $t->ua->build_tx(head => '/');
+my $tx = $t->ua->build_tx(HEAD => '/');
 $t->request_ok($tx)
   ->status_is(200)
   ->header_is(Server           => 'Mojolicious (Perl)')
@@ -895,7 +895,7 @@ $t->delete_ok('/something')->status_is(200)->header_is(Server => 'Mojolicious (P
 # Only GET, POST and a custom request method
 $t->get_ok('/something/else')->status_is(200)->header_is(Server => 'Mojolicious (Perl)')->content_is('Yay!');
 $t->post_ok('/something/else')->status_is(200)->header_is(Server => 'Mojolicious (Perl)')->content_is('Yay!');
-$t->request_ok($t->ua->build_tx(WHATEVER => '/something/else'))
+$t->request_ok($t->ua->build_tx(whatever => '/something/else'))
   ->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')
   ->content_is('Yay!');

--- a/t/mojolicious/routes.t
+++ b/t/mojolicious/routes.t
@@ -130,10 +130,10 @@ $r->any('/method/get', [format => ['html']])
   ->to(testcase => 'method', action => 'get', format => undef);
 
 # POST /method/post
-$r->any('/method/post')->methods('post')->to(testcase => 'method', action => 'post');
+$r->any('/method/post')->methods('POST')->to(testcase => 'method', action => 'post');
 
 # POST|GET /method/post_get
-$r->any('/method/post_get')->methods(qw(POST get))->to(testcase => 'method', action => 'post_get');
+$r->any('/method/post_get')->methods(qw(POST GET))->to(testcase => 'method', action => 'post_get');
 
 # /simple/form
 $r->any('/simple/form')->to('test-test#test');


### PR DESCRIPTION
While weird, mixed-case or lower-cased methods are totally legal, and some symbols are permitted too.
The ABNF is here: https://www.rfc-editor.org/rfc/rfc9110#appendix-A