### PR TITLE
JSON-encode objects with no TO_JSON or stringification overload as null

### DIFF
--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -28,7 +28,7 @@ CORE
   Mojolicious ($Mojolicious::VERSION, $Mojolicious::CODENAME)
 
 OPTIONAL
-  Cpanel::JSON::XS 4.09+   ($json)
+  Cpanel::JSON::XS 4.20+   ($json)
   CryptX 0.080+            ($cryptx)
   EV 4.32+                 ($ev)
   IO::Socket::Socks 0.64+  ($socks)

--- a/t/mojo/json.t
+++ b/t/mojo/json.t
@@ -13,6 +13,9 @@ package JSONTest2;
 use Mojo::Base -base;
 use overload '&' => sub {die}, '""' => sub {'works!'};
 
+package JSONTest3;
+use Mojo::Base -base;
+
 package main;
 
 use Test::More;
@@ -334,6 +337,7 @@ subtest 'dualvar' => sub {
 
 subtest 'Other reference types' => sub {
   is encode_json([JSONTest2->new]), "[\"works!\"]", 'object stringified';
+  is encode_json([JSONTest3->new]), '[null]',       'object with no stringification overload';
 };
 
 subtest 'Ensure numbers and strings are not upgraded' => sub {

--- a/t/mojo/json_xs.t
+++ b/t/mojo/json_xs.t
@@ -4,7 +4,7 @@ use Test::More;
 use Mojo::JSON qw(decode_json encode_json false from_json j to_json true);
 
 BEGIN {
-  plan skip_all => 'Cpanel::JSON::XS 4.09+ required for this test!' unless Mojo::JSON->JSON_XS;
+  plan skip_all => 'Cpanel::JSON::XS 4.20+ required for this test!' unless Mojo::JSON->JSON_XS;
 }
 
 package JSONTest;
@@ -13,6 +13,13 @@ use Mojo::Base -base;
 has 'something' => sub { {} };
 
 sub TO_JSON { shift->something }
+
+package JSONTest2;
+use Mojo::Base -base;
+use overload '&' => sub {die}, '""' => sub {'works!'};
+
+package JSONTest3;
+use Mojo::Base -base;
 
 package main;
 
@@ -64,6 +71,8 @@ subtest '"convert_blessed"' => sub {
   is_deeply decode_json($bytes), {}, 'successful roundtrip';
   $bytes = encode_json(JSONTest->new(something => {just => 'works'}, else => {not => 'working'}));
   is_deeply decode_json($bytes), {just => 'works'}, 'successful roundtrip';
+  is encode_json([JSONTest2->new]), "[\"works!\"]", 'object stringified';
+  is encode_json([JSONTest3->new]), '[null]',       'object with no stringification overload';
 };
 
 subtest '"stringify_infnan"' => sub {


### PR DESCRIPTION
This matches the `convert_blessed`/`allow_blessed` behaviour of `Cpanel::JSON::XS` (since version 4.20, so also bump the requirement to that).