### PR TITLE
Both HTTP method and query can have a value of '0'

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -176,10 +176,10 @@ sub _parse_env {
   $headers->content_length($env->{CONTENT_LENGTH}) if $env->{CONTENT_LENGTH};
 
   # Query
-  $url->query->parse($env->{QUERY_STRING}) if $env->{QUERY_STRING};
+  $url->query->parse($env->{QUERY_STRING}) if length $env->{QUERY_STRING};
 
   # Method
-  $self->method($env->{REQUEST_METHOD}) if $env->{REQUEST_METHOD};
+  $self->method($env->{REQUEST_METHOD}) if defined $env->{REQUEST_METHOD};
 
   # Scheme/Version
   $base->scheme($1) and $self->version($2) if ($env->{SERVER_PROTOCOL} // '') =~ m!^([^/]+)/([^/]+)$!;


### PR DESCRIPTION
Method ABNF is in https://datatracker.ietf.org/doc/html/rfc9110#appendix-A and equivalent to the regex: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$

I couldn't find a good place to test this, as parse_env is only called from the cgi and psgi tests; open to suggestion and will happily add some.
