### PR TITLE
Add support for 'webp' image format

### DIFF
--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -30,6 +30,7 @@ has mapping => sub {
     ttf      => ['font/ttf'],
     txt      => ['text/plain;charset=UTF-8'],
     webm     => ['video/webm'],
+    webp     => ['image/webp'],
     woff     => ['font/woff'],
     woff2    => ['font/woff2'],
     xml      => ['application/xml', 'text/xml'],


### PR DESCRIPTION
### Summary

Add support for 'webp' image format

### Motivation

It's a common mime type 

### References

https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types
