### PR TITLE
fix serialization of cookies

### DIFF
--- a/lib/Mojo/Headers.pm
+++ b/lib/Mojo/Headers.pm
@@ -20,11 +20,12 @@ my %NAMES = map { lc() => $_ } (
 for my $header (keys %NAMES) {
   my $name = $header;
   $name =~ y/-/_/;
+  my $delim = $name eq 'cookie' ? '; ' : ', ';
   monkey_patch __PACKAGE__, $name, sub {
     my $self = shift;
     $self->{headers}{$header} = [@_] and return $self if @_;
     return undef unless my $headers = $self->{headers}{$header};
-    return join ', ', @$headers;
+    return join($delim, @$headers);
   };
 }
 
@@ -48,7 +49,7 @@ sub add {
 sub append {
   my ($self, $name, $value) = @_;
   my $old = $self->header($name);
-  return $self->header($name => defined $old ? "$old, $value" : $value);
+  return $self->header($name => defined $old ? ($old . (lc $name eq 'cookie' ? '; ' : ', ') . $value) : $value);
 }
 
 sub clone {
@@ -90,8 +91,9 @@ sub header {
   # Replace
   return $self->remove($name)->add($name, @_) if @_;
 
-  return undef unless my $headers = $self->{headers}{lc $name};
-  return join ', ', @$headers;
+  $name = lc $name;
+  return undef unless my $headers = $self->{headers}{$name};
+  return join(($name eq 'cookie' ? '; ' : ', '), @$headers);
 }
 
 sub is_finished { (shift->{state} // '') eq 'finished' }
@@ -178,7 +180,14 @@ sub to_string {
 
   # Make sure multi-line values are formatted correctly
   my @headers;
-  for my $name (@{$self->names}) { push @headers, "$name: $_" for @{$self->{headers}{lc $name}} }
+  for my $name (@{$self->names}) {
+    if ($name eq 'Cookie') {
+      push @headers, "$name: " . join('; ', @{$self->{headers}{lc $name}});
+    }
+    else {
+      push @headers, "$name: $_" for @{$self->{headers}{lc $name}};
+    }
+  }
 
   return join "\x0d\x0a", @headers;
 }

--- a/t/mojo/headers.t
+++ b/t/mojo/headers.t
@@ -64,7 +64,6 @@ subtest 'Common headers' => sub {
   is $headers->content_range('foo')->content_range,                             'foo', 'right value';
   is $headers->content_security_policy('foo')->content_security_policy,         'foo', 'right value';
   is $headers->content_type('foo')->content_type,                               'foo', 'right value';
-  is $headers->cookie('foo')->cookie,                                           'foo', 'right value';
   is $headers->dnt('foo')->dnt,                                                 'foo', 'right value';
   is $headers->date('foo')->date,                                               'foo', 'right value';
   is $headers->etag('foo')->etag,                                               'foo', 'right value';
@@ -101,6 +100,9 @@ subtest 'Common headers' => sub {
   is $headers->referer,                   'foo', 'right value';
   is $headers->referer('bar')->referer,   'bar', 'right value';
   is $headers->referrer,                  'bar', 'right value';
+
+  is $headers->cookie('foo')->cookie,    'foo',  'right value for single cookie';
+  is $headers->cookie('a', 'b')->cookie, 'a; b', 'right value for multiple cookies';
 };
 
 subtest 'Clone' => sub {
@@ -177,6 +179,15 @@ subtest 'Set headers from hash' => sub {
   my $headers = Mojo::Headers->new;
   $headers->from_hash({Connection => 'close', 'Content-Type' => 'text/html'});
   is_deeply $headers->to_hash, {Connection => 'close', 'Content-Type' => 'text/html'}, 'right structure';
+  is $headers->to_string, "Connection: close\r\nContent-Type: text/html", 'right string';
+
+  $headers = Mojo::Headers->new;
+  $headers->from_hash({'Cookie' => ['a=b', 'c=d']});
+  is_deeply $headers->to_hash, {Cookie => 'a=b; c=d'}, 'right structure';
+  is $headers->to_string, "Cookie: a=b; c=d", 'right string';
+  $headers->from_hash({'Cookie' => ['e=f']});
+  is_deeply $headers->to_hash, {Cookie => 'a=b; c=d; e=f'}, 'right structure';
+  is $headers->to_string, "Cookie: a=b; c=d; e=f", 'right string';
 };
 
 subtest 'Remove all headers' => sub {
@@ -200,6 +211,12 @@ subtest 'Append values' => sub {
   is_deeply $headers->to_hash(1), {Vary => ['Accept', 'Accept-Encoding']}, 'right structure';
   $headers->append(Vary => 'Accept-Language');
   is_deeply $headers->to_hash(1), {Vary => ['Accept, Accept-Encoding, Accept-Language']}, 'right structure';
+  $headers->append(Cookie => 'a=b');
+  is_deeply $headers->to_hash(1), {Cookie => ['a=b'], Vary => ['Accept, Accept-Encoding, Accept-Language']},
+    'right structure';
+  $headers->append(Cookie => 'x=y');
+  is_deeply $headers->to_hash(1), {Cookie => ['a=b; x=y'], Vary => ['Accept, Accept-Encoding, Accept-Language']},
+    'right structure';
 };
 
 subtest 'Multiple headers with the same name' => sub {


### PR DESCRIPTION
- only one Cookie header is permitted; all cookies must be in a single string (see https://www.rfc-editor.org/rfc/rfc6265#section-5.4)
- the delimiter between individual cookie-pairs is "; ", not ", " (see https://www.rfc-editor.org/rfc/rfc6265#section-4.2.1)
