### PR TITLE
Use dynamic subroutine reference to avoid memory leak

### DIFF
--- a/lib/Mojo/File.pm
+++ b/lib/Mojo/File.pm
@@ -76,7 +76,7 @@ sub list_tree {
       my $child  = $self->new($path, $name);
       my $is_dir = -d $$child;
       push @results, $child if $options->{dir} || !$is_dir;
-      $walk->($$child, $depth + 1)
+      __SUB__->($$child, $depth + 1)
         if $is_dir && !-l $$child && (!$options->{max_depth} || $depth + 1 < $options->{max_depth});
     }
   };


### PR DESCRIPTION
Use __SUB__ as a dynamic subroutine reference ("current_sub" feature available since Perl 5.16, cf. Mojolicious 8.50) for the recursive call instead of the named variable to avoid a circular reference and a resulting memory leak.

We narrowed it down to this when the application in our development environment started growing continuously after updating our Mojolicious dependency from 9.35 to 9.45, even without receiving requests. It uses morbo, watching for changes on a fairly big directory structure. The memory usage did not increase when we used a different (inotify-based) watcher backend or when we used this modification.